### PR TITLE
util: make reduce tsset object allocation

### DIFF
--- a/tikv/snapshot.go
+++ b/tikv/snapshot.go
@@ -104,7 +104,7 @@ type KVSnapshot struct {
 	keyOnly         bool
 	vars            *kv.Variables
 	replicaReadSeed uint32
-	resolvedLocks   *util.TSSet
+	resolvedLocks   util.TSSet
 	scanBatchSize   int
 
 	// Cache the result of BatchGet.
@@ -146,7 +146,6 @@ func newTiKVSnapshot(store *KVStore, ts uint64, replicaReadSeed uint32) *KVSnaps
 		priority:        PriorityNormal,
 		vars:            kv.DefaultVars,
 		replicaReadSeed: replicaReadSeed,
-		resolvedLocks:   util.NewTSSet(5),
 	}
 }
 
@@ -164,8 +163,6 @@ func (s *KVSnapshot) SetSnapshotTS(ts uint64) {
 	s.mu.Lock()
 	s.mu.cached = nil
 	s.mu.Unlock()
-	// And also the minCommitTS pushed information.
-	s.resolvedLocks = util.NewTSSet(5)
 }
 
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
@@ -328,7 +325,7 @@ func (s *KVSnapshot) batchGetKeysByRegions(bo *Backoffer, keys [][]byte, collect
 }
 
 func (s *KVSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, collectF func(k, v []byte)) error {
-	cli := NewClientHelper(s.store, s.resolvedLocks)
+	cli := NewClientHelper(s.store, &s.resolvedLocks)
 	s.mu.RLock()
 	if s.mu.stats != nil {
 		cli.Stats = make(map[tikvrpc.CmdType]*locate.RPCRuntimeStats)
@@ -497,7 +494,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 		}
 	})
 
-	cli := NewClientHelper(s.store, s.resolvedLocks)
+	cli := NewClientHelper(s.store, &s.resolvedLocks)
 
 	s.mu.RLock()
 	if s.mu.stats != nil {

--- a/util/ts_set.go
+++ b/util/ts_set.go
@@ -61,7 +61,7 @@ func (s *TSSet) Put(tss ...uint64) {
 func (s *TSSet) GetAll() []uint64 {
 	s.RLock()
 	defer s.RUnlock()
-	if s.m == nil || len(s.m) == 0 {
+	if len(s.m) == 0 {
 		return nil
 	}
 	ret := make([]uint64, 0, len(s.m))


### PR DESCRIPTION
TSSet object allocation ranks Top3 during the point get operation.

![](https://user-images.githubusercontent.com/1420062/124618085-0e42d680-deaa-11eb-9e38-601f9c8e41d4.png)

It's a burden for Go GC as we observed in https://github.com/pingcap/tidb/issues/25573

This PR make the object allocation lazy, because not every transaction would meet lock conflict.
After this change, this object allocation is totally eliminated.

And the benchmark result in tidb shows

```
cd session
go test -test.run XXX -bench BenchmarkPreparedPointGet  -test.benchmem -test.benchtime 30s  -test.memprofile mem.out
```

Before vs After:

```
BenchmarkPreparedPointGet-16    	 3750292	      9442 ns/op	    7830 B/op	     101 allocs/op
BenchmarkPreparedPointGet-16    	 3824121	      9293 ns/op	    7702 B/op	      97 allocs/op
```