### PR TITLE
*:rechange to retry when tikv disk full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .idea
+.vscode

--- a/error/error.go
+++ b/error/error.go
@@ -84,6 +84,8 @@ var (
 	ErrRegionDataNotReady = errors.New("region data not ready")
 	// ErrRegionNotInitialized is error when region is not initialized
 	ErrRegionNotInitialized = errors.New("region not Initialized")
+	// ErrTiKVDiskFull is the error when tikv server disk usage is full.
+	ErrTiKVDiskFull = errors.New("tikv disk full")
 	// ErrUnknown is the unknow error.
 	ErrUnknown = errors.New("unknow")
 )

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1350,12 +1350,13 @@ func (s *RegionRequestSender) onRegionError(bo *retry.Backoffer, ctx *RPCContext
 		}
 	}
 
-	// Not Retry when tikv disk full happens.
+	// Retry it when tikv disk full happens.
 	if diskFull := regionErr.GetDiskFull(); diskFull != nil {
-		logutil.BgLogger().Error("tikv reports `DiskFull` not retry",
-			zap.String("diskFull", diskFull.String()),
-			zap.String("ctx", ctx.String()))
-		return false, nil
+		if err = bo.Backoff(retry.BoTiKVDiskFull, errors.Errorf("tikv disk full: %v ctx: %v", diskFull.String(), ctx.String())); err != nil {
+			retry.BoTiKVDiskFull.SetErrors(errors.Errorf("tikv disk full: %v", diskFull.String()))
+			return false, nil
+		}
+		return true, nil
 	}
 
 	// This peer is removed from the region. Invalidate the region since it's too stale.

--- a/internal/retry/config.go
+++ b/internal/retry/config.go
@@ -99,6 +99,11 @@ func (c *Config) String() string {
 	return c.name
 }
 
+// SetErrors sets a more detailed error instead of the default bo config.
+func (c *Config) SetErrors(err error) {
+	c.err = err
+}
+
 const txnLockFastName = "txnLockFast"
 
 // Backoff Config variables.
@@ -112,6 +117,7 @@ var (
 	BoRegionMiss              = NewConfig("regionMiss", &metrics.BackoffHistogramRegionMiss, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrRegionUnavailable)
 	BoRegionScheduling        = NewConfig("regionScheduling", &metrics.BackoffHistogramRegionScheduling, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrRegionUnavailable)
 	BoTiKVServerBusy          = NewConfig("tikvServerBusy", &metrics.BackoffHistogramServerBusy, NewBackoffFnCfg(2000, 10000, EqualJitter), tikverr.ErrTiKVServerBusy)
+	BoTiKVDiskFull            = NewConfig("tikvDiskFull", &metrics.BackoffHistogramTiKVDiskFull, NewBackoffFnCfg(500, 5000, NoJitter), tikverr.ErrTiKVDiskFull)
 	BoTiFlashServerBusy       = NewConfig("tiflashServerBusy", &metrics.BackoffHistogramServerBusy, NewBackoffFnCfg(2000, 10000, EqualJitter), tikverr.ErrTiFlashServerBusy)
 	BoTxnNotFound             = NewConfig("txnNotFound", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrResolveLockTimeout)
 	BoStaleCmd                = NewConfig("staleCommand", &metrics.BackoffHistogramStaleCmd, NewBackoffFnCfg(2, 1000, NoJitter), tikverr.ErrTiKVStaleCommand)

--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -41,7 +41,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/kv"
 )
@@ -164,11 +163,6 @@ func (db *MemDB) Reset() {
 	db.count = 0
 	db.vlog.reset()
 	db.allocator.reset()
-}
-
-// SetDiskFullOpt is used by TiDB test case.
-func (db *MemDB) SetDiskFullOpt(level kvrpcpb.DiskFullOpt) {
-	// Nothing to do.
 }
 
 // DiscardValues releases the memory used by all values.

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -61,6 +61,7 @@ var (
 	BackoffHistogramRegionMiss       prometheus.Observer
 	BackoffHistogramRegionScheduling prometheus.Observer
 	BackoffHistogramServerBusy       prometheus.Observer
+	BackoffHistogramTiKVDiskFull     prometheus.Observer
 	BackoffHistogramStaleCmd         prometheus.Observer
 	BackoffHistogramDataNotReady     prometheus.Observer
 	BackoffHistogramEmpty            prometheus.Observer
@@ -148,6 +149,7 @@ func initShortcuts() {
 	BackoffHistogramRegionMiss = TiKVBackoffHistogram.WithLabelValues("regionMiss")
 	BackoffHistogramRegionScheduling = TiKVBackoffHistogram.WithLabelValues("regionScheduling")
 	BackoffHistogramServerBusy = TiKVBackoffHistogram.WithLabelValues("serverBusy")
+	BackoffHistogramTiKVDiskFull = TiKVBackoffHistogram.WithLabelValues("tikvDiskFull")
 	BackoffHistogramStaleCmd = TiKVBackoffHistogram.WithLabelValues("staleCommand")
 	BackoffHistogramDataNotReady = TiKVBackoffHistogram.WithLabelValues("dataNotReady")
 	BackoffHistogramEmpty = TiKVBackoffHistogram.WithLabelValues("")


### PR DESCRIPTION
Signed-off-by: tier-cap <zhengxiaojin@pingcap.com>
### What problem does this PR solve?
1. When TiKV is disk full, the original design is just return the disk full error to user without any retry.
2. Currently, need change to retry before return to user.

### What is changed and how it works?
1. Use backoff to retry it when TiKV is disk full.