### PR TITLE
internal/client: fix recycle idle connection block sending request

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -365,9 +365,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	start := time.Now()
 	if atomic.CompareAndSwapUint32(&c.idleNotify, 1, 0) {
-		c.recycleMu.Lock()
-		c.recycleIdleConnArray()
-		c.recycleMu.Unlock()
+		go c.recycleIdleConnArray()
 	}
 
 	// TiDB will not send batch commands to TiFlash, to resolve the conflict with Batch Cop Request.

--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -8,6 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -27,6 +28,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 

--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -8,7 +8,6 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -28,7 +27,6 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -795,6 +793,9 @@ func sendBatchRequest(
 }
 
 func (c *RPCClient) recycleIdleConnArray() {
+	c.recycleMu.Lock()
+	defer c.recycleMu.Unlock()
+
 	var addrs []string
 	c.RLock()
 	for _, conn := range c.conns {


### PR DESCRIPTION
Move the `recycleIdleConnArray()` operation to a separate goroutine.

In our internal OnCall issue 3520 and 3381, I observed sending request blocked here when recycling idle connection.

recycle idle connection need to obtain the `recycleMu` write lock
when some connections are sending batch request, the `recycleMu` read lock is hold.
If the send batch request blocks for some reason (like TiFlash down), recycle idle connection will also be blocked by that, and then it blocks `SendRequest()` function.

I also consider some other options, like remove the recycle idle connection logic ... we introduce it because when some TiKV server are gone, there will be resource leak here. 

Anyway, this change is small and should fix the problem, the risk of side effect is low.

Signed-off-by: tiancaiamao <tiancaiamao@gmail.com>