### PR TITLE
add global async commit and 1pc config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ type Config struct {
 	Path                  string
 	EnableForwarding      bool
 	TxnScope              string
+	EnableAsyncCommit     bool
+	Enable1PC             bool
 }
 
 // DefaultConfig returns the default configuration.
@@ -91,6 +93,8 @@ func DefaultConfig() Config {
 		Path:                  "",
 		EnableForwarding:      false,
 		TxnScope:              "",
+		EnableAsyncCommit:     false,
+		Enable1PC:             false,
 	}
 }
 

--- a/tikv/txn.go
+++ b/tikv/txn.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/tikv/client-go/v2/config"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/internal/retry"
@@ -150,15 +151,18 @@ func newTiKVTxnWithOptions(store *KVStore, options StartTSOption) (*KVTxn, error
 		return nil, errors.Trace(err)
 	}
 	snapshot := newTiKVSnapshot(store, startTS, store.nextReplicaReadSeed())
+	cfg := config.GetGlobalConfig()
 	newTiKVTxn := &KVTxn{
-		snapshot:  snapshot,
-		us:        unionstore.NewUnionStore(snapshot),
-		store:     store,
-		startTS:   startTS,
-		startTime: time.Now(),
-		valid:     true,
-		vars:      tikv.DefaultVars,
-		scope:     options.TxnScope,
+		snapshot:          snapshot,
+		us:                unionstore.NewUnionStore(snapshot),
+		store:             store,
+		startTS:           startTS,
+		startTime:         time.Now(),
+		valid:             true,
+		vars:              tikv.DefaultVars,
+		scope:             options.TxnScope,
+		enableAsyncCommit: cfg.EnableAsyncCommit,
+		enable1PC:         cfg.Enable1PC,
 	}
 	return newTiKVTxn, nil
 }


### PR DESCRIPTION
If a client-go user needs to use async commit or 1PC, they need to set the configs for each transaction, which is not user-friendly.

This PR adds global switches for the two features.

We haven't claimed the supported TiKV version of this client. Considering large amount of TiKV 4.0 users, the default values of these settings are remained `false`.

This PR should not affect TiDB. TiDB sets the `enableAsyncCommit` and `enable1PC` settings according to session variables for each transaction.