### PR TITLE
reset resolvedLocks when setting snapshot ts

### DIFF
--- a/tikv/snapshot.go
+++ b/tikv/snapshot.go
@@ -163,6 +163,8 @@ func (s *KVSnapshot) SetSnapshotTS(ts uint64) {
 	s.mu.Lock()
 	s.mu.cached = nil
 	s.mu.Unlock()
+	// And also remove the minCommitTS pushed information.
+	s.resolvedLocks = util.TSSet{}
 }
 
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.


### PR DESCRIPTION
This PR intends to fix the jepsen failure https://github.com/tikv/tikv/issues/10552#issuecomment-879531922.

If the `minCommitTS` of some transaction was advanced before, and the snapshot timestamp is reset, we must also reset the `resolvedLocks`. Otherwise, the reader can read a stale result if only the primary lock is committed. (See the test as an example)