### PR TITLE
tikv/kv.go: define Lock & LockResolver before updating tidb/br

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -571,3 +571,14 @@ func NewLockResolver(etcdAddrs []string, security config.Security, opts ...pd.Cl
 	}
 	return s.lockResolver, nil
 }
+
+// TODO: remove Lock&LockResolver&TxnStatus once tidb and br are ready.
+
+// Lock represents a lock from tikv server.
+type Lock = txnlock.Lock
+
+// LockResolver resolves locks and also caches resolved txn status.
+type LockResolver = txnlock.LockResolver
+
+// TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
+type TxnStatus = txnlock.TxnStatus


### PR DESCRIPTION
This PR defines Lock & LockResolver back in package `tikv` since both tidb and br are using it. We could remove them once br and tidb are ready.

Signed-off-by: shirly <AndreMouche@126.com>