### PR TITLE
txnkv: `RangedKVRetriever` struct to provide custom range data operations

### DIFF
--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -61,12 +61,17 @@ type Getter interface {
 // Retriever is the interface to get or scan key/values
 type Retriever interface {
 	Getter
-	// Scan creates an Iterator positioned on the first entry that startKey <= entry's key.
+	// Iter creates an Iterator positioned on the first entry that k <= entry's key.
 	// If such entry is not found, it returns an invalid Iterator with no error.
-	// It yields only keys that < endKey. If upperBound is nil, it means the upperBound is unbounded.
-	// If reverse is specified, the returned iterator will iterate from greater key to smaller key
+	// It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
 	// The Iterator must be Closed after use.
-	Scan(startKey []byte, endKey []byte, reverse bool) (Iterator, error)
+	Iter(k []byte, upperBound []byte) (Iterator, error)
+
+	// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
+	// The returned iterator will iterate from greater key to smaller key.
+	// It yields only keys that >= lowerBound. If lowerBound is nil, it means the lowerBound is unbounded.
+	// The Iterator must be Closed after use.
+	IterReverse(k []byte, lowerBound []byte) (Iterator, error)
 }
 
 // uSnapshot defines the interface for the snapshot fetched from KV store.
@@ -111,8 +116,11 @@ type EmptyRetriever struct{}
 // Get gets the value for key k from kv store. Always return nil for this retriever
 func (r *EmptyRetriever) Get(_ []byte) ([]byte, error) { return nil, tikverr.ErrNotExist }
 
-// Scan creates an Iterator positioned on the first entry that startKey <= entry's key. Always return EmptyIterator for this retriever
-func (r *EmptyRetriever) Scan(_ []byte, _ []byte, _ bool) (Iterator, error) {
+// Iter creates an Iterator. Always return EmptyIterator for this retriever
+func (r *EmptyRetriever) Iter(_ []byte, _ []byte) (Iterator, error) { return &EmptyIterator{}, nil }
+
+// IterReverse creates a reversed Iterator. Always return EmptyIterator for this retriever
+func (r *EmptyRetriever) IterReverse(_ []byte, _ []byte) (Iterator, error) {
 	return &EmptyIterator{}, nil
 }
 

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -108,7 +108,10 @@ func (i *EmptyIterator) Close() {}
 // EmptyRetriever is a retriever without any entry
 type EmptyRetriever struct{}
 
+// Get gets the value for key k from kv store. Always return nil for this retriever
 func (r *EmptyRetriever) Get(_ []byte) ([]byte, error) { return nil, tikverr.ErrNotExist }
+
+// Scan creates an Iterator positioned on the first entry that startKey <= entry's key. Always return EmptyIterator for this retriever
 func (r *EmptyRetriever) Scan(_ []byte, _ []byte, _ bool) (Iterator, error) {
 	return &EmptyIterator{}, nil
 }

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -90,11 +90,20 @@ type uSnapshot interface {
 // EmptyIterator is an iterator without any entry
 type EmptyIterator struct{}
 
-func (i *EmptyIterator) Valid() bool   { return false }
-func (i *EmptyIterator) Key() []byte   { return nil }
+// Valid returns true if the current iterator is valid.
+func (i *EmptyIterator) Valid() bool { return false }
+
+// Key returns the current key. Always return nil for this iterator
+func (i *EmptyIterator) Key() []byte { return nil }
+
+// Value returns the current value. Always return nil for this iterator
 func (i *EmptyIterator) Value() []byte { return nil }
-func (i *EmptyIterator) Next() error   { return errors.New("scanner iterator is invalid") }
-func (i *EmptyIterator) Close()        {}
+
+// Next goes the next position. Always return error for this iterator
+func (i *EmptyIterator) Next() error { return errors.New("scanner iterator is invalid") }
+
+// Close closes the iterator.
+func (i *EmptyIterator) Close() {}
 
 // EmptyRetriever is a retriever without any entry
 type EmptyRetriever struct{}

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -1,0 +1,218 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnsnapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tikv/client-go/v2/internal/unionstore"
+)
+
+func newRetriever(startKey, endKey []byte) *RangedKVRetriever {
+	return NewRangeRetriever(&unionstore.EmptyRetriever{}, startKey, endKey)
+}
+
+func makeBytes(s interface{}) []byte {
+	if s == nil {
+		return nil
+	}
+
+	switch key := s.(type) {
+	case string:
+		return []byte(key)
+	default:
+		return key.([]byte)
+	}
+}
+
+func TestRangedKVRetrieverContains(t *testing.T) {
+	assert := assert.New(t)
+	cases := []struct {
+		startKey    interface{}
+		endKey      interface{}
+		contains    []interface{}
+		notContains []interface{}
+	}{
+		{
+			startKey:    "abcdef",
+			endKey:      nil,
+			contains:    []interface{}{[]byte{0xFF}, "abcdef", "abcdefg", "abcdeg", "bbcdeg"},
+			notContains: []interface{}{"abcdee", "abcde", "a", "0bcdefg", []byte{0x0}},
+		},
+		{
+			startKey:    nil,
+			endKey:      "abcdef",
+			contains:    []interface{}{"abcdee", "abcde", "a", "0bcdefg", []byte{0x0}},
+			notContains: []interface{}{[]byte{0xFF}, "abcdef", "abcdefg", "abcdeg", "bbcdeg"},
+		},
+		{
+			startKey:    "abcdef",
+			endKey:      "abcdeg",
+			contains:    []interface{}{"abcdef", "abcdefg"},
+			notContains: []interface{}{"abcdeg", "abcdega", "abcdee", "abcdeea", "a", []byte{0xFF}, []byte{0x0}},
+		},
+		{
+			startKey:    "abcdef",
+			endKey:      "abcdeh",
+			contains:    []interface{}{"abcdef", "abcdeg", "abcdefg"},
+			notContains: []interface{}{"abcdeh"},
+		},
+		{
+			startKey: nil,
+			endKey:   nil,
+			contains: []interface{}{[]byte{0xFF}, "abcdef", "abcdefg", "abcdeg", "bbcdeg", "abcdee", "abcde", "a", "0bcdefg", []byte{0x0}},
+		},
+		{
+			startKey:    "abcdef",
+			endKey:      "abcdef",
+			notContains: []interface{}{[]byte{0xFF}, "abcdef", "abcdefg", "abcdeg", "bbcdeg", "abcdee", "abcde", "a", "0bcdefg", []byte{0x0}},
+		},
+	}
+
+	for _, c := range cases {
+		startKey := makeBytes(c.startKey)
+		endKey := makeBytes(c.endKey)
+		retriever := newRetriever(startKey, endKey)
+		if len(startKey) == 0 {
+			assert.Nil(retriever.StartKey)
+		} else {
+			assert.Equal(startKey, retriever.StartKey)
+		}
+
+		if len(endKey) == 0 {
+			assert.Nil(retriever.EndKey)
+		} else {
+			assert.Equal(endKey, retriever.EndKey)
+		}
+
+		for _, k := range c.contains {
+			assert.True(retriever.Contains(makeBytes(k)))
+		}
+
+		for _, k := range c.notContains {
+			assert.False(retriever.Contains(makeBytes(k)))
+		}
+	}
+}
+
+func TestRangedKVRetrieverIntersect(t *testing.T) {
+	assert := assert.New(t)
+	retrievers := []struct {
+		startKey interface{}
+		endKey   interface{}
+		// {{inputStart, inputEnd}, {expectedOutputStart, expectedOutputEnd}}
+		cases [][][]interface{}
+	}{
+		{
+			startKey: nil,
+			endKey:   nil,
+			cases: [][][]interface{}{
+				{{nil, nil}, {nil, nil}},
+				{{"abcde", "abcdg"}, {"abcde", "abcdg"}},
+				{{nil, "abcdg"}, {nil, "abcdg"}},
+				{{"abcde", nil}, {"abcde", nil}},
+			},
+		},
+		{
+			startKey: nil,
+			endKey:   "abcde",
+			cases: [][][]interface{}{
+				{{nil, nil}, {nil, "abcde"}},
+				{{nil, "abcde"}, {nil, "abcde"}},
+				{{nil, "abcdef"}, {nil, "abcde"}},
+				{{nil, "abcdd"}, {nil, "abcdd"}},
+				{{"abcde", nil}, nil},
+				{{"abcdd", nil}, {"abcdd", "abcde"}},
+				{{"abcdef", nil}, nil},
+				{{"abcde", "abcdf"}, nil},
+				{{"abcdd", "abcde"}, {"abcdd", "abcde"}},
+				{{"abcdd", "abcdf"}, {"abcdd", "abcde"}},
+				{{"abcdc", "abcdd"}, {"abcdc", "abcdd"}},
+				{{"abcdef", "abcdf"}, nil},
+			},
+		},
+		{
+			startKey: "abcde",
+			endKey:   nil,
+			cases: [][][]interface{}{
+				{{nil, nil}, {"abcde", nil}},
+				{{nil, "abcde"}, nil},
+				{{nil, "abcdef"}, {"abcde", "abcdef"}},
+				{{nil, "abcdd"}, nil},
+				{{"abcde", nil}, {"abcde", nil}},
+				{{"abcdd", nil}, {"abcde", nil}},
+				{{"abcdef", nil}, {"abcdef", nil}},
+				{{"abcde", "abcdf"}, {"abcde", "abcdf"}},
+				{{"abcdd", "abcde"}, nil},
+				{{"abcdd", "abcdf"}, {"abcde", "abcdf"}},
+				{{"abcdc", "abcdd"}, nil},
+				{{"abcdef", "abcdf"}, {"abcdef", "abcdf"}},
+			},
+		},
+		{
+			startKey: "abcde",
+			endKey:   "abcdg",
+			cases: [][][]interface{}{
+				{{nil, nil}, {"abcde", "abcdg"}},
+				{{nil, "abcde"}, nil},
+				{{nil, "abcdef"}, {"abcde", "abcdef"}},
+				{{nil, "abcdd"}, nil},
+				{{nil, "abcdg"}, {"abcde", "abcdg"}},
+				{{nil, "abcdga"}, {"abcde", "abcdg"}},
+				{{"abcde", nil}, {"abcde", "abcdg"}},
+				{{"abcdd", nil}, {"abcde", "abcdg"}},
+				{{"abcdef", nil}, {"abcdef", "abcdg"}},
+				{{"abcdg", nil}, nil},
+				{{"abcdga", nil}, nil},
+				{{"abcde", "abcdf"}, {"abcde", "abcdf"}},
+				{{"abcdd", "abcde"}, nil},
+				{{"abcdd", "abcdf"}, {"abcde", "abcdf"}},
+				{{"abcdc", "abcdd"}, nil},
+				{{"abcdef", "abcdf"}, {"abcdef", "abcdf"}},
+				{{"abcde", "abcdg"}, {"abcde", "abcdg"}},
+				{{"abcde", "abcdh"}, {"abcde", "abcdg"}},
+				{{"abcdef", "abcdg"}, {"abcdef", "abcdg"}},
+				{{"abcdef", "abcdh"}, {"abcdef", "abcdg"}},
+				{{"abcdg", "abcdh"}, nil},
+			},
+		},
+	}
+
+	for _, r := range retrievers {
+		retriever := newRetriever(makeBytes(r.startKey), makeBytes(r.endKey))
+		for _, c := range r.cases {
+			result := retriever.Intersect(makeBytes(c[0][0]), makeBytes(c[0][1]))
+			if len(c[1]) == 0 {
+				assert.Nil(result)
+				continue
+			}
+
+			assert.Equal(retriever.Retriever, result.Retriever)
+			expectedStart := makeBytes(c[1][0])
+			expectedEnd := makeBytes(c[1][1])
+			if len(expectedStart) == 0 {
+				assert.Nil(result.StartKey)
+			} else {
+				assert.Equal(expectedStart, result.StartKey)
+			}
+
+			if len(expectedEnd) == 0 {
+				assert.Nil(result.EndKey)
+			} else {
+				assert.Equal(expectedEnd, result.EndKey)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Refer: https://github.com/pingcap/tidb/issues/26952

To make a better implement for temporary table. It is required that snapshot can read data from other sources like memory for some specified ranges. So we expect `KVSnapshot` can provide some methods to override data fetch.

The draft has been proposed here: #262 . This pr is the first step, introduce a struct to provide custom range data operations. 

Signed-off-by: Chao Wang <cclcwangchao@hotmail.com>