### PR TITLE
error: replace usages of terror.Log

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/log"
 	"github.com/pingcap/parser/terror"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/util"
@@ -266,4 +267,11 @@ func ExtractKeyErr(keyErr *kvrpcpb.KeyError) error {
 // IsErrorUndetermined checks if the error is undetermined error.
 func IsErrorUndetermined(err error) bool {
 	return terror.ErrorEqual(err, terror.ErrResultUndetermined)
+}
+
+// Log logs the error if it is not nil.
+func Log(err error) {
+	if err != nil {
+		log.Error("encountered error", zap.Error(err), zap.Stack("stack"))
+	}
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -53,9 +53,9 @@ import (
 	"github.com/pingcap/kvproto/pkg/debugpb"
 	"github.com/pingcap/kvproto/pkg/mpp"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
-	"github.com/pingcap/parser/terror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/config"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -237,7 +237,7 @@ func (a *connArray) Close() {
 	for i, c := range a.v {
 		if c != nil {
 			err := c.Close()
-			terror.Log(errors.Trace(err))
+			tikverr.Log(errors.Trace(err))
 			a.v[i] = nil
 		}
 	}

--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -45,9 +45,9 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
-	"github.com/pingcap/parser/terror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/config"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/internal/retry"
 	"github.com/tikv/client-go/v2/metrics"
@@ -702,7 +702,7 @@ func (c *batchCommandsClient) recreateStreamingClient(err error, streamClient *b
 		err2 := b.Backoff(retry.BoTiKVRPC, err1)
 		// As timeout is set to math.MaxUint32, err2 should always be nil.
 		// This line is added to make the 'make errcheck' pass.
-		terror.Log(err2)
+		tikverr.Log(err2)
 	}
 	return false
 }

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -50,8 +50,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/parser/terror"
 	"github.com/tikv/client-go/v2/config"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/client"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/internal/retry"
@@ -435,7 +435,7 @@ func (c *RegionCache) checkAndResolve(needCheckStores []*Store, needCheck func(*
 
 	for _, store := range needCheckStores {
 		_, err := store.reResolve(c)
-		terror.Log(err)
+		tikverr.Log(err)
 	}
 }
 
@@ -671,7 +671,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 		}
 		if store.getResolveState() == needCheck {
 			_, err := store.reResolve(c)
-			terror.Log(err)
+			tikverr.Log(err)
 		}
 		atomic.StoreInt32(&regionStore.workTiFlashIdx, int32(accessIdx))
 		peer := cachedRegion.meta.Peers[storeIdx]

--- a/internal/mockstore/mocktikv/mvcc_leveldb.go
+++ b/internal/mockstore/mocktikv/mvcc_leveldb.go
@@ -47,7 +47,7 @@ import (
 	"github.com/pingcap/goleveldb/leveldb/storage"
 	"github.com/pingcap/goleveldb/leveldb/util"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/parser/terror"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/internal/mockstore/deadlock"
 	"github.com/tikv/client-go/v2/oracle"
@@ -420,7 +420,7 @@ func (mvcc *MVCCLevelDB) ReverseScan(startKey, endKey []byte, limit int, startTS
 	succ := iter.Last()
 	currKey, _, err := mvccDecode(iter.Key())
 	// TODO: return error.
-	terror.Log(errors.Trace(err))
+	tikverr.Log(err)
 	helper := reverseScanHelper{
 		startTS:       startTS,
 		isoLevel:      isoLevel,
@@ -1532,7 +1532,7 @@ func (mvcc *MVCCLevelDB) RawPut(key, value []byte) {
 	if value == nil {
 		value = []byte{}
 	}
-	terror.Log(mvcc.db.Put(key, value, nil))
+	tikverr.Log(mvcc.db.Put(key, value, nil))
 }
 
 // RawBatchPut implements the RawKV interface
@@ -1548,7 +1548,7 @@ func (mvcc *MVCCLevelDB) RawBatchPut(keys, values [][]byte) {
 		}
 		batch.Put(key, value)
 	}
-	terror.Log(mvcc.db.Write(batch, nil))
+	tikverr.Log(mvcc.db.Write(batch, nil))
 }
 
 // RawGet implements the RawKV interface.
@@ -1557,7 +1557,7 @@ func (mvcc *MVCCLevelDB) RawGet(key []byte) []byte {
 	defer mvcc.mu.Unlock()
 
 	ret, err := mvcc.db.Get(key, nil)
-	terror.Log(err)
+	tikverr.Log(err)
 	return ret
 }
 
@@ -1569,7 +1569,7 @@ func (mvcc *MVCCLevelDB) RawBatchGet(keys [][]byte) [][]byte {
 	values := make([][]byte, 0, len(keys))
 	for _, key := range keys {
 		value, err := mvcc.db.Get(key, nil)
-		terror.Log(err)
+		tikverr.Log(err)
 		values = append(values, value)
 	}
 	return values
@@ -1580,7 +1580,7 @@ func (mvcc *MVCCLevelDB) RawDelete(key []byte) {
 	mvcc.mu.Lock()
 	defer mvcc.mu.Unlock()
 
-	terror.Log(mvcc.db.Delete(key, nil))
+	tikverr.Log(mvcc.db.Delete(key, nil))
 }
 
 // RawBatchDelete implements the RawKV interface.
@@ -1592,7 +1592,7 @@ func (mvcc *MVCCLevelDB) RawBatchDelete(keys [][]byte) {
 	for _, key := range keys {
 		batch.Delete(key)
 	}
-	terror.Log(mvcc.db.Write(batch, nil))
+	tikverr.Log(mvcc.db.Write(batch, nil))
 }
 
 // RawScan implements the RawKV interface.
@@ -1654,7 +1654,7 @@ func (mvcc *MVCCLevelDB) RawReverseScan(startKey, endKey []byte, limit int) []Pa
 
 // RawDeleteRange implements the RawKV interface.
 func (mvcc *MVCCLevelDB) RawDeleteRange(startKey, endKey []byte) {
-	terror.Log(mvcc.doRawDeleteRange(startKey, endKey))
+	tikverr.Log(mvcc.doRawDeleteRange(startKey, endKey))
 }
 
 // doRawDeleteRange deletes all keys in a range and return the error if any.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Copy `terror.Log` utility function to package `error` so we can remove dependency on `terror` later.