### PR TITLE
metrics,internal/client: add metrics for batch client stream receiving duration

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -66,6 +66,7 @@ var (
 	TiKVBatchClientUnavailable               prometheus.Histogram
 	TiKVBatchClientWaitEstablish             prometheus.Histogram
 	TiKVBatchClientRecycle                   prometheus.Histogram
+	TiKVBatchRecvLatency                     *prometheus.HistogramVec
 	TiKVRangeTaskStats                       *prometheus.GaugeVec
 	TiKVRangeTaskPushDuration                *prometheus.HistogramVec
 	TiKVTokenWaitDuration                    prometheus.Histogram
@@ -274,6 +275,15 @@ func initMetrics(namespace, subsystem string) {
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
 			Help:      "batch send latency",
 		})
+
+	TiKVBatchRecvLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "batch_recv_latency",
+			Buckets:   prometheus.ExponentialBuckets(1000, 2, 34), // 1us ~ 8000s
+			Help:      "batch recv latency",
+		}, []string{LblResult})
 
 	TiKVBatchWaitOverLoad = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -554,6 +564,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVStatusCounter)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
 	prometheus.MustRegister(TiKVBatchSendLatency)
+	prometheus.MustRegister(TiKVBatchRecvLatency)
 	prometheus.MustRegister(TiKVBatchWaitOverLoad)
 	prometheus.MustRegister(TiKVBatchPendingRequests)
 	prometheus.MustRegister(TiKVBatchRequests)

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -119,6 +119,9 @@ var (
 	OnePCTxnCounterOk       prometheus.Counter
 	OnePCTxnCounterError    prometheus.Counter
 	OnePCTxnCounterFallback prometheus.Counter
+
+	BatchRecvHistogramOK    prometheus.Observer
+	BatchRecvHistogramError prometheus.Observer
 )
 
 func initShortcuts() {
@@ -203,4 +206,7 @@ func initShortcuts() {
 	OnePCTxnCounterOk = TiKVOnePCTxnCounter.WithLabelValues("ok")
 	OnePCTxnCounterError = TiKVOnePCTxnCounter.WithLabelValues("err")
 	OnePCTxnCounterFallback = TiKVOnePCTxnCounter.WithLabelValues("fallback")
+
+	BatchRecvHistogramOK = TiKVBatchRecvLatency.WithLabelValues("ok")
+	BatchRecvHistogramError = TiKVBatchRecvLatency.WithLabelValues("err")
 }


### PR DESCRIPTION
Add metrics for batch client recv duration.

![image](https://user-images.githubusercontent.com/1420062/130223986-57aab08f-6ddc-41da-8df8-daf58083cbb9.png)

(In those picture, there is no workload, so the duration goes to seconds ... in the real scenario it is us ~ ms)

![image](https://user-images.githubusercontent.com/1420062/130224311-f004b864-8beb-4765-99b8-a16e6bf6c22b.png)


This metrics is useful for us to locate some problem.
If TiKV server is too busy, and when it's channel is full, it might drop some message.
If the raft leader change meet some problems, it may also takes a long time ...
In those cases, there will be no response for a long time (or never?)

From this metrics we can check those case ... for example, if the duration goes to several minutes, something might be wrong.

Signed-off-by: tiancaiamao <tiancaiamao@gmail.com>