### PR TITLE
Split and scatter regions by pd

### DIFF
--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -170,7 +170,7 @@ func (s *KVStore) scanLocksInRegionWithStartKey(bo *retry.Backoffer, startKey []
 // batchResolveLocksInARegion resolves locks in a region.
 // It returns the real location of the resolved locks if resolve locks success.
 // It returns error when meet an unretryable error.
-// When the locks are not in one region, resolve locks should be failed, it returns with nil resolveLocation and nil err.
+// When the locks are not in one region, resolve locks should be failed, it returns with nil resolveLocation and nil Error.
 // Used it in gcworker only!
 func (s *KVStore) batchResolveLocksInARegion(bo *Backoffer, locks []*txnlock.Lock, expectedLoc *locate.KeyLocation) (resolvedLocation *locate.KeyLocation, err error) {
 	resolvedLocation = expectedLoc

--- a/tikv/split_region.go
+++ b/tikv/split_region.go
@@ -49,6 +49,7 @@ import (
 	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/txnkv/rangetask"
 	"github.com/tikv/client-go/v2/util"
+	"github.com/tikv/client-go/v2/util/codec"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 )
@@ -146,6 +147,11 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch kvrpc.Batch, scatte
 	opts := make([]pd.RegionsOption, 0, 1)
 	if tableID != nil {
 		opts = append(opts, pd.WithGroup(fmt.Sprintf("%v", *tableID)))
+	}
+
+	keys := batch.Keys
+	for i, key := range keys {
+		keys[i] = codec.EncodeBytes([]byte(nil), key)
 	}
 
 	// Split regions by pd

--- a/tikv/split_region.go
+++ b/tikv/split_region.go
@@ -115,7 +115,7 @@ func (s *KVStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter boo
 		}(batch1)
 	}
 
-	regionsID := make([]uint64, len(keys)*2)
+	regionsID := make([]uint64, 0, len(keys)*2)
 	for i := 0; i < len(batches); i++ {
 		resp := <-ch
 		if resp.Error != nil {
@@ -185,7 +185,7 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch kvrpc.Batch, scatte
 		if err = s.scatterRegion(bo, regionID, tableID); err == nil {
 			logutil.BgLogger().Info("batch split regions, scatter region complete",
 				zap.Uint64("batch region ID", batch.RegionID.GetID()),
-				zap.String("at", kv.StrKey(batch.Keys[i])),
+				zap.String("at", "arr"),
 				zap.Uint64("new region Id", regionID))
 			continue
 		}


### PR DESCRIPTION
Previously, the steps of TiDB to split regions :

- First, send split instruction to TIKV 
- Secondly, send scatter instruction to pd
- Last , wait scatter done

At present, we hope that these  steps can be all handed by PD

In this PR , I modify the logic in tiKV /split_region.go,  directly use the two Apis provided by PD (split-regions, scatter-regions).
