### PR TITLE
ci: remove br compatibility test

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -33,21 +33,6 @@ jobs:
         go mod tidy
         make server
       working-directory: tidb
-
-    - name: Checkout BR
-      uses: actions/checkout@v2
-      with:
-        repository: pingcap/br
-        path: br
-
-    - name: Check build
-      run: |
-        cp go.mod1 go.mod && cp go.sum1 go.sum
-        go mod edit -replace=github.com/tikv/client-go/v2=../client-go
-        go mod edit -replace=github.com/pingcap/tidb=../tidb
-        go mod tidy
-        go build ./...
-      working-directory: br
     
     - name: Checkout TiCDC
       uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

As `br` is merged with tidb, there is no need to test its compatibility.