### PR TITLE
[internal]: improve RegionRequestRuntimeStats

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -132,6 +132,7 @@ func (r *RegionRequestRuntimeStats) String() string {
 		if builder.Len() > 0 {
 			builder.WriteByte(',')
 		}
+		// append string: fmt.Sprintf("%s:{num_rpc:%v, total_time:%s}", k.String(), v.Count, util.FormatDuration(time.Duration(v.Consume))")
 		builder.WriteString(k.String())
 		builder.WriteString(":{num_rpc:")
 		builder.WriteString(strconv.FormatInt(v.Count, 10))

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -134,7 +134,7 @@ func (r *RegionRequestRuntimeStats) String() string {
 		}
 		builder.WriteString(k.String())
 		builder.WriteString(":{num_rpc:")
-		builder.WriteString(strconv.FormatInt(v.Count,10))
+		builder.WriteString(strconv.FormatInt(v.Count, 10))
 		builder.WriteString(", total_time:")
 		builder.WriteString(util.FormatDuration(time.Duration(v.Consume)))
 		builder.WriteString("}")

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -33,10 +33,10 @@
 package locate
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -127,14 +127,19 @@ type RPCRuntimeStats struct {
 
 // String implements fmt.Stringer interface.
 func (r *RegionRequestRuntimeStats) String() string {
-	var buf bytes.Buffer
+	var builder strings.Builder
 	for k, v := range r.Stats {
-		if buf.Len() > 0 {
-			buf.WriteByte(',')
+		if builder.Len() > 0 {
+			builder.WriteByte(',')
 		}
-		buf.WriteString(fmt.Sprintf("%s:{num_rpc:%d, total_time:%s}", k.String(), v.Count, util.FormatDuration(time.Duration(v.Consume))))
+		builder.WriteString(k.String())
+		builder.WriteString(":{num_rpc:")
+		builder.WriteString(strconv.FormatInt(v.Count,10))
+		builder.WriteString(", total_time:")
+		builder.WriteString(util.FormatDuration(time.Duration(v.Consume)))
+		builder.WriteString("}")
 	}
-	return buf.String()
+	return builder.String()
 }
 
 // Clone returns a copy of itself.


### PR DESCRIPTION
I've been working on improving TiDB's Point-Get performance, and I found out there is space for improvement in client-go.
![图片](https://user-images.githubusercontent.com/44747719/125746943-285cb478-760d-41e1-8c4e-2160a00e6cfd.png)
So I merely replaced that `fmt.Sprintf()` with `strings.Builder`. By doing so, time cost of the function should be reduced to a half.

Signed-off-by: ClSlaid <cailue@bupt.edu.cn>