### PR TITLE
client: change maxRecvMsgSize to MaxInt64-1

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -50,7 +50,7 @@ import (
 
 // MaxRecvMsgSize set max gRPC receive message size received from server. If any message size is larger than
 // current value, an error will be reported from gRPC.
-var MaxRecvMsgSize = math.MaxInt64
+var MaxRecvMsgSize = math.MaxInt64 - 1
 
 // Timeout durations.
 const (


### PR DESCRIPTION
there is a bug that compresses cannot work with maxInt64 in go-grpc  https://github.com/grpc/grpc-go/issues/4552

to work around, we can use `MaxInt64-1`

manual test passed

ref https://github.com/pingcap/tidb/issues/25419