### PR TITLE
Add Keyonly option for rawKv Scan

### DIFF
--- a/config/raw.go
+++ b/config/raw.go
@@ -24,7 +24,7 @@ type Raw struct {
 	// BatchPairCount is the maximum limit for rawkv each batch get/delete request.
 	BatchPairCount int
 
-	// Return only keys when scan
+	// If true, the Server will only return keys when using Scan function
 	KeyOnlyScan bool
 }
 

--- a/config/raw.go
+++ b/config/raw.go
@@ -23,6 +23,9 @@ type Raw struct {
 
 	// BatchPairCount is the maximum limit for rawkv each batch get/delete request.
 	BatchPairCount int
+
+	// Return only keys when scan
+	KeyOnlyScan bool
 }
 
 // DefaultRaw returns default rawkv configuration.
@@ -31,5 +34,6 @@ func DefaultRaw() Raw {
 		MaxScanLimit:    10240,
 		MaxBatchPutSize: 16 * 1024,
 		BatchPairCount:  512,
+		KeyOnlyScan:     false,
 	}
 }

--- a/config/raw.go
+++ b/config/raw.go
@@ -23,9 +23,6 @@ type Raw struct {
 
 	// BatchPairCount is the maximum limit for rawkv each batch get/delete request.
 	BatchPairCount int
-
-	// If true, the Server will only return keys when using Scan function
-	KeyOnlyScan bool
 }
 
 // DefaultRaw returns default rawkv configuration.
@@ -34,6 +31,5 @@ func DefaultRaw() Raw {
 		MaxScanLimit:    10240,
 		MaxBatchPutSize: 16 * 1024,
 		BatchPairCount:  512,
-		KeyOnlyScan:     false,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -52,5 +52,3 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
+
+go 1.13

--- a/mockstore/mocktikv/rpc.go
+++ b/mockstore/mocktikv/rpc.go
@@ -476,6 +476,16 @@ func (h *rpcHandler) handleKvRawScan(req *kvrpcpb.RawScanRequest) *kvrpcpb.RawSc
 		endKey = req.EndKey
 	}
 	pairs := rawKV.RawScan(req.GetStartKey(), endKey, int(req.GetLimit()))
+	if req.KeyOnly {
+		//filter values when
+		for i := range pairs {
+			pairs[i] = Pair{
+				Key:   pairs[i].Key,
+				Value: nil,
+				Err:   nil,
+			}
+		}
+	}
 	return &kvrpcpb.RawScanResponse{
 		Kvs: convertToPbPairs(pairs),
 	}

--- a/mockstore/mocktikv/rpc.go
+++ b/mockstore/mocktikv/rpc.go
@@ -477,7 +477,7 @@ func (h *rpcHandler) handleKvRawScan(req *kvrpcpb.RawScanRequest) *kvrpcpb.RawSc
 	}
 	pairs := rawKV.RawScan(req.GetStartKey(), endKey, int(req.GetLimit()))
 	if req.KeyOnly {
-		//filter values when
+		//filter values when the client set key only to true.
 		for i := range pairs {
 			pairs[i] = Pair{
 				Key:   pairs[i].Key,

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -270,6 +270,7 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int) (
 				StartKey: startKey,
 				EndKey:   endKey,
 				Limit:    uint32(limit - len(keys)),
+				KeyOnly:  c.conf.Raw.KeyOnlyScan,
 			},
 		}
 		resp, loc, err := c.sendReq(ctx, startKey, req)
@@ -315,6 +316,7 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 				EndKey:   endKey,
 				Limit:    uint32(limit - len(keys)),
 				Reverse:  true,
+				KeyOnly:  c.conf.Raw.KeyOnlyScan,
 			},
 		}
 		resp, loc, err := c.sendReq(ctx, startKey, req)

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -271,7 +271,7 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int, o
 	defer func() { metrics.RawkvCmdHistogram.WithLabelValues("scan").Observe(time.Since(start).Seconds()) }()
 
 	var option ScanOption
-	if options == nil {
+	if options == nil || len(options) == 0 {
 		option = DefaultScanOption()
 	} else {
 		option = options[0]
@@ -323,7 +323,7 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 	defer func() { metrics.RawkvCmdHistogram.WithLabelValues("reverse_scan").Observe(time.Since(start).Seconds()) }()
 
 	var option ScanOption
-	if options == nil {
+	if options == nil || len(options) == 0 {
 		option = DefaultScanOption()
 	} else {
 		option = options[0]

--- a/rawkv/rawkv_test.go
+++ b/rawkv/rawkv_test.go
@@ -285,7 +285,7 @@ func (s *testRawKVSuite) TestScan(c *C) {
 	check()
 }
 
-func (s *testRawKVSuite) TestScanOnly(c *C) {
+func (s *testRawKVSuite) TestScanWithKeyOnly(c *C) {
 	s.mustPut(c, []byte("k1"), []byte("v1"))
 	s.mustPut(c, []byte("k3"), []byte("v3"))
 	s.mustPut(c, []byte("k5"), []byte("v5"))

--- a/rawkv/rawkv_test.go
+++ b/rawkv/rawkv_test.go
@@ -111,6 +111,18 @@ func (s *testRawKVSuite) mustBatchDelete(c *C, keys [][]byte) {
 	c.Assert(err, IsNil)
 }
 
+func (s *testRawKVSuite) mustScanKeyOnly(c *C, startKey string, limit int, expect ...string) {
+	option := DefaultScanOption()
+	option.KeyOnly = true
+	keys, values, err := s.client.Scan(context.TODO(), []byte(startKey), nil, limit, option)
+	c.Assert(err, IsNil)
+	c.Assert(len(keys), Equals, len(expect))
+	for i := range keys {
+		c.Assert(string(keys[i]), Equals, expect[i])
+		c.Assert(values[i], IsNil)
+	}
+}
+
 func (s *testRawKVSuite) mustScan(c *C, startKey string, limit int, expect ...string) {
 	keys, values, err := s.client.Scan(context.TODO(), []byte(startKey), nil, limit)
 	c.Assert(err, IsNil)
@@ -118,16 +130,6 @@ func (s *testRawKVSuite) mustScan(c *C, startKey string, limit int, expect ...st
 	for i := range keys {
 		c.Assert(string(keys[i]), Equals, expect[i*2])
 		c.Assert(string(values[i]), Equals, expect[i*2+1])
-	}
-}
-
-func (s *testRawKVSuite) mustScanKeyOnly(c *C, startKey string, limit int, expect ...string) {
-	keys, values, err := s.client.Scan(context.TODO(), []byte(startKey), nil, limit)
-	c.Assert(err, IsNil)
-	c.Assert(len(keys), Equals, len(expect))
-	for i := range keys {
-		c.Assert(string(keys[i]), Equals, expect[i])
-		c.Assert(values[i], IsNil)
 	}
 }
 
@@ -141,6 +143,18 @@ func (s *testRawKVSuite) mustScanRange(c *C, startKey string, endKey string, lim
 	}
 }
 
+func (s *testRawKVSuite) mustReverseScanKeyOnly(c *C, startKey string, limit int, expect ...string) {
+	option := DefaultScanOption()
+	option.KeyOnly = true
+	keys, values, err := s.client.ReverseScan(context.TODO(), []byte(startKey), nil, limit, option)
+	c.Assert(err, IsNil)
+	c.Assert(len(keys), Equals, len(expect))
+	for i := range keys {
+		c.Assert(string(keys[i]), Equals, expect[i])
+		c.Assert(values[i], IsNil)
+	}
+}
+
 func (s *testRawKVSuite) mustReverseScan(c *C, startKey []byte, limit int, expect ...string) {
 	keys, values, err := s.client.ReverseScan(context.TODO(), startKey, nil, limit)
 	c.Assert(err, IsNil)
@@ -148,16 +162,6 @@ func (s *testRawKVSuite) mustReverseScan(c *C, startKey []byte, limit int, expec
 	for i := range keys {
 		c.Assert(string(keys[i]), Equals, expect[i*2])
 		c.Assert(string(values[i]), Equals, expect[i*2+1])
-	}
-}
-
-func (s *testRawKVSuite) mustReverseScanKeyOnly(c *C, startKey string, limit int, expect ...string) {
-	keys, values, err := s.client.ReverseScan(context.TODO(), []byte(startKey), nil, limit)
-	c.Assert(err, IsNil)
-	c.Assert(len(keys), Equals, len(expect))
-	for i := range keys {
-		c.Assert(string(keys[i]), Equals, expect[i])
-		c.Assert(values[i], IsNil)
 	}
 }
 
@@ -282,9 +286,6 @@ func (s *testRawKVSuite) TestScan(c *C) {
 }
 
 func (s *testRawKVSuite) TestScanOnly(c *C) {
-	s.client.conf.Raw.KeyOnlyScan = true //key only
-	defer func() { s.client.conf.Raw.KeyOnlyScan = false }()
-
 	s.mustPut(c, []byte("k1"), []byte("v1"))
 	s.mustPut(c, []byte("k3"), []byte("v3"))
 	s.mustPut(c, []byte("k5"), []byte("v5"))


### PR DESCRIPTION
As mention in #44 and in tikv/tikv#7673. It would helpful to have some kind of options for RawKv.

However, in order to avoid the breaking change and maintain API stability. We cannot just add a options parameter in RawKv API functions. We can put options somewhere in client object
implement another version of RawKv API functions with Option parameters, like GetWithOptions.
I choose to leave the Option in Config in this PR, but feel free to let me know if you feel other choice is better.