### PR TITLE
WIP: txnkv/txnsnapshot: Support snapshot set ranges for memory scan

### DIFF
--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -86,7 +86,7 @@ type MemDB struct {
 	stages      []memdbCheckpoint
 }
 
-func newMemDB() *MemDB {
+func NewMemDB() *MemDB {
 	db := new(MemDB)
 	db.allocator.init()
 	db.root = nullAddr

--- a/internal/unionstore/memdb_bench_test.go
+++ b/internal/unionstore/memdb_bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkLargeIndex(b *testing.B) {
 	for i := range buf {
 		binary.LittleEndian.PutUint32(buf[i][:], uint32(i))
 	}
-	db := newMemDB()
+	db := NewMemDB()
 	b.ResetTimer()
 
 	for i := range buf {
@@ -62,7 +62,7 @@ func BenchmarkPut(b *testing.B) {
 		binary.BigEndian.PutUint32(buf[i][:], uint32(i))
 	}
 
-	p := newMemDB()
+	p := NewMemDB()
 	b.ResetTimer()
 
 	for i := range buf {
@@ -76,7 +76,7 @@ func BenchmarkPutRandom(b *testing.B) {
 		binary.LittleEndian.PutUint32(buf[i][:], uint32(rand.Int()))
 	}
 
-	p := newMemDB()
+	p := NewMemDB()
 	b.ResetTimer()
 
 	for i := range buf {
@@ -90,7 +90,7 @@ func BenchmarkGet(b *testing.B) {
 		binary.BigEndian.PutUint32(buf[i][:], uint32(i))
 	}
 
-	p := newMemDB()
+	p := NewMemDB()
 	for i := range buf {
 		p.Set(buf[i][:keySize], buf[i][:])
 	}
@@ -107,7 +107,7 @@ func BenchmarkGetRandom(b *testing.B) {
 		binary.LittleEndian.PutUint32(buf[i][:], uint32(rand.Int()))
 	}
 
-	p := newMemDB()
+	p := NewMemDB()
 	for i := range buf {
 		p.Set(buf[i][:keySize], buf[i][:])
 	}
@@ -125,7 +125,7 @@ func BenchmarkMemDbBufferSequential(b *testing.B) {
 	for i := 0; i < opCnt; i++ {
 		data[i] = encodeInt(i)
 	}
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	benchmarkSetGet(b, buffer, data)
 	b.ReportAllocs()
 }
@@ -136,20 +136,20 @@ func BenchmarkMemDbBufferRandom(b *testing.B) {
 		data[i] = encodeInt(i)
 	}
 	shuffle(data)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	benchmarkSetGet(b, buffer, data)
 	b.ReportAllocs()
 }
 
 func BenchmarkMemDbIter(b *testing.B) {
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	benchIterator(b, buffer)
 	b.ReportAllocs()
 }
 
 func BenchmarkMemDbCreation(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		newMemDB()
+		NewMemDB()
 	}
 	b.ReportAllocs()
 }

--- a/internal/unionstore/memdb_norace_test.go
+++ b/internal/unionstore/memdb_norace_test.go
@@ -55,7 +55,7 @@ func TestRandom(t *testing.T) {
 		rand.Read(keys[i])
 	}
 
-	p1 := newMemDB()
+	p1 := NewMemDB()
 	p2 := leveldb.New(comparer.DefaultComparer, 4*1024)
 	for _, k := range keys {
 		p1.Set(k, k)
@@ -84,7 +84,7 @@ func TestRandom(t *testing.T) {
 
 // The test takes too long under the race detector.
 func TestRandomDerive(t *testing.T) {
-	db := newMemDB()
+	db := NewMemDB()
 	golden := leveldb.New(comparer.DefaultComparer, 4*1024)
 	testRandomDeriveRecur(t, db, golden, 0)
 }

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -78,7 +78,7 @@ func TestGetSet(t *testing.T) {
 
 func TestBigKV(t *testing.T) {
 	assert := assert.New(t)
-	db := newMemDB()
+	db := NewMemDB()
 	db.Set([]byte{1}, make([]byte, 80<<20))
 	assert.Equal(db.vlog.blockSize, maxBlockSize)
 	assert.Equal(len(db.vlog.blocks), 1)
@@ -120,7 +120,7 @@ func TestDiscard(t *testing.T) {
 	assert := assert.New(t)
 
 	const cnt = 10000
-	db := newMemDB()
+	db := NewMemDB()
 	base := deriveAndFill(0, cnt, 0, db)
 	sz := db.Size()
 
@@ -175,7 +175,7 @@ func TestFlushOverwrite(t *testing.T) {
 	assert := assert.New(t)
 
 	const cnt = 10000
-	db := newMemDB()
+	db := NewMemDB()
 	db.Release(deriveAndFill(0, cnt, 0, db))
 	sz := db.Size()
 
@@ -224,7 +224,7 @@ func TestComplexUpdate(t *testing.T) {
 		insert    = 9000
 	)
 
-	db := newMemDB()
+	db := NewMemDB()
 	db.Release(deriveAndFill(0, overwrite, 0, db))
 	assert.Equal(db.Len(), overwrite)
 	db.Release(deriveAndFill(keep, insert, 1, db))
@@ -246,7 +246,7 @@ func TestComplexUpdate(t *testing.T) {
 
 func TestNestedSandbox(t *testing.T) {
 	assert := assert.New(t)
-	db := newMemDB()
+	db := NewMemDB()
 	h0 := deriveAndFill(0, 200, 0, db)
 	h1 := deriveAndFill(0, 100, 1, db)
 	h2 := deriveAndFill(50, 150, 2, db)
@@ -360,7 +360,7 @@ func TestOverwrite(t *testing.T) {
 
 func TestKVLargeThanBlock(t *testing.T) {
 	assert := assert.New(t)
-	db := newMemDB()
+	db := NewMemDB()
 	db.Set([]byte{1}, make([]byte, 1))
 	db.Set([]byte{2}, make([]byte, 4096))
 	assert.Equal(len(db.vlog.blocks), 2)
@@ -373,7 +373,7 @@ func TestKVLargeThanBlock(t *testing.T) {
 
 func TestEmptyDB(t *testing.T) {
 	assert := assert.New(t)
-	db := newMemDB()
+	db := NewMemDB()
 	_, err := db.Get([]byte{0})
 	assert.NotNil(err)
 	it1, _ := db.Iter(nil, nil)
@@ -405,7 +405,7 @@ func TestReset(t *testing.T) {
 func TestInspectStage(t *testing.T) {
 	assert := assert.New(t)
 
-	db := newMemDB()
+	db := NewMemDB()
 	h1 := deriveAndFill(0, 1000, 0, db)
 	h2 := deriveAndFill(500, 1000, 1, db)
 	for i := 500; i < 1500; i++ {
@@ -459,11 +459,11 @@ func TestInspectStage(t *testing.T) {
 func TestDirty(t *testing.T) {
 	assert := assert.New(t)
 
-	db := newMemDB()
+	db := NewMemDB()
 	db.Set([]byte{1}, []byte{1})
 	assert.True(db.Dirty())
 
-	db = newMemDB()
+	db = NewMemDB()
 	h := db.Staging()
 	db.Set([]byte{1}, []byte{1})
 	db.Cleanup(h)
@@ -475,14 +475,14 @@ func TestDirty(t *testing.T) {
 	assert.True(db.Dirty())
 
 	// persistent flags will make memdb dirty.
-	db = newMemDB()
+	db = NewMemDB()
 	h = db.Staging()
 	db.SetWithFlags([]byte{1}, []byte{1}, kv.SetKeyLocked)
 	db.Cleanup(h)
 	assert.True(db.Dirty())
 
 	// non-persistent flags will not make memdb dirty.
-	db = newMemDB()
+	db = NewMemDB()
 	h = db.Staging()
 	db.SetWithFlags([]byte{1}, []byte{1}, kv.SetPresumeKeyNotExists)
 	db.Cleanup(h)
@@ -493,7 +493,7 @@ func TestFlags(t *testing.T) {
 	assert := assert.New(t)
 
 	const cnt = 10000
-	db := newMemDB()
+	db := NewMemDB()
 	h := db.Staging()
 	for i := uint32(0); i < cnt; i++ {
 		var buf [4]byte
@@ -596,7 +596,7 @@ func checkConsist(t *testing.T, p1 *MemDB, p2 *leveldb.DB) {
 }
 
 func fillDB(cnt int) *MemDB {
-	db := newMemDB()
+	db := NewMemDB()
 	h := deriveAndFill(0, cnt, 0, db)
 	db.Release(h)
 	return db
@@ -698,14 +698,14 @@ func mustGet(t *testing.T, buffer *MemDB) {
 }
 
 func TestKVGetSet(t *testing.T) {
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	insertData(t, buffer)
 	mustGet(t, buffer)
 }
 
 func TestNewIterator(t *testing.T) {
 	assert := assert.New(t)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	// should be invalid
 	iter, err := buffer.Iter(nil, nil)
 	assert.Nil(err)
@@ -733,7 +733,7 @@ func NextUntil(it Iterator, fn FnKeyCmp) error {
 
 func TestIterNextUntil(t *testing.T) {
 	assert := assert.New(t)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	insertData(t, buffer)
 
 	iter, err := buffer.Iter(nil, nil)
@@ -748,7 +748,7 @@ func TestIterNextUntil(t *testing.T) {
 
 func TestBasicNewIterator(t *testing.T) {
 	assert := assert.New(t)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	it, err := buffer.Iter([]byte("2"), nil)
 	assert.Nil(err)
 	assert.False(it.Valid())
@@ -767,7 +767,7 @@ func TestNewIteratorMin(t *testing.T) {
 		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000002_0002", "2"},
 		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000002_0003", "hello"},
 	}
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	for _, kv := range kvs {
 		err := buffer.Set([]byte(kv.key), []byte(kv.value))
 		assert.Nil(err)
@@ -790,7 +790,7 @@ func TestNewIteratorMin(t *testing.T) {
 
 func TestMemDBStaging(t *testing.T) {
 	assert := assert.New(t)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	err := buffer.Set([]byte("x"), make([]byte, 2))
 	assert.Nil(err)
 
@@ -818,7 +818,7 @@ func TestMemDBStaging(t *testing.T) {
 
 func TestBufferLimit(t *testing.T) {
 	assert := assert.New(t)
-	buffer := newMemDB()
+	buffer := NewMemDB()
 	buffer.bufferSizeLimit = 1000
 	buffer.entrySizeLimit = 500
 

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -55,6 +55,13 @@ type Getter interface {
 	Get(k []byte) ([]byte, error)
 }
 
+// Retriever is the interface for Getter and Scan method
+type Retriever interface {
+	Getter
+	// Scan creates an Iterator
+	Scan(k []byte, upperBound []byte, reverse bool) (Iterator, error)
+}
+
 // uSnapshot defines the interface for the snapshot fetched from KV store.
 type uSnapshot interface {
 	// Get gets the value for key k from kv store.

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -84,7 +84,7 @@ type KVUnionStore struct {
 func NewUnionStore(snapshot uSnapshot) *KVUnionStore {
 	return &KVUnionStore{
 		snapshot:  snapshot,
-		memBuffer: newMemDB(),
+		memBuffer: NewMemDB(),
 	}
 }
 

--- a/internal/unionstore/union_store_test.go
+++ b/internal/unionstore/union_store_test.go
@@ -42,7 +42,7 @@ import (
 
 func TestUnionStoreGetSet(t *testing.T) {
 	assert := assert.New(t)
-	store := newMemDB()
+	store := NewMemDB()
 	us := NewUnionStore(&mockSnapshot{store})
 
 	err := store.Set([]byte("1"), []byte("1"))
@@ -61,7 +61,7 @@ func TestUnionStoreGetSet(t *testing.T) {
 
 func TestUnionStoreDelete(t *testing.T) {
 	assert := assert.New(t)
-	store := newMemDB()
+	store := NewMemDB()
 	us := NewUnionStore(&mockSnapshot{store})
 
 	err := store.Set([]byte("1"), []byte("1"))
@@ -80,7 +80,7 @@ func TestUnionStoreDelete(t *testing.T) {
 
 func TestUnionStoreSeek(t *testing.T) {
 	assert := assert.New(t)
-	store := newMemDB()
+	store := NewMemDB()
 	us := NewUnionStore(&mockSnapshot{store})
 
 	err := store.Set([]byte("1"), []byte("1"))
@@ -113,7 +113,7 @@ func TestUnionStoreSeek(t *testing.T) {
 
 func TestUnionStoreIterReverse(t *testing.T) {
 	assert := assert.New(t)
-	store := newMemDB()
+	store := NewMemDB()
 	us := NewUnionStore(&mockSnapshot{store})
 
 	err := store.Set([]byte("1"), []byte("1"))

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -582,6 +582,16 @@ type Scanner = txnsnapshot.Scanner
 // KVSnapshot implements the tidbkv.Snapshot interface.
 type KVSnapshot = txnsnapshot.KVSnapshot
 
+// MemDBRetriever implements unionstore.Retriever
+type MemDBRetriever = txnsnapshot.MemDBRetriever
+
+// EmptyRetriever implements unionstore.Retriever
+type EmptyRetriever = txnsnapshot.EmptyRetriever
+
+type RangeRetriever = txnsnapshot.RangeRetriever
+
+var NewRangeRetriever = txnsnapshot.NewRangeRetriever
+
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats = txnsnapshot.SnapshotRuntimeStats
 

--- a/tikv/unionstore_export.go
+++ b/tikv/unionstore_export.go
@@ -49,3 +49,6 @@ type Iterator = unionstore.Iterator
 // When discarding a newly added KV in `Cleanup`, the non-persistent flags will be cleared.
 // If there are persistent flags associated with key, we will keep this key in node without value.
 type MemDB = unionstore.MemDB
+
+// NewMemDB creates a new MemDB
+var NewMemDB = unionstore.NewMemDB

--- a/tikv/unionstore_export.go
+++ b/tikv/unionstore_export.go
@@ -40,6 +40,9 @@ type Getter = unionstore.Getter
 // Iterator is the interface for a iterator on KV store.
 type Iterator = unionstore.Iterator
 
+// Retriever is the interface for Getter and Scan method
+type Retriever = unionstore.Retriever
+
 // MemDB is rollbackable Red-Black Tree optimized for transaction states buffer use scenario.
 // You can think MemDB is a combination of two separate tree map, one for key => value and another for key => keyFlags.
 //

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -436,7 +436,7 @@ func (m *MemDBRetriever) Scan(k []byte, upperBound []byte, reverse bool) (unions
 		return m.MemDB.Iter(k, upperBound)
 	}
 
-	iter, err := m.MemDB.Iter(k, upperBound)
+	iter, err := m.MemDB.IterReverse(upperBound)
 	if err != nil {
 		return nil, err
 	}

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -421,10 +421,10 @@ func newOneByOneIter(iters []unionstore.Iterator) *oneByOneIter {
 
 func (o *oneByOneIter) updateCur() {
 	for o.cur >= 0 && o.cur < len(o.iters) {
-		cur := o.iters[o.cur]
-		if !cur.Valid() {
-			o.cur++
+		if o.iters[o.cur].Valid() {
+			break
 		}
+		o.cur++
 	}
 }
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -831,7 +831,7 @@ func (s *KVSnapshot) Iter(k []byte, upperBound []byte) (unionstore.Iterator, err
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
 func (s *KVSnapshot) IterReverse(k []byte) (unionstore.Iterator, error) {
-	iter, err := s.tryCreateMultiRangeIter(nil, k, false)
+	iter, err := s.tryCreateMultiRangeIter(nil, k, true)
 	if err != nil {
 		return nil, err
 	}

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -279,6 +279,7 @@ func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]
 			if fromCustom, val, err := s.tryGetCustomSnapshotKey(key); fromCustom {
 				if err == nil {
 					m[string(key)] = val
+					continue
 				}
 
 				if !tikverr.IsErrNotFound(err) {


### PR DESCRIPTION
Related to issue: https://github.com/pingcap/tidb/issues/26952

Introduce method `SetSortedCustomKeyRetrievers` to read custom ranges. For example, we can do it like below:

```
var snapshot *KVSnapshot
...
retrievers := []*RangeRetriever{NewRangeRetriever(tblPrefix, tblKeyEnd, NewMemDBRetriver(memDB))}
snapshot.SetSortedCustomKeyRetrievers(retrievers)
```

Then the key in range `[tblPrefix, tblKeyEnd)` will be fetched from memDB

 