### PR TITLE
txnkv: fix commit bug

### DIFF
--- a/txnkv/txn.go
+++ b/txnkv/txn.go
@@ -204,6 +204,9 @@ func (txn *Transaction) Commit(ctx context.Context) error {
 		if c := txn.us.LookupConditionPair(k); c != nil && c.ShouldNotExist() {
 			op = kvrpcpb.Op_Insert
 		}
+		if len(v) == 0 {
+			op = kvrpcpb.Op_Del
+		}
 		mutations[string(k)] = &kvrpcpb.Mutation{
 			Op:    op,
 			Key:   k,


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

The unionstore use zero length value to indicate `Del`, but txn committer does not use `OpDel` for it. It will cause deleted key-values be seen by `scan`.

Related issues: https://github.com/tikv/tikv/issues/5047 https://github.com/tikv/tikv/issues/5058