### PR TITLE
fix RowKVClient scan method can't rightly break loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 go.sum
+.idea

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -288,6 +288,10 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int) (
 		if len(startKey) == 0 {
 			break
 		}
+
+		if len(endKey) > 0 && bytes.Compare(startKey, endKey) > 0 {
+			break
+		}
 	}
 	return
 }
@@ -333,6 +337,11 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 		if len(startKey) == 0 {
 			break
 		}
+
+		if len(endKey) > 0 && bytes.Compare(startKey, endKey) < 0 {
+			break
+		}
+
 	}
 	return
 }

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -263,7 +263,7 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int) (
 		return nil, nil, errors.WithStack(ErrMaxScanLimitExceeded)
 	}
 
-	for len(keys) < limit {
+	for len(keys) < limit && (len(endKey) == 0 || bytes.Compare(startKey, endKey) < 0) {
 		req := &rpc.Request{
 			Type: rpc.CmdRawScan,
 			RawScan: &kvrpcpb.RawScanRequest{
@@ -288,10 +288,6 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int) (
 		if len(startKey) == 0 {
 			break
 		}
-
-		if len(endKey) > 0 && bytes.Compare(startKey, endKey) > 0 {
-			break
-		}
 	}
 	return
 }
@@ -311,7 +307,7 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 		return nil, nil, errors.WithStack(ErrMaxScanLimitExceeded)
 	}
 
-	for len(keys) < limit {
+	for len(keys) < limit && bytes.Compare(startKey, endKey) > 0 {
 		req := &rpc.Request{
 			Type: rpc.CmdRawScan,
 			RawScan: &kvrpcpb.RawScanRequest{
@@ -337,11 +333,6 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 		if len(startKey) == 0 {
 			break
 		}
-
-		if len(endKey) > 0 && bytes.Compare(startKey, endKey) < 0 {
-			break
-		}
-
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: Yushen Lin <ldnvnbl@gmail.com>

fix https://github.com/pingcap/tidb/issues/14363