### PR TITLE
error: remove use of terror.ErrResultUndetermined

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -42,7 +42,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/log"
-	"github.com/pingcap/parser/terror"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
@@ -89,6 +88,8 @@ var (
 	ErrTiKVDiskFull = errors.New("tikv disk full")
 	// ErrUnknown is the unknow error.
 	ErrUnknown = errors.New("unknow")
+	// ErrResultUndetermined is the error when execution result is unknown.
+	ErrResultUndetermined = errors.New("execution result undetermined")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -266,7 +267,7 @@ func ExtractKeyErr(keyErr *kvrpcpb.KeyError) error {
 
 // IsErrorUndetermined checks if the error is undetermined error.
 func IsErrorUndetermined(err error) bool {
-	return terror.ErrorEqual(err, terror.ErrResultUndetermined)
+	return errors.Cause(err) == ErrResultUndetermined
 }
 
 // Log logs the error if it is not nil.

--- a/integration_tests/client_fp_test.go
+++ b/integration_tests/client_fp_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/parser/terror"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util"
@@ -90,7 +90,7 @@ func (c fpClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Req
 	case tikvrpc.CmdPrewrite:
 		if val, err := util.EvalFailpoint("rpcPrewriteTimeout"); err == nil {
 			if val.(bool) {
-				return nil, terror.ErrResultUndetermined
+				return nil, tikverr.ErrResultUndetermined
 			}
 		}
 	}

--- a/internal/mockstore/mocktikv/rpc.go
+++ b/internal/mockstore/mocktikv/rpc.go
@@ -48,13 +48,10 @@ import (
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/parser/terror"
+	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util"
 )
-
-// For gofail injection.
-var undeterminedErr = terror.ErrResultUndetermined
 
 const requestMaxSize = 8 * 1024 * 1024
 
@@ -759,7 +756,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		resp.Resp = kvHandler{session}.handleKvCommit(r)
 		if val, err := util.EvalFailpoint("rpcCommitTimeout"); err == nil {
 			if val.(bool) {
-				return nil, undeterminedErr
+				return nil, tikverr.ErrResultUndetermined
 			}
 		}
 	case tikvrpc.CmdCleanup:

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -48,7 +48,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/parser/terror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/config"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -1230,7 +1229,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 				zap.Error(err),
 				zap.NamedError("rpcErr", undeterminedErr),
 				zap.Uint64("txnStartTS", c.startTS))
-			return errors.Trace(terror.ErrResultUndetermined)
+			return errors.Trace(tikverr.ErrResultUndetermined)
 		}
 	}
 
@@ -1414,7 +1413,7 @@ func (c *twoPhaseCommitter) commitTxn(ctx context.Context, commitDetail *util.Co
 				zap.Error(err),
 				zap.NamedError("rpcErr", undeterminedErr),
 				zap.Uint64("txnStartTS", c.startTS))
-			err = errors.Trace(terror.ErrResultUndetermined)
+			err = errors.Trace(tikverr.ErrResultUndetermined)
 		}
 		if !c.mu.committed {
 			logutil.Logger(ctx).Debug("2PC failed on commit",


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

Aims to remove parser dependency.
We will need to update tidb store/driver to convert client-go error to terror.ErrResultUndetermined.