### PR TITLE
latch: replace pingcap/check with testify

### DIFF
--- a/latch/scheduler_test.go
+++ b/latch/scheduler_test.go
@@ -17,20 +17,11 @@ import (
 	"bytes"
 	"math/rand"
 	"sync"
+	"testing"
 	"time"
-
-	. "github.com/pingcap/check"
 )
 
-var _ = Suite(&testSchedulerSuite{})
-
-type testSchedulerSuite struct {
-}
-
-func (s *testSchedulerSuite) SetUpTest(c *C) {
-}
-
-func (s *testSchedulerSuite) TestWithConcurrency(c *C) {
+func TestWithConcurrency(t *testing.T) {
 	sched := NewScheduler(7)
 	defer sched.Close()
 	rand.Seed(time.Now().Unix())


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

closes #114 

cc @disksing 

I'm a bit confused by `scheduler_test.go#TestWithConcurrency` since it has no assertion but just validate code executed. We may take a closer look at the tests.