### PR TITLE
tikv: move temporary export types to package txnkv

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/kvproto v0.0.0-20210722091755-91a52cd9e8db
-	github.com/pingcap/parser v0.0.0-20210707071004-31c87e37af5c
-	github.com/pingcap/tidb v1.1.0-beta.0.20210727065815-01ac21c194a5
+	github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2
+	github.com/pingcap/tidb v1.1.0-beta.0.20210729073017-a27d306e65a0
 	github.com/stretchr/testify v1.7.0
 	github.com/tikv/client-go/v2 v2.0.0
 	github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -429,13 +429,13 @@ github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7 h1:k2BbABz9+TNpYRwsCCFS8pEEnFVOdbgEjL/kTlLuzZQ=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/parser v0.0.0-20210525032559-c37778aff307/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
-github.com/pingcap/parser v0.0.0-20210707071004-31c87e37af5c h1:FPBMwDTtMW25zyLLBrIMUnM7Zl/WtLxR9LSEiaL5hII=
-github.com/pingcap/parser v0.0.0-20210707071004-31c87e37af5c/go.mod h1:Ek0mLKEqUGnQqBw1JnYrJQxsguU433DU68yUbsoeJ7s=
+github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2 h1:2cwX3RI5skZ4rEC1yz+VuS70DkLsCr2g9/Bur/UWBac=
+github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2/go.mod h1:Ek0mLKEqUGnQqBw1JnYrJQxsguU433DU68yUbsoeJ7s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
-github.com/pingcap/tidb v1.1.0-beta.0.20210727065815-01ac21c194a5 h1:AZkG3LvNC6onKcSWJh7FtRJhWJaz6xH3icLSxlcHo34=
-github.com/pingcap/tidb v1.1.0-beta.0.20210727065815-01ac21c194a5/go.mod h1:HdSBIf/qkvB7PSVEzr3vO++xrTKO5E8WjWMr3nTMLtY=
+github.com/pingcap/tidb v1.1.0-beta.0.20210729073017-a27d306e65a0 h1:ue1C7Vl+7CoK3tKJNhXod85cbLHhoznoyYsZGOfP434=
+github.com/pingcap/tidb v1.1.0-beta.0.20210729073017-a27d306e65a0/go.mod h1:vvO2Sq9M60PKpJjroZtq72hMjc4ulDn6hlGedRKCeDY=
 github.com/pingcap/tidb-dashboard v0.0.0-20210312062513-eef5d6404638/go.mod h1:OzFN8H0EDMMqeulPhPMw2i2JaiZWOKFQ7zdRPhENNgo=
 github.com/pingcap/tidb-tools v5.0.3+incompatible h1:vYMrW9ux+3HRMeRZ1fUOjy2nyiodtuVyAyK270EKBEs=
 github.com/pingcap/tidb-tools v5.0.3+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/txnkv"
 )
 
 func TestSnapshot(t *testing.T) {
@@ -285,7 +286,7 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 	tikv.RecordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Second)
 	tikv.RecordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Millisecond)
 	snapshot := s.store.GetSnapshot(0)
-	snapshot.SetRuntimeStats(&tikv.SnapshotRuntimeStats{})
+	snapshot.SetRuntimeStats(&txnkv.SnapshotRuntimeStats{})
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	bo := tikv.NewBackofferWithVars(context.Background(), 2000, nil)

--- a/integration_tests/store_test.go
+++ b/integration_tests/store_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tikv/client-go/v2/oracle/oracles"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/txnkv"
 )
 
 func TestStore(t *testing.T) {
@@ -137,7 +138,7 @@ func (s *testStoreSuite) TestRequestPriority() {
 	txn, err := s.store.Begin()
 	s.Require().Nil(err)
 	client.priority = kvrpcpb.CommandPri_High
-	txn.SetPriority(tikv.PriorityHigh)
+	txn.SetPriority(txnkv.PriorityHigh)
 	err = txn.Set([]byte("key"), []byte("value"))
 	s.Nil(err)
 	err = txn.Commit(context.Background())
@@ -147,20 +148,20 @@ func (s *testStoreSuite) TestRequestPriority() {
 	txn, err = s.store.Begin()
 	s.Require().Nil(err)
 	client.priority = kvrpcpb.CommandPri_Low
-	txn.SetPriority(tikv.PriorityLow)
+	txn.SetPriority(txnkv.PriorityLow)
 	_, err = txn.Get(context.TODO(), []byte("key"))
 	s.Nil(err)
 
 	// A counter example.
 	client.priority = kvrpcpb.CommandPri_Low
-	txn.SetPriority(tikv.PriorityNormal)
+	txn.SetPriority(txnkv.PriorityNormal)
 	_, err = txn.Get(context.TODO(), []byte("key"))
 	// err is translated to "try again later" by backoffer, so doesn't check error value here.
 	s.NotNil(err)
 
 	// Cover Seek request.
 	client.priority = kvrpcpb.CommandPri_High
-	txn.SetPriority(tikv.PriorityHigh)
+	txn.SetPriority(txnkv.PriorityHigh)
 	iter, err := txn.Iter([]byte("key"), nil)
 	s.Nil(err)
 	for iter.Valid() {

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -62,7 +62,6 @@ import (
 	"github.com/tikv/client-go/v2/txnkv/rangetask"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
-	"github.com/tikv/client-go/v2/txnkv/txnutil"
 	"github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	"go.etcd.io/etcd/clientv3"
@@ -572,50 +571,4 @@ func NewLockResolver(etcdAddrs []string, security config.Security, opts ...pd.Cl
 		return nil, errors.Trace(err)
 	}
 	return s.lockResolver, nil
-}
-
-// TODO: remove it when tidb/br is ready.
-
-// Scanner support tikv scan
-type Scanner = txnsnapshot.Scanner
-
-// KVSnapshot implements the tidbkv.Snapshot interface.
-type KVSnapshot = txnsnapshot.KVSnapshot
-
-// SnapshotRuntimeStats records the runtime stats of snapshot.
-type SnapshotRuntimeStats = txnsnapshot.SnapshotRuntimeStats
-
-// IsoLevel is the transaction's isolation level.
-type IsoLevel = txnsnapshot.IsoLevel
-
-// IsoLevel value for transaction priority.
-const (
-	SI = txnsnapshot.SI
-	RC = txnsnapshot.RC
-)
-
-// Priority is the priority for tikv to execute a command.
-type Priority = txnutil.Priority
-
-// Priority value for transaction priority.
-const (
-	PriorityHigh   = txnutil.PriorityHigh
-	PriorityNormal = txnutil.PriorityNormal
-	PriorityLow    = txnutil.PriorityLow
-)
-
-// TODO: remove Lock&LockResolver&TxnStatus once tidb and br are ready.
-
-// Lock represents a lock from tikv server.
-type Lock = txnlock.Lock
-
-// LockResolver resolves locks and also caches resolved txn status.
-type LockResolver = txnlock.LockResolver
-
-// TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
-type TxnStatus = txnlock.TxnStatus
-
-// NewLock creates a new *Lock.
-func NewLock(l *kvrpcpb.LockInfo) *Lock {
-	return txnlock.NewLock(l)
 }

--- a/txnkv/lock_export.go
+++ b/txnkv/lock_export.go
@@ -1,0 +1,33 @@
+// Copyright 2021 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnkv
+
+import (
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
+)
+
+// Lock represents a lock from tikv server.
+type Lock = txnlock.Lock
+
+// LockResolver resolves locks and also caches resolved txn status.
+type LockResolver = txnlock.LockResolver
+
+// TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
+type TxnStatus = txnlock.TxnStatus
+
+// NewLock creates a new *Lock.
+func NewLock(l *kvrpcpb.LockInfo) *Lock {
+	return txnlock.NewLock(l)
+}

--- a/txnkv/snapshot_export.go
+++ b/txnkv/snapshot_export.go
@@ -13,13 +13,24 @@
 
 package txnkv
 
-import "github.com/tikv/client-go/v2/txnkv/txnlock"
+import (
+	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
+)
 
-// Lock represents a lock from tikv server.
-type Lock = txnlock.Lock
+// Scanner support tikv scan
+type Scanner = txnsnapshot.Scanner
 
-// LockResolver resolves locks and also caches resolved txn status.
-type LockResolver = txnlock.LockResolver
+// KVSnapshot implements the tidbkv.Snapshot interface.
+type KVSnapshot = txnsnapshot.KVSnapshot
 
-// TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
-type TxnStatus = txnlock.TxnStatus
+// SnapshotRuntimeStats records the runtime stats of snapshot.
+type SnapshotRuntimeStats = txnsnapshot.SnapshotRuntimeStats
+
+// IsoLevel is the transaction's isolation level.
+type IsoLevel = txnsnapshot.IsoLevel
+
+// IsoLevel value for transaction priority.
+const (
+	SI = txnsnapshot.SI
+	RC = txnsnapshot.RC
+)

--- a/txnkv/util_export.go
+++ b/txnkv/util_export.go
@@ -1,0 +1,26 @@
+// Copyright 2021 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnkv
+
+import "github.com/tikv/client-go/v2/txnkv/txnutil"
+
+// Priority is the priority for tikv to execute a command.
+type Priority = txnutil.Priority
+
+// Priority value for transaction priority.
+const (
+	PriorityHigh   = txnutil.PriorityHigh
+	PriorityNormal = txnutil.PriorityNormal
+	PriorityLow    = txnutil.PriorityLow
+)


### PR DESCRIPTION
This PR moves temporary export types to package `txnkv`

Signed-off-by: shirly <AndreMouche@126.com>