### PR TITLE
integration_tests: reduce memory usage

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -86,7 +86,7 @@ func (s *testCommitterSuite) SetUpTest(c *C) {
 	pdCli := &tikv.CodecPDClient{Client: mocktikv.NewPDClient(cluster)}
 	spkv := tikv.NewMockSafePointKV()
 	store, err := tikv.NewKVStore("mocktikv-store", pdCli, spkv, client)
-	store.EnableTxnLocalLatches(10240)
+	store.EnableTxnLocalLatches(8096)
 	c.Assert(err, IsNil)
 
 	// TODO: make it possible

--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -86,7 +86,7 @@ func (s *testCommitterSuite) SetUpTest(c *C) {
 	pdCli := &tikv.CodecPDClient{Client: mocktikv.NewPDClient(cluster)}
 	spkv := tikv.NewMockSafePointKV()
 	store, err := tikv.NewKVStore("mocktikv-store", pdCli, spkv, client)
-	store.EnableTxnLocalLatches(1024000)
+	store.EnableTxnLocalLatches(10240)
 	c.Assert(err, IsNil)
 
 	// TODO: make it possible


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Profile shows that `testCommitterSuite` uses too much memory. It could be the reason that test is been killed in CI.

```
5181904 testDeleteRangeSuite
8709096 testSplitSuite
19538784 testRangeTaskSuite
56275888 TestSetMinCommitTSInAsyncCommit
56395856 testStoreSerialSuite
56414864 testSafePointSuite
59393704 testSnapshotFailSuite
60530104 testSnapshotSuite
67307808 testScanSuite
68852040 TestTiclient
112780688 testStoreSuite
112813464 testScanMockSuite
283599256 testAsyncCommitSuite
338677600 testOnePCSuite
373290744 testRawKVSuite
400179416 testAsyncCommitFailSuite
1056385608 testLockSuite
2142688984 testCommitterSuite
```