### PR TITLE
Update the PD client version to eliminate performance regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,14 +14,15 @@ require (
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20201104042953-62eb316d5182
+	github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c
+	github.com/pingcap/tiup v1.2.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1 // indirect
-	github.com/tikv/pd v1.1.0-beta.0.20201113054545-cbbb7946a0d4
+	github.com/tikv/pd v1.1.0-beta.0.20210122094357-c7aac753461a
 	go.etcd.io/etcd v3.3.25+incompatible // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20210112051026-540f4cb76c1c
-	github.com/pingcap/tiup v1.2.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.9.1
+	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/coreos/etcd v3.3.25+incompatible
-	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/golang/protobuf v1.3.4
 	github.com/google/btree v1.0.0
 	github.com/google/uuid v1.1.1
@@ -18,7 +17,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.9.1
-	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/mockstore/mocktikv/pd.go
+++ b/mockstore/mocktikv/pd.go
@@ -143,7 +143,15 @@ func (c *pdClient) ScatterRegion(ctx context.Context, regionID uint64) error {
 	panic("unimplemented")
 }
 
-func (c *pdClient) ScatterRegionWithOption(ctx context.Context, regionID uint64, opts ...pd.ScatterRegionOption) error {
+func (c *pdClient) ScatterRegionWithOption(ctx context.Context, regionID uint64, opts ...pd.RegionsOption) error {
+	panic("unimplemented")
+}
+
+func (c *pdClient) ScatterRegions(ctx context.Context, regionsID []uint64, opts ...pd.RegionsOption) (*pdpb.ScatterRegionResponse, error) {
+	panic("unimplemented")
+}
+
+func (c *pdClient) SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...pd.RegionsOption) (*pdpb.SplitRegionsResponse, error) {
 	panic("unimplemented")
 }
 

--- a/txnkv/latch/latch.go
+++ b/txnkv/latch/latch.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cznic/mathutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spaolacci/murmur3"
 	"github.com/tikv/client-go/config"
@@ -186,7 +185,9 @@ func (latches *Latches) releaseSlot(lock *Lock) (nextLock *Lock) {
 	if find.value != lock {
 		panic("releaseSlot wrong")
 	}
-	find.maxCommitTS = mathutil.MaxUint64(find.maxCommitTS, lock.commitTS)
+	if lock.commitTS > find.maxCommitTS {
+		find.maxCommitTS = lock.commitTS
+	}
 	find.value = nil
 	// Make a copy of the key, so latch does not reference the transaction's memory.
 	// If we do not do it, transaction memory can't be recycle by GC and there will


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

Close #64.

The PD client version currently using has a performance regression problem which is fixed by tikv/pd#3169.