### PR TITLE
Bump go version to 1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Test
       run: go test ./...
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Test with race
       run: go test -race ./...
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2

--- a/config/security.go
+++ b/config/security.go
@@ -37,7 +37,7 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -66,7 +66,7 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 		certPool := x509.NewCertPool()
 		// Create a certificate pool from the certificate authority
 		var ca []byte
-		ca, err = ioutil.ReadFile(s.ClusterSSLCA)
+		ca, err = os.ReadFile(s.ClusterSSLCA)
 		if err != nil {
 			err = errors.Errorf("could not read ca certificate: %s", err)
 			return

--- a/config/security_test.go
+++ b/config/security_test.go
@@ -35,7 +35,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,8 +49,8 @@ func TestTLSConfig(t *testing.T) {
 	keyFile := filepath.Join(filepath.Dir(localFile), "key.pem")
 	perm := os.FileMode(0666)
 
-	assert.Nil(t, ioutil.WriteFile(certFile, []byte(cert), perm))
-	assert.Nil(t, ioutil.WriteFile(keyFile, []byte(key), perm))
+	assert.Nil(t, os.WriteFile(certFile, []byte(cert), perm))
+	assert.Nil(t, os.WriteFile(keyFile, []byte(key), perm))
 
 	security := Security{
 		ClusterSSLCA:   certFile,

--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -1,6 +1,6 @@
 module gcworker
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -1,6 +1,6 @@
 module rawkv
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -1,6 +1,6 @@
 module 1pc_txn
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -1,6 +1,6 @@
 module async_commit
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -1,6 +1,6 @@
 module delete_range
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -1,6 +1,6 @@
 module txnkv
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -1,6 +1,6 @@
 module pessimistic_txn
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -1,6 +1,6 @@
 module unsafedestoryrange
 
-go 1.15
+go 1.16
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/client-go/v2
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548


### PR DESCRIPTION
Go 1.15 is EOL and 1.17 has been released for about 3 months (https://endoflife.date/go). It should be reasonable to bump required go version to 1.16. I'd like to revert the previous PR (#217). 