### PR TITLE
all tests run in serial

### DIFF
--- a/client/client_fail_test.go
+++ b/client/client_fail_test.go
@@ -47,16 +47,6 @@ import (
 )
 
 type testClientFailSuite struct {
-	OneByOneSuite
-}
-
-func (s *testClientFailSuite) SetUpSuite(_ *C) {
-	// This lock make testClientFailSuite runs exclusively.
-	s.LockGlobalTiKV()
-}
-
-func (s testClientFailSuite) TearDownSuite(_ *C) {
-	s.UnLockGlobalTiKV()
 }
 
 func (s *testClientFailSuite) TestPanicInRecvLoop(c *C) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -47,13 +47,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/tikv/client-go/v2/config"
-	"github.com/tikv/client-go/v2/mockstore"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"google.golang.org/grpc/metadata"
 )
-
-// OneByOneSuite is a suite, When with-tikv flag is true, there is only one storage, so the test suite have to run one by one.
-type OneByOneSuite = mockstore.OneByOneSuite
 
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true
@@ -61,14 +57,12 @@ func TestT(t *testing.T) {
 }
 
 type testClientSuite struct {
-	OneByOneSuite
 }
 
 type testClientSerialSuite struct {
-	OneByOneSuite
 }
 
-var _ = Suite(&testClientSuite{})
+var _ = SerialSuites(&testClientSuite{})
 var _ = SerialSuites(&testClientFailSuite{})
 var _ = SerialSuites(&testClientSerialSuite{})
 

--- a/integration_tests/1pc_test.go
+++ b/integration_tests/1pc_test.go
@@ -51,7 +51,6 @@ func (s *testAsyncCommitCommon) begin1PC(c *C) tikv.TxnProbe {
 }
 
 type testOnePCSuite struct {
-	OneByOneSuite
 	testAsyncCommitCommon
 	bo *tikv.Backoffer
 }

--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -64,7 +64,6 @@ var (
 )
 
 type testCommitterSuite struct {
-	OneByOneSuite
 	cluster cluster.Cluster
 	store   tikv.StoreProbe
 }
@@ -73,7 +72,6 @@ var _ = SerialSuites(&testCommitterSuite{})
 
 func (s *testCommitterSuite) SetUpSuite(c *C) {
 	atomic.StoreUint64(&tikv.ManagedLockTTL, 3000) // 3s
-	s.OneByOneSuite.SetUpSuite(c)
 	atomic.StoreUint64(&tikv.CommitMaxBackoff, 1000)
 	atomic.StoreUint64(&tikv.VeryLongMaxBackoff, 1000)
 }
@@ -112,7 +110,6 @@ func (s *testCommitterSuite) TearDownSuite(c *C) {
 	atomic.StoreUint64(&tikv.CommitMaxBackoff, 20000)
 	atomic.StoreUint64(&tikv.VeryLongMaxBackoff, 600000)
 	s.store.Close()
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testCommitterSuite) begin(c *C) tikv.TxnProbe {

--- a/integration_tests/async_commit_fail_test.go
+++ b/integration_tests/async_commit_fail_test.go
@@ -49,7 +49,6 @@ import (
 )
 
 type testAsyncCommitFailSuite struct {
-	OneByOneSuite
 	testAsyncCommitCommon
 }
 

--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -164,7 +164,6 @@ func (s *testAsyncCommitCommon) begin(c *C) tikv.TxnProbe {
 }
 
 type testAsyncCommitSuite struct {
-	OneByOneSuite
 	testAsyncCommitCommon
 	bo *tikv.Backoffer
 }

--- a/integration_tests/delete_range_test.go
+++ b/integration_tests/delete_range_test.go
@@ -46,12 +46,11 @@ import (
 )
 
 type testDeleteRangeSuite struct {
-	OneByOneSuite
 	cluster cluster.Cluster
 	store   *tikv.KVStore
 }
 
-var _ = Suite(&testDeleteRangeSuite{})
+var _ = SerialSuites(&testDeleteRangeSuite{})
 
 func (s *testDeleteRangeSuite) SetUpTest(c *C) {
 	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("", mockcopr.NewCoprRPCHandler())

--- a/integration_tests/isolation_test.go
+++ b/integration_tests/isolation_test.go
@@ -49,20 +49,17 @@ import (
 // testIsolationSuite represents test isolation suite.
 // The test suite takes too long under the race detector.
 type testIsolationSuite struct {
-	OneByOneSuite
 	store *tikv.KVStore
 }
 
-var _ = Suite(&testIsolationSuite{})
+var _ = SerialSuites(&testIsolationSuite{})
 
 func (s *testIsolationSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c)
 }
 
 func (s *testIsolationSuite) TearDownSuite(c *C) {
 	s.store.Close()
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 type writeRecord struct {

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -56,11 +56,10 @@ import (
 var getMaxBackoff = tikv.ConfigProbe{}.GetGetMaxBackoff()
 
 type testLockSuite struct {
-	OneByOneSuite
 	store tikv.StoreProbe
 }
 
-var _ = Suite(&testLockSuite{})
+var _ = SerialSuites(&testLockSuite{})
 
 func (s *testLockSuite) SetUpTest(c *C) {
 	s.store = tikv.StoreProbe{KVStore: NewTestStore(c)}

--- a/integration_tests/range_task_test.go
+++ b/integration_tests/range_task_test.go
@@ -47,7 +47,6 @@ import (
 )
 
 type testRangeTaskSuite struct {
-	OneByOneSuite
 	cluster cluster.Cluster
 	store   *tikv.KVStore
 
@@ -55,7 +54,7 @@ type testRangeTaskSuite struct {
 	expectedRanges [][]kv.KeyRange
 }
 
-var _ = Suite(&testRangeTaskSuite{})
+var _ = SerialSuites(&testRangeTaskSuite{})
 
 func makeRange(startKey string, endKey string) kv.KeyRange {
 	return kv.KeyRange{

--- a/integration_tests/rawkv_test.go
+++ b/integration_tests/rawkv_test.go
@@ -44,13 +44,12 @@ import (
 )
 
 type testRawKVSuite struct {
-	OneByOneSuite
 	cluster cluster.Cluster
 	client  tikv.RawKVClientProbe
 	bo      *tikv.Backoffer
 }
 
-var _ = Suite(&testRawKVSuite{})
+var _ = SerialSuites(&testRawKVSuite{})
 
 func (s *testRawKVSuite) SetUpTest(c *C) {
 	client, pdClient, cluster, err := unistore.New("")

--- a/integration_tests/safepoint_test.go
+++ b/integration_tests/safepoint_test.go
@@ -45,15 +45,13 @@ import (
 )
 
 type testSafePointSuite struct {
-	OneByOneSuite
 	store  tikv.StoreProbe
 	prefix string
 }
 
-var _ = Suite(&testSafePointSuite{})
+var _ = SerialSuites(&testSafePointSuite{})
 
 func (s *testSafePointSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	s.store = tikv.StoreProbe{KVStore: NewTestStore(c)}
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
 }
@@ -61,7 +59,6 @@ func (s *testSafePointSuite) SetUpSuite(c *C) {
 func (s *testSafePointSuite) TearDownSuite(c *C) {
 	err := s.store.Close()
 	c.Assert(err, IsNil)
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testSafePointSuite) beginTxn(c *C) tikv.TxnProbe {

--- a/integration_tests/scan_mock_test.go
+++ b/integration_tests/scan_mock_test.go
@@ -40,10 +40,9 @@ import (
 )
 
 type testScanMockSuite struct {
-	OneByOneSuite
 }
 
-var _ = Suite(&testScanMockSuite{})
+var _ = SerialSuites(&testScanMockSuite{})
 
 func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
 	store := tikv.StoreProbe{KVStore: NewTestStore(c)}

--- a/integration_tests/scan_test.go
+++ b/integration_tests/scan_test.go
@@ -49,7 +49,6 @@ import (
 var scanBatchSize = tikv.ConfigProbe{}.GetScanBatchSize()
 
 type testScanSuite struct {
-	OneByOneSuite
 	store        *tikv.KVStore
 	recordPrefix []byte
 	rowNums      []int
@@ -59,7 +58,6 @@ type testScanSuite struct {
 var _ = SerialSuites(&testScanSuite{})
 
 func (s *testScanSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c)
 	s.recordPrefix = []byte("prefix")
 	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1, scanBatchSize*3)
@@ -82,7 +80,6 @@ func (s *testScanSuite) TearDownSuite(c *C) {
 	c.Assert(err, IsNil)
 	err = s.store.Close()
 	c.Assert(err, IsNil)
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testScanSuite) beginTxn(c *C) *tikv.KVTxn {

--- a/integration_tests/snapshot_fail_test.go
+++ b/integration_tests/snapshot_fail_test.go
@@ -46,24 +46,18 @@ import (
 )
 
 type testSnapshotFailSuite struct {
-	OneByOneSuite
 	store tikv.StoreProbe
 }
 
 var _ = SerialSuites(&testSnapshotFailSuite{})
 
 func (s *testSnapshotFailSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	client, pdClient, cluster, err := unistore.New("")
 	c.Assert(err, IsNil)
 	unistore.BootstrapWithSingleStore(cluster)
 	store, err := tikv.NewTestTiKVStore(fpClient{Client: client}, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 	s.store = tikv.StoreProbe{KVStore: store}
-}
-
-func (s *testSnapshotFailSuite) TearDownSuite(c *C) {
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testSnapshotFailSuite) cleanup(c *C) {

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -51,16 +51,14 @@ import (
 )
 
 type testSnapshotSuite struct {
-	OneByOneSuite
 	store   tikv.StoreProbe
 	prefix  string
 	rowNums []int
 }
 
-var _ = Suite(&testSnapshotSuite{})
+var _ = SerialSuites(&testSnapshotSuite{})
 
 func (s *testSnapshotSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	s.store = tikv.StoreProbe{KVStore: NewTestStore(c)}
 	s.prefix = fmt.Sprintf("snapshot_%d", time.Now().Unix())
 	s.rowNums = append(s.rowNums, 1, 100, 191)
@@ -81,7 +79,6 @@ func (s *testSnapshotSuite) TearDownSuite(c *C) {
 	c.Assert(err, IsNil)
 	err = s.store.Close()
 	c.Assert(err, IsNil)
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testSnapshotSuite) beginTxn(c *C) tikv.TxnProbe {

--- a/integration_tests/split_test.go
+++ b/integration_tests/split_test.go
@@ -48,13 +48,12 @@ import (
 )
 
 type testSplitSuite struct {
-	OneByOneSuite
 	cluster cluster.Cluster
 	store   tikv.StoreProbe
 	bo      *tikv.Backoffer
 }
 
-var _ = Suite(&testSplitSuite{})
+var _ = SerialSuites(&testSplitSuite{})
 
 func (s *testSplitSuite) SetUpTest(c *C) {
 	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("", mockcopr.NewCoprRPCHandler())

--- a/integration_tests/store_test.go
+++ b/integration_tests/store_test.go
@@ -54,11 +54,10 @@ type testStoreSerialSuite struct {
 }
 
 type testStoreSuiteBase struct {
-	OneByOneSuite
 	store tikv.StoreProbe
 }
 
-var _ = Suite(&testStoreSuite{})
+var _ = SerialSuites(&testStoreSuite{})
 var _ = SerialSuites(&testStoreSerialSuite{})
 
 func (s *testStoreSuiteBase) SetUpTest(c *C) {

--- a/integration_tests/ticlient_test.go
+++ b/integration_tests/ticlient_test.go
@@ -44,17 +44,15 @@ import (
 )
 
 type testTiclientSuite struct {
-	OneByOneSuite
 	store *tikv.KVStore
 	// prefix is prefix of each key in this test. It is used for table isolation,
 	// or it may pollute other data.
 	prefix string
 }
 
-var _ = Suite(&testTiclientSuite{})
+var _ = SerialSuites(&testTiclientSuite{})
 
 func (s *testTiclientSuite) SetUpSuite(c *C) {
-	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c)
 	s.prefix = fmt.Sprintf("ticlient_%d", time.Now().Unix())
 }
@@ -75,7 +73,6 @@ func (s *testTiclientSuite) TearDownSuite(c *C) {
 	c.Assert(err, IsNil)
 	err = s.store.Close()
 	c.Assert(err, IsNil)
-	s.OneByOneSuite.TearDownSuite(c)
 }
 
 func (s *testTiclientSuite) beginTxn(c *C) *tikv.KVTxn {

--- a/integration_tests/util_test.go
+++ b/integration_tests/util_test.go
@@ -102,9 +102,6 @@ func clearStorage(store *tikv.KVStore) error {
 	return txn.Commit(context.Background())
 }
 
-// OneByOneSuite is a suite, When with-tikv flag is true, there is only one storage, so the test suite have to run one by one.
-type OneByOneSuite = mockstore.OneByOneSuite
-
 func encodeKey(prefix, s string) []byte {
 	return codec.EncodeBytes(nil, []byte(fmt.Sprintf("%s_%s", prefix, s)))
 }

--- a/locate/region_cache_test.go
+++ b/locate/region_cache_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/client-go/v2/kv"
-	"github.com/tikv/client-go/v2/mockstore"
 	"github.com/tikv/client-go/v2/mockstore/mocktikv"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/retry"
@@ -55,9 +54,7 @@ import (
 	pd "github.com/tikv/pd/client"
 )
 
-type OneByOneSuite = mockstore.OneByOneSuite
 type testRegionCacheSuite struct {
-	OneByOneSuite
 	cluster *mocktikv.Cluster
 	store1  uint64 // store1 is leader
 	store2  uint64 // store2 is follower
@@ -68,7 +65,7 @@ type testRegionCacheSuite struct {
 	bo      *retry.Backoffer
 }
 
-var _ = Suite(&testRegionCacheSuite{})
+var _ = SerialSuites(&testRegionCacheSuite{})
 
 func (s *testRegionCacheSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster(mocktikv.MustNewMVCCStore())

--- a/locate/region_request_test.go
+++ b/locate/region_request_test.go
@@ -73,7 +73,6 @@ type testRegionRequestToSingleStoreSuite struct {
 }
 
 type testRegionRequestToThreeStoresSuite struct {
-	OneByOneSuite
 	cluster             *mocktikv.Cluster
 	storeIDs            []uint64
 	peerIDs             []uint64
@@ -85,8 +84,8 @@ type testRegionRequestToThreeStoresSuite struct {
 	mvccStore           mocktikv.MVCCStore
 }
 
-var _ = Suite(&testRegionRequestToSingleStoreSuite{})
-var _ = Suite(&testRegionRequestToThreeStoresSuite{})
+var _ = SerialSuites(&testRegionRequestToSingleStoreSuite{})
+var _ = SerialSuites(&testRegionRequestToThreeStoresSuite{})
 
 func (s *testRegionRequestToSingleStoreSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster(mocktikv.MustNewMVCCStore())

--- a/mockstore/test_suite.go
+++ b/mockstore/test_suite.go
@@ -34,44 +34,9 @@ package mockstore
 
 import (
 	"flag"
-	"sync"
-
-	"github.com/pingcap/check"
 )
 
 var (
-	withTiKVGlobalLock sync.RWMutex
 	// WithTiKV is the flag which indicates whether it runs with tikv.
 	WithTiKV = flag.Bool("with-tikv", false, "run tests with TiKV cluster started. (not use the mock server)")
 )
-
-// OneByOneSuite is a suite, When with-tikv flag is true, there is only one storage, so the test suite have to run one by one.
-type OneByOneSuite struct{}
-
-// SetUpSuite implements the interface check.Suite.
-func (s *OneByOneSuite) SetUpSuite(c *check.C) {
-	if *WithTiKV {
-		withTiKVGlobalLock.Lock()
-	} else {
-		withTiKVGlobalLock.RLock()
-	}
-}
-
-// TearDownSuite implements the interface check.Suite.
-func (s *OneByOneSuite) TearDownSuite(c *check.C) {
-	if *WithTiKV {
-		withTiKVGlobalLock.Unlock()
-	} else {
-		withTiKVGlobalLock.RUnlock()
-	}
-}
-
-// LockGlobalTiKV locks withTiKVGlobalLock.
-func (s *OneByOneSuite) LockGlobalTiKV() {
-	withTiKVGlobalLock.Lock()
-}
-
-// UnLockGlobalTiKV unlocks withTiKVGlobalLock
-func (s *OneByOneSuite) UnLockGlobalTiKV() {
-	withTiKVGlobalLock.Unlock()
-}

--- a/tikv/rawkv_test.go
+++ b/tikv/rawkv_test.go
@@ -43,7 +43,6 @@ import (
 )
 
 type testRawkvSuite struct {
-	OneByOneSuite
 	cluster *mocktikv.Cluster
 	store1  uint64 // store1 is leader
 	store2  uint64 // store2 is follower
@@ -53,7 +52,7 @@ type testRawkvSuite struct {
 	bo      *retry.Backoffer
 }
 
-var _ = Suite(&testRawkvSuite{})
+var _ = SerialSuites(&testRawkvSuite{})
 
 func (s *testRawkvSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster(mocktikv.MustNewMVCCStore())

--- a/tikv/tikv_test.go
+++ b/tikv/tikv_test.go
@@ -36,12 +36,9 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/tikv/client-go/v2/mockstore"
 )
 
-type OneByOneSuite = mockstore.OneByOneSuite
 type testTiKVSuite struct {
-	OneByOneSuite
 }
 
 func TestT(t *testing.T) {
@@ -49,7 +46,7 @@ func TestT(t *testing.T) {
 	TestingT(t)
 }
 
-var _ = Suite(&testTiKVSuite{})
+var _ = SerialSuites(&testTiKVSuite{})
 
 func (s *testTiKVSuite) TestBasicFunc(c *C) {
 	if IsMockCommitErrorEnable() {

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -45,7 +45,7 @@ func TestT(t *testing.T) {
 
 type testBatchCommand struct{}
 
-var _ = Suite(&testBatchCommand{})
+var _ = SerialSuites(&testBatchCommand{})
 
 func (s *testBatchCommand) TestBatchResponse(c *C) {
 	resp := &tikvpb.BatchCommandsResponse_Response{}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

As we are migrating to `testify`, later test suites cannot run in parallel. This PR makes all tests run in serial to test if there are any problems.

Test result shows that it runs faster in serial. I have no idea why.

```
                    norace+parallel       norace+serial        race+parallel        race+serial
unit-test           35.974s               25.274s              9.268s               4.315s
integration-test    47.216s               37.393s              54.462s              46.847s
```