### PR TITLE
init buffer when create buffer store

### DIFF
--- a/txnkv/kv/buffer_store.go
+++ b/txnkv/kv/buffer_store.go
@@ -35,8 +35,11 @@ type BufferStore struct {
 // NewBufferStore creates a BufferStore using r for read.
 func NewBufferStore(r Retriever, conf *config.Txn) *BufferStore {
 	return &BufferStore{
-		r:         r,
-		MemBuffer: &lazyMemBuffer{conf: conf},
+		r: r,
+		MemBuffer: &lazyMemBuffer{
+			mb:   NewMemDbBuffer(conf, 0),
+			conf: conf,
+		},
 	}
 }
 


### PR DESCRIPTION
When using txn client in multiple threads, transaction loss often occurs. Because lazyMemBuffer is not initialized during concurrent access, the transaction will be lost.

Signed-off-by: Cuixiaotian <cxt90730@126.com>