### PR TITLE
locate: don't backoff if fails to decode region key

### DIFF
--- a/internal/locate/pd_codec.go
+++ b/internal/locate/pd_codec.go
@@ -111,18 +111,33 @@ func processRegionResult(region *pd.Region, err error) (*pd.Region, error) {
 	return region, nil
 }
 
+// decodeError happens if the region range key is not well-formed.
+// It indicates TiKV has bugs and the client can't handle such a case,
+// so it should report the error to users soon.
+type decodeError struct {
+	error
+}
+
+func isDecodeError(err error) bool {
+	_, ok := errors.Cause(err).(*decodeError)
+	if !ok {
+		_, ok = errors.Cause(err).(decodeError)
+	}
+	return ok
+}
+
 func decodeRegionMetaKeyInPlace(r *metapb.Region) error {
 	if len(r.StartKey) != 0 {
 		_, decoded, err := codec.DecodeBytes(r.StartKey, nil)
 		if err != nil {
-			return errors.Trace(err)
+			return &decodeError{err}
 		}
 		r.StartKey = decoded
 	}
 	if len(r.EndKey) != 0 {
 		_, decoded, err := codec.DecodeBytes(r.EndKey, nil)
 		if err != nil {
-			return errors.Trace(err)
+			return &decodeError{err}
 		}
 		r.EndKey = decoded
 	}

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1284,6 +1284,9 @@ func (c *RegionCache) loadRegion(bo *retry.Backoffer, key []byte, isEndKey bool)
 			metrics.RegionCacheCounterWithGetRegionOK.Inc()
 		}
 		if err != nil {
+			if isDecodeError(err) {
+				return nil, errors.Errorf("failed to decode region range key, key: %q, err: %v", key, err)
+			}
 			backoffErr = errors.Errorf("loadRegion from PD failed, key: %q, err: %v", key, err)
 			continue
 		}
@@ -1334,6 +1337,9 @@ func (c *RegionCache) loadRegionByID(bo *retry.Backoffer, regionID uint64) (*Reg
 			metrics.RegionCacheCounterWithGetRegionByIDOK.Inc()
 		}
 		if err != nil {
+			if isDecodeError(err) {
+				return nil, errors.Errorf("failed to decode region range key, regionID: %q, err: %v", regionID, err)
+			}
 			backoffErr = errors.Errorf("loadRegion from PD failed, regionID: %v, err: %v", regionID, err)
 			continue
 		}
@@ -1379,6 +1385,9 @@ func (c *RegionCache) scanRegions(bo *retry.Backoffer, startKey, endKey []byte, 
 		}
 		regionsInfo, err := c.pdClient.ScanRegions(ctx, startKey, endKey, limit)
 		if err != nil {
+			if isDecodeError(err) {
+				return nil, errors.Errorf("failed to decode region range key, startKey: %q, limit: %q, err: %v", startKey, limit, err)
+			}
 			metrics.RegionCacheCounterWithScanRegionsError.Inc()
 			backoffErr = errors.Errorf(
 				"scanRegion from PD failed, startKey: %q, limit: %q, err: %v",


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

To prevent the client from reporting errors slowly in such cases https://github.com/tikv/tikv/issues/10542, I ban the backoff in the region cache.