### PR TITLE
Fix broken integration_tests

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/kvproto v0.0.0-20210611081648-a215b4e61d2f
-	github.com/pingcap/parser v0.0.0-20210610080504-cb77169bfed9
+	github.com/pingcap/parser v0.0.0-20210618053735-57843e8185c4
 	github.com/pingcap/tidb v1.1.0-beta.0.20210616023036-9461f5ba55b1
 	github.com/tikv/client-go/v2 v2.0.0
 	github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d
@@ -15,3 +15,5 @@ require (
 )
 
 replace github.com/tikv/client-go/v2 => ../
+
+replace github.com/pingcap/tidb => github.com/JmPotato/tidb v1.1.0-beta.0.20210621110155-cd5d22e7497a

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -29,6 +29,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/HdrHistogram/hdrhistogram-go v0.9.0 h1:dpujRju0R4M/QZzcnR1LH1qm+TVG3UzkWdp5tH1WMcg=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/Jeffail/gabs/v2 v2.5.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
+github.com/JmPotato/tidb v1.1.0-beta.0.20210621110155-cd5d22e7497a h1:BNBuWYVjAD2mgs76eyeFOkk4+HkbfduwnTFYd3usla0=
+github.com/JmPotato/tidb v1.1.0-beta.0.20210621110155-cd5d22e7497a/go.mod h1:ygaM0+11va+a64EHXHjPN1WhvaYn3Cv/SloOpCsBgus=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -424,13 +426,11 @@ github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4 h1:ERrF0fTuIOnwfGbt71Ji3DKbOEaP189tjym50u8gpC8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/parser v0.0.0-20210525032559-c37778aff307/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
-github.com/pingcap/parser v0.0.0-20210610080504-cb77169bfed9 h1:Y6kdGSXaL2cW2qkRjOyCSSaijy1FNryMn50RX6I5R2o=
-github.com/pingcap/parser v0.0.0-20210610080504-cb77169bfed9/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
+github.com/pingcap/parser v0.0.0-20210618053735-57843e8185c4 h1:NASsbyMTNW8pbYfoO/YTykO6MQJiNRa094lwCPU6R2Q=
+github.com/pingcap/parser v0.0.0-20210618053735-57843e8185c4/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
-github.com/pingcap/tidb v1.1.0-beta.0.20210616023036-9461f5ba55b1 h1:chmxXK/2P/x3zqXdmr56gI7UHHCmWgeYx6YEqxzCTLc=
-github.com/pingcap/tidb v1.1.0-beta.0.20210616023036-9461f5ba55b1/go.mod h1:qC/By1WbjT3arKXJChHxBLgP+bJzGW8lUmPRjIevaKw=
 github.com/pingcap/tidb-dashboard v0.0.0-20210312062513-eef5d6404638/go.mod h1:OzFN8H0EDMMqeulPhPMw2i2JaiZWOKFQ7zdRPhENNgo=
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible h1:ceznmu/lLseGHP/jKyOa/3u/5H3wtLLLqkH2V3ssSjg=
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Use a forked branch of TiDB to make integration_tests pass. We will reset it to `pingcap/tidb` after https://github.com/pingcap/tidb/pull/25559 is merged.