### PR TITLE
Fix flaky TestSecondaryListInPrimaryLock

### DIFF
--- a/integration_tests/async_commit_fail_test.go
+++ b/integration_tests/async_commit_fail_test.go
@@ -39,6 +39,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -179,16 +180,20 @@ func (s *testAsyncCommitFailSuite) TestSecondaryListInPrimaryLock() {
 	}
 
 	// Ensure the region has been split
-	bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
-	loc, err := s.store.GetRegionCache().LocateKey(bo, []byte("i"))
-	s.Nil(err)
-	s.Equal(loc.StartKey, []byte("h"))
-	s.Equal(loc.EndKey, []byte("o"))
-
-	loc, err = s.store.GetRegionCache().LocateKey(bo, []byte("p"))
-	s.Nil(err)
-	s.Equal(loc.StartKey, []byte("o"))
-	s.Equal(loc.EndKey, []byte("u"))
+	s.Eventually(func() bool {
+		checkRegionBound := func(key, startKey, endKey []byte) bool {
+			bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
+			loc, err := s.store.GetRegionCache().LocateKey(bo, key)
+			s.Nil(err)
+			if bytes.Equal(loc.StartKey, startKey) && bytes.Equal(loc.EndKey, endKey) {
+				return true
+			}
+			s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
+			return false
+		}
+		return checkRegionBound([]byte("i"), []byte("h"), []byte("o")) &&
+			checkRegionBound([]byte("p"), []byte("o"), []byte("u"))
+	}, time.Second, 10*time.Millisecond, "region is not split successfully")
 
 	var sessionID uint64 = 0
 	test := func(keys []string, values []string) {
@@ -202,7 +207,7 @@ func (s *testAsyncCommitFailSuite) TestSecondaryListInPrimaryLock() {
 
 		s.Nil(failpoint.Enable("tikvclient/asyncCommitDoNothing", "return"))
 
-		err = txn.Commit(ctx)
+		err := txn.Commit(ctx)
 		s.Nil(err)
 
 		primary := txn.GetCommitter().GetPrimaryKey()


### PR DESCRIPTION
CI for https://github.com/tikv/client-go/pull/315 [fails](https://github.com/tikv/client-go/pull/315/checks?check_run_id=3728456996) due to `TestSecondaryListInPrimaryLock`. The failure reason is that the region is not split in time.

This checks periodically whether the regions are split successfully to stablize the test.