### PR TITLE
rename txnScope as readReplicaScope

### DIFF
--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -792,6 +792,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestSendReqWithReplicaSelector() {
 	reloadRegion()
 	req = tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")})
 	req.ReadReplicaScope = oracle.GlobalTxnScope
+	req.TxnScope = oracle.GlobalTxnScope
 	req.EnableStaleRead()
 	for i := 0; i < 5; i++ {
 		// The request may be sent to the leader directly. We have to distinguish it.

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -791,7 +791,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestSendReqWithReplicaSelector() {
 	s.cluster.ChangeLeader(region.Region.id, s.peerIDs[0])
 	reloadRegion()
 	req = tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")})
-	req.TxnScope = oracle.GlobalTxnScope
+	req.ReadReplicaScope = oracle.GlobalTxnScope
 	req.EnableStaleRead()
 	for i := 0; i < 5; i++ {
 		// The request may be sent to the leader directly. We have to distinguish it.

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -207,6 +207,8 @@ type Request struct {
 	Type CmdType
 	Req  interface{}
 	kvrpcpb.Context
+	ReadReplicaScope string
+	// remove txnScope after tidb removed txnScope
 	TxnScope        string
 	ReplicaReadType kv.ReplicaReadType // different from `kvrpcpb.Context.ReplicaRead`
 	ReplicaReadSeed *uint32            // pointer to follower read seed in snapshot/coprocessor
@@ -259,7 +261,10 @@ func (req *Request) EnableStaleRead() {
 
 // IsGlobalStaleRead checks if the request is a global stale read request.
 func (req *Request) IsGlobalStaleRead() bool {
-	return req.TxnScope == oracle.GlobalTxnScope && req.GetStaleRead()
+	return req.ReadReplicaScope == oracle.GlobalTxnScope &&
+		// remove txnScope after tidb remove it
+		req.TxnScope == oracle.GlobalTxnScope &&
+		req.GetStaleRead()
 }
 
 // IsDebugReq check whether the req is debug req.


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

txnScope indicates tso scope and request scope, as the txnSope in request only indicates request scope. I think it's more proper to rename it as request scope in order to avoid confused meaning.