### PR TITLE
Abort if the mismatching lock is from the current transaction when resolving locks (#367)

### DIFF
--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -325,7 +325,16 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *retry.B
 			}
 			logutil.BgLogger().Info("prewrite encounters lock",
 				zap.Uint64("session", c.sessionID),
+				zap.Uint64("txnID", c.startTS),
 				zap.Stringer("lock", lock))
+			// If an optimistic transaction encounters a lock with larger TS, this transaction will certainly
+			// fail due to a WriteConflict error. So we can construct and return an error here early.
+			// Pessimistic transactions don't need such an optimization. If this key needs a pessimistic lock,
+			// TiKV will return a PessimisticLockNotFound error directly if it encounters a different lock. Otherwise,
+			// TiKV returns lock.TTL = 0, and we still need to resolve the lock.
+			if lock.TxnID > c.startTS && !c.isPessimistic {
+				return tikverr.NewErrWriteConfictWithArgs(c.startTS, lock.TxnID, 0, lock.Key)
+			}
 			locks = append(locks, lock)
 		}
 		start := time.Now()


### PR DESCRIPTION
Cherry picks #367 to tidb-5.2 to fix https://github.com/tikv/tikv/issues/11148