### PR TITLE
tikvrpc: rename txnScope as readReplicaScope instead

### DIFF
--- a/locate/region_cache_test.go
+++ b/locate/region_cache_test.go
@@ -1108,7 +1108,7 @@ func (s *testRegionCacheSuite) TestRegionDataNotReady(c *C) {
 		var opts []StoreSelectorOption
 		seed := uint32(0)
 		s.bo.Reset()
-		req := &tikvrpc.Request{TxnScope: testcase.scope, Context: kvrpcpb.Context{StaleRead: true}, ReplicaReadSeed: &seed}
+		req := &tikvrpc.Request{ReadReplicaScope: testcase.scope, Context: kvrpcpb.Context{StaleRead: true}, ReplicaReadSeed: &seed}
 		retry, err := reqSend.onRegionError(s.bo, fctx, req, regionErr, &opts)
 		c.Assert(err, IsNil)
 		c.Assert(retry, IsTrue)

--- a/locate/region_request.go
+++ b/locate/region_request.go
@@ -895,9 +895,9 @@ func (s *RegionRequestSender) onRegionError(bo *retry.Backoffer, ctx *RPCContext
 		bo.SetCtx(opentracing.ContextWithSpan(bo.GetCtx(), span1))
 	}
 	// Stale Read request will retry the leader or next peer on error,
-	// if txnScope is global, we will only retry the leader by using the WithLeaderOnly option,
-	// if txnScope is local, we will retry both other peers and the leader by the incresing seed.
-	if ctx.tryTimes < 1 && req != nil && req.TxnScope == oracle.GlobalTxnScope && req.GetStaleRead() {
+	// if ReadReplicaScope is global, we will only retry the leader by using the WithLeaderOnly option,
+	// if ReadReplicaScope isn't global, we will retry both other peers and the leader by the increasing seed.
+	if ctx.tryTimes < 1 && req != nil && req.ReadReplicaScope == oracle.GlobalTxnScope && req.GetStaleRead() {
 		*opts = append(*opts, WithLeaderOnly())
 	}
 	seed := req.GetReplicaReadSeed()

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -199,10 +199,10 @@ type Request struct {
 	Type CmdType
 	Req  interface{}
 	kvrpcpb.Context
-	TxnScope        string
-	ReplicaReadType kv.ReplicaReadType // different from `kvrpcpb.Context.ReplicaRead`
-	ReplicaReadSeed *uint32            // pointer to follower read seed in snapshot/coprocessor
-	StoreTp         EndpointType
+	ReadReplicaScope string
+	ReplicaReadType  kv.ReplicaReadType // different from `kvrpcpb.Context.ReplicaRead`
+	ReplicaReadSeed  *uint32            // pointer to follower read seed in snapshot/coprocessor
+	StoreTp          EndpointType
 	// ForwardedHost is the address of a store which will handle the request. It's different from
 	// the address the request sent to.
 	// If it's not empty, the store which receive the request will forward it to


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

txnScope indicates the tso scope and the request replica scope while we only use replica scope here, thus I think rename to `readReplicaScope` is more proper.