### PR TITLE
Add Keyonly option for rawKv Scan.

### DIFF
--- a/config/raw.go
+++ b/config/raw.go
@@ -24,7 +24,7 @@ type Raw struct {
 	// BatchPairCount is the maximum limit for rawkv each batch get/delete request.
 	BatchPairCount int
 
-	// Return only keys when scan
+	// If true, the Server will only return keys when using Scan function
 	KeyOnlyScan bool
 }
 

--- a/config/raw.go
+++ b/config/raw.go
@@ -23,6 +23,9 @@ type Raw struct {
 
 	// BatchPairCount is the maximum limit for rawkv each batch get/delete request.
 	BatchPairCount int
+
+	// Return only keys when scan
+	KeyOnlyScan bool
 }
 
 // DefaultRaw returns default rawkv configuration.
@@ -31,5 +34,6 @@ func DefaultRaw() Raw {
 		MaxScanLimit:    10240,
 		MaxBatchPutSize: 16 * 1024,
 		BatchPairCount:  512,
+		KeyOnlyScan:     false,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
+
+go 1.13

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -270,6 +270,7 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int) (
 				StartKey: startKey,
 				EndKey:   endKey,
 				Limit:    uint32(limit - len(keys)),
+				KeyOnly:  c.conf.Raw.KeyOnlyScan,
 			},
 		}
 		resp, loc, err := c.sendReq(ctx, startKey, req)
@@ -315,6 +316,7 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 				EndKey:   endKey,
 				Limit:    uint32(limit - len(keys)),
 				Reverse:  true,
+				KeyOnly:  c.conf.Raw.KeyOnlyScan,
 			},
 		}
 		resp, loc, err := c.sendReq(ctx, startKey, req)


### PR DESCRIPTION
As mention in #44 and in https://github.com/tikv/tikv/pull/7673. It would helpful to have some kind of options for RawKv. 

However, in order to avoid the breaking change and maintain API stability. We cannot just add a options parameter in RawKv API functions. We can 
1. put options somewhere in client object
2. implement another version of RawKv API functions with Option parameters, like `GetWithOptions`.

I choose to leave the Option in `Config` in this PR, but feel free to let me know if you feel other choice is better.