### PR TITLE
(WIP) select replica for forward requests using RegionRequestSender

### DIFF
--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -725,7 +725,7 @@ func (s *testRegionCacheSuite) TestSendFailEnableForwarding() {
 	s.Nil(err)
 	s.Equal(loc1.Region.id, s.region1)
 
-	// Invoke OnSendFail so that the store will be marked as needForwarding
+	// Invoke OnSendFail so that the store will be marked as unreachable
 	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	s.Nil(err)
 	s.NotNil(ctx)

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -243,8 +243,19 @@ type replicaSelector struct {
 	// replicas contains all TiKV replicas for now and the leader is at the
 	// head of the slice.
 	replicas []*replica
+	state selectorState
 	// nextReplicaIdx points to the candidate for the next attempt.
 	nextReplicaIdx int
+}
+
+type selectorState interface {}
+
+type accessKnownLeader struct {
+	attempt int
+}
+
+type accessByProxy struct {
+
 }
 
 func newReplicaSelector(regionCache *RegionCache, regionID RegionVerID) (*replicaSelector, error) {
@@ -268,6 +279,7 @@ func newReplicaSelector(regionCache *RegionCache, regionID RegionVerID) (*replic
 		regionCache,
 		cachedRegion,
 		replicas,
+		accessKnownLeader{0},
 		0,
 	}, nil
 }
@@ -336,6 +348,8 @@ func (s *replicaSelector) onSendFailure(bo *retry.Backoffer, err error) {
 	if replica.store.requestLiveness(bo, s.regionCache) == reachable {
 		s.rewind()
 		return
+	} else {
+		replica.store.startHealthCheckLoopIfNeeded(s.regionCache)
 	}
 
 	store := replica.store
@@ -420,7 +434,7 @@ func (s *RegionRequestSender) getRPCContext(
 		// Now only requests sent to the replica leader will use the replica selector to get
 		// the RPC context.
 		// TODO(youjiali1995): make all requests use the replica selector.
-		if !s.regionCache.enableForwarding && req.ReplicaReadType == kv.ReplicaReadLeader {
+		if /* !s.regionCache.enableForwarding && */ req.ReplicaReadType == kv.ReplicaReadLeader {
 			if s.leaderReplicaSelector == nil {
 				selector, err := newReplicaSelector(s.regionCache, regionID)
 				if selector == nil || err != nil {

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -218,7 +218,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestForwarding() {
 	atomic.StoreUint32(&storeState, uint32(reachable))
 	start := time.Now()
 	for {
-		if atomic.LoadInt32(&leaderStore.needForwarding) == 0 {
+		if atomic.LoadInt32(&leaderStore.unreachable) == 0 {
 			break
 		}
 		if time.Since(start) > 3*time.Second {


### PR DESCRIPTION
This PR refactors the `RegionRequestSender` with state machines to make the logic easier to understand (hopefully).

And it also supports selecting replicas for request forwarding.

WIP for changing tests and doing manual integration tests.