### PR TITLE
Start heartbeat immediately after locking the primary key

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -752,6 +752,8 @@ func (c *twoPhaseCommitter) doActionOnGroupMutations(bo *retry.Backoffer, action
 		}
 		batchBuilder.forgetPrimary()
 	}
+	util.EvalFailpoint("afterPrimaryBatch")
+
 	// Already spawned a goroutine for async commit transaction.
 	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
 		secondaryBo := retry.NewBackofferWithVars(c.store.Ctx(), CommitSecondaryMaxBackoff, c.txn.vars)

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -884,10 +884,6 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter, closeCh chan struct{}) {
 	// Ticker is set to 1/2 of the ManagedLockTTL.
 	ticker := time.NewTicker(time.Duration(atomic.LoadUint64(&ManagedLockTTL)) * time.Millisecond / 2)
 	defer ticker.Stop()
-	logutil.BgLogger().Warn("start TxnHeartBeat")
-	defer func() {
-		logutil.BgLogger().Warn("stop TxnHeartBeat")
-	}()
 	keepFail := 0
 	for {
 		select {

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1471,7 +1471,6 @@ func (c *twoPhaseCommitter) amendPessimisticLock(ctx context.Context, addMutatio
 	if keysNeedToLock.Len() > 0 {
 		lCtx := kv.NewLockCtx(c.forUpdateTS, c.lockCtx.LockWaitTime(), time.Now())
 		lCtx.Killed = c.lockCtx.Killed
-		lCtx.LockExpired = c.lockCtx.LockExpired
 		tryTimes := uint(0)
 		retryLimit := config.GetGlobalConfig().PessimisticTxn.MaxRetryCount
 		var err error

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -623,7 +623,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 			if assignedPrimaryKey {
 				// unset the primary key and stop heartbeat if we assigned primary key when failed to lock it.
 				txn.committer.primaryKey = nil
-				txn.committer.ttlManager.close()
+				txn.committer.ttlManager.reset()
 			}
 			return err
 		}

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -621,13 +621,11 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 				}
 			}
 			if assignedPrimaryKey {
-				// unset the primary key if we assigned primary key when failed to lock it.
+				// unset the primary key and stop heartbeat if we assigned primary key when failed to lock it.
 				txn.committer.primaryKey = nil
+				txn.committer.ttlManager.close()
 			}
 			return err
-		}
-		if assignedPrimaryKey {
-			txn.committer.ttlManager.run(txn.committer, lockCtx)
 		}
 	}
 	for _, key := range keys {


### PR DESCRIPTION
See https://github.com/pingcap/tidb/issues/26801 for what this PR wants to solve.

This PR starts the `keepAlive` goroutine after locking the primary key. So even if locking other keys takes a long time, the TTL of the primary lock will not expire.

However, before all keys are locked successfully, the primary lock may be determined. So if some keys fail to be locked and , we need to stop the heartbeat goroutine.