### PR TITLE
txnkv: read through locks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad
+	github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f
 	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
@@ -43,5 +43,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.2.0 // indirect
 )
-
-replace github.com/pingcap/kvproto => github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde

--- a/go.mod
+++ b/go.mod
@@ -43,3 +43,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.2.0 // indirect
 )
+
+replace github.com/pingcap/kvproto => github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
+github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -129,6 +130,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -278,6 +280,11 @@ github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd h1:I8IeI8MNiZVKn
 github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd/go.mod h1:IVF+ijPSMZVtx2oIqxAg7ur6EyixtTYfOHwpfmlhqI4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
+github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
+github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210819164333-bd5706b9d9f2/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f h1:hjInxK1Ie6CYx7Jy2pYnBdEnWI8jIfr423l9Yh6LRy8=
+github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
@@ -400,8 +407,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
-github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde h1:gynz5k6dOojz6pUFI8Kcizxl/JXxInySSS+7oybVGhQ=
-github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -572,10 +577,12 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63 h1:YzfoEYWbODU5Fbt37+h7X16BWQbad7Q4S6gclTKFXM8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/go.sum
+++ b/go.sum
@@ -116,7 +116,6 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -130,7 +129,6 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -280,11 +278,6 @@ github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd h1:I8IeI8MNiZVKn
 github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd/go.mod h1:IVF+ijPSMZVtx2oIqxAg7ur6EyixtTYfOHwpfmlhqI4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210819164333-bd5706b9d9f2/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad h1:suBPTeuY6yVF7xvTGeTQ9+tiGzufnORJpCRwzbdN2sc=
-github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
@@ -407,6 +400,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
+github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde h1:gynz5k6dOojz6pUFI8Kcizxl/JXxInySSS+7oybVGhQ=
+github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -577,12 +572,10 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63 h1:YzfoEYWbODU5Fbt37+h7X16BWQbad7Q4S6gclTKFXM8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -255,7 +255,7 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries() {
 	status := lockutil.NewLockStatus(nil, true, ts)
 
 	resolver := tikv.NewLockResolverProb(s.store.GetLockResolver())
-	err = resolver.ResolveLockAsync(s.bo, lock, status)
+	err = resolver.ResolveAsyncCommitLock(s.bo, lock, status)
 	s.Nil(err)
 	currentTS, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 	s.Nil(err)
@@ -334,7 +334,7 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries() {
 
 	_ = s.beginAsyncCommit()
 
-	err = resolver.ResolveLockAsync(s.bo, lock, status)
+	err = resolver.ResolveAsyncCommitLock(s.bo, lock, status)
 	s.Nil(err)
 	s.Equal(gotCheckA, int64(1))
 	s.Equal(gotCheckB, int64(1))
@@ -371,7 +371,7 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries() {
 	lock.TxnID = ts
 	lock.MinCommitTS = ts + 5
 
-	err = resolver.ResolveLockAsync(s.bo, lock, status)
+	err = resolver.ResolveAsyncCommitLock(s.bo, lock, status)
 	s.Nil(err)
 	s.Equal(gotCheckA, int64(1))
 	s.Equal(gotCheckB, int64(1))

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
-	github.com/pingcap/kvproto v0.0.0-20211109071446-a8b4d34474bc
-	github.com/pingcap/tidb v1.1.0-beta.0.20211118075747-4fad89c46b3b
-	github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b // indirect
+	github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f
+	github.com/pingcap/tidb v1.1.0-beta.0.20211130051352-37e0dac25981
+	github.com/pingcap/tidb/parser v0.0.0-20211130051352-37e0dac25981 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tikv/client-go/v2 v2.0.0
@@ -20,7 +20,3 @@ replace github.com/tikv/client-go/v2 => ../
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
-
-replace github.com/pingcap/kvproto => github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde
-
-replace github.com/pingcap/tidb => github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -5,14 +5,14 @@ go 1.16
 require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
-	github.com/pingcap/kvproto v0.0.0-20211011060348-d957056f1551
-	github.com/pingcap/tidb v1.1.0-beta.0.20211111035905-25d698c79730
-	github.com/pingcap/tidb/parser v0.0.0-20211111035905-25d698c79730 // indirect
+	github.com/pingcap/kvproto v0.0.0-20211109071446-a8b4d34474bc
+	github.com/pingcap/tidb v1.1.0-beta.0.20211118075747-4fad89c46b3b
+	github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20211103022933-5ae005dac331
-	github.com/tikv/pd v1.1.0-beta.0.20211029083450-e65f0c55b6ae
-	go.uber.org/goleak v1.1.11-0.20210813005559-691160354723
+	github.com/tikv/client-go/v2 v2.0.0
+	github.com/tikv/pd v1.1.0-beta.0.20211118054146-02848d2660ee
+	go.uber.org/goleak v1.1.12
 )
 
 replace github.com/tikv/client-go/v2 => ../
@@ -20,3 +20,7 @@ replace github.com/tikv/client-go/v2 => ../
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
+
+replace github.com/pingcap/kvproto => github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde
+
+replace github.com/pingcap/tidb => github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -252,7 +252,6 @@ github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/E
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -277,7 +276,6 @@ github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -562,12 +560,6 @@ github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd/go.mod h1:IVF+ij
 github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059/go.mod h1:fMRU1BA1y+r89AxUoaAar4JjrhUkVDt0o0Np6V8XbDQ=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
-github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210819164333-bd5706b9d9f2/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20211011060348-d957056f1551 h1:aRx2l2TAeYNPPUc+lk5dEFCXfUGxR/C2fbt/YA5nqiQ=
-github.com/pingcap/kvproto v0.0.0-20211011060348-d957056f1551/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
@@ -577,16 +569,27 @@ github.com/pingcap/log v0.0.0-20210906054005-afc726e70354/go.mod h1:DWQW5jICDR7U
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5 h1:7rvAtZe/ZUzOKzgriNPQoBNvleJXBk4z7L3Z47+tS98=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5/go.mod h1:XsOaV712rUk63aOEKYP9PhXTIE3FMNHmC2r1wX5wElY=
+<<<<<<< HEAD
 github.com/pingcap/tidb v1.1.0-beta.0.20211111035905-25d698c79730 h1:dFbUXxGYk0rx3R2dxhK6HZ93cj+tCAq66JjZ1GX5TgU=
 github.com/pingcap/tidb v1.1.0-beta.0.20211111035905-25d698c79730/go.mod h1:Z5NlUEsyr1yVAtTaKNdOO7WgySTZuwnCP6kuCaUiRyc=
+=======
+>>>>>>> txnkv: read through locks
 github.com/pingcap/tidb-dashboard v0.0.0-20211008050453-a25c25809529/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
+github.com/pingcap/tidb-dashboard v0.0.0-20211107164327-80363dfbe884/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
 github.com/pingcap/tidb-tools v5.2.2-0.20211019062242-37a8bef2fa17+incompatible h1:c7+izmker91NkjkZ6FgTlmD4k1A5FLOAq+li6Ki2/GY=
 github.com/pingcap/tidb-tools v5.2.2-0.20211019062242-37a8bef2fa17+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb/parser v0.0.0-20211011031125-9b13dc409c5e/go.mod h1:e1MGCA9Sg3T8jid8PKAEq5eYVuMMCq4n8gJ+Kqp4Plg=
+<<<<<<< HEAD
 github.com/pingcap/tidb/parser v0.0.0-20211111035905-25d698c79730 h1:wNgibpxmYT9nhnB6mwOpY+Jn29Pze49f5GXHz+Wv7ks=
 github.com/pingcap/tidb/parser v0.0.0-20211111035905-25d698c79730/go.mod h1:MAa22tagoj7nv5b1NBcxPkc5CiUNhqj1wuSQnw4f9WE=
 github.com/pingcap/tipb v0.0.0-20211105090418-71142a4d40e3 h1:xnp/Qkk5gELlB8TaY6oro0JNXMBXTafNVxU/vbrNU8I=
 github.com/pingcap/tipb v0.0.0-20211105090418-71142a4d40e3/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
+=======
+github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b h1:X5/5QuvV4m+vtRtjs8DfVEt/l6EXbiTiS6lDQuHKg1o=
+github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b/go.mod h1:MAa22tagoj7nv5b1NBcxPkc5CiUNhqj1wuSQnw4f9WE=
+github.com/pingcap/tipb v0.0.0-20211116093845-e9b045a0bdf8 h1:Vu/6oq8EFNWgyXRHiclNzTKIu+YKHPCSI/Ba5oVrLtM=
+github.com/pingcap/tipb v0.0.0-20211116093845-e9b045a0bdf8/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
+>>>>>>> txnkv: read through locks
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -694,8 +697,9 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/pd v1.1.0-beta.0.20211029083450-e65f0c55b6ae h1:PmnkhiOopgMZYDQ7Htj1kt/zwW4MEOUL+Dem6WLZISY=
 github.com/tikv/pd v1.1.0-beta.0.20211029083450-e65f0c55b6ae/go.mod h1:varH0IE0jJ9E9WN2Ei/N6pajMlPkcXdDEf7f5mmsUVQ=
+github.com/tikv/pd v1.1.0-beta.0.20211118054146-02848d2660ee h1:rAAdvQ8Hh36syHr92g0VmZEpkH+40RGQBpFL2121xMs=
+github.com/tikv/pd v1.1.0-beta.0.20211118054146-02848d2660ee/go.mod h1:lRbwxBAhnTQR5vqbTzeI/Bj62bD2OvYYuFezo2vrmeI=
 github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZc=
@@ -745,6 +749,10 @@ github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
+github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde h1:gynz5k6dOojz6pUFI8Kcizxl/JXxInySSS+7oybVGhQ=
+github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42 h1:gUGNDRXM4yCDp23AXuEom2fbAvELsdf06J1pQct7fuc=
+github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42/go.mod h1:ALJkQU35R9AOIIbPgOgIgchNrnmi23cWwJ71XhLlHzU=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
@@ -782,8 +790,9 @@ go.uber.org/dig v1.8.0/go.mod h1:X34SnWGr8Fyla9zQNO2GSO2D+TIuqB14OS8JhYocIyw=
 go.uber.org/fx v1.10.0/go.mod h1:vLRicqpG/qQEzno4SYU86iCwfT95EZza+Eba0ItuxqY=
 go.uber.org/goleak v0.10.0/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
-go.uber.org/goleak v1.1.11-0.20210813005559-691160354723 h1:sHOAIxRGBp443oHZIPB+HsUGaksVCXVQENPxwTfQdH4=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -1133,7 +1142,6 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -252,6 +252,7 @@ github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/E
 github.com/goccy/go-graphviz v0.0.5/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v0.0.0-20180717141946-636bf0302bc9/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -276,6 +277,7 @@ github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/golang/protobuf v0.0.0-20180814211427-aa810b61a9c7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -560,6 +562,12 @@ github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd/go.mod h1:IVF+ij
 github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059/go.mod h1:fMRU1BA1y+r89AxUoaAar4JjrhUkVDt0o0Np6V8XbDQ=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
+github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
+github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210819164333-bd5706b9d9f2/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20211109071446-a8b4d34474bc/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f h1:hjInxK1Ie6CYx7Jy2pYnBdEnWI8jIfr423l9Yh6LRy8=
+github.com/pingcap/kvproto v0.0.0-20211122024046-03abd340988f/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
@@ -569,27 +577,17 @@ github.com/pingcap/log v0.0.0-20210906054005-afc726e70354/go.mod h1:DWQW5jICDR7U
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5 h1:7rvAtZe/ZUzOKzgriNPQoBNvleJXBk4z7L3Z47+tS98=
 github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5/go.mod h1:XsOaV712rUk63aOEKYP9PhXTIE3FMNHmC2r1wX5wElY=
-<<<<<<< HEAD
-github.com/pingcap/tidb v1.1.0-beta.0.20211111035905-25d698c79730 h1:dFbUXxGYk0rx3R2dxhK6HZ93cj+tCAq66JjZ1GX5TgU=
-github.com/pingcap/tidb v1.1.0-beta.0.20211111035905-25d698c79730/go.mod h1:Z5NlUEsyr1yVAtTaKNdOO7WgySTZuwnCP6kuCaUiRyc=
-=======
->>>>>>> txnkv: read through locks
+github.com/pingcap/tidb v1.1.0-beta.0.20211130051352-37e0dac25981 h1:qDBc/5rWnNMVjnrvNd7rHc+EwPryNUQ15uPEGaQgLX0=
+github.com/pingcap/tidb v1.1.0-beta.0.20211130051352-37e0dac25981/go.mod h1:QV0oFMcfKZzSOK6Z5cKJdeKmYePKKZZo+sqzUvYkPOA=
 github.com/pingcap/tidb-dashboard v0.0.0-20211008050453-a25c25809529/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
 github.com/pingcap/tidb-dashboard v0.0.0-20211107164327-80363dfbe884/go.mod h1:OCXbZTBTIMRcIt0jFsuCakZP+goYRv6IjawKbwLS2TQ=
 github.com/pingcap/tidb-tools v5.2.2-0.20211019062242-37a8bef2fa17+incompatible h1:c7+izmker91NkjkZ6FgTlmD4k1A5FLOAq+li6Ki2/GY=
 github.com/pingcap/tidb-tools v5.2.2-0.20211019062242-37a8bef2fa17+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb/parser v0.0.0-20211011031125-9b13dc409c5e/go.mod h1:e1MGCA9Sg3T8jid8PKAEq5eYVuMMCq4n8gJ+Kqp4Plg=
-<<<<<<< HEAD
-github.com/pingcap/tidb/parser v0.0.0-20211111035905-25d698c79730 h1:wNgibpxmYT9nhnB6mwOpY+Jn29Pze49f5GXHz+Wv7ks=
-github.com/pingcap/tidb/parser v0.0.0-20211111035905-25d698c79730/go.mod h1:MAa22tagoj7nv5b1NBcxPkc5CiUNhqj1wuSQnw4f9WE=
-github.com/pingcap/tipb v0.0.0-20211105090418-71142a4d40e3 h1:xnp/Qkk5gELlB8TaY6oro0JNXMBXTafNVxU/vbrNU8I=
-github.com/pingcap/tipb v0.0.0-20211105090418-71142a4d40e3/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
-=======
-github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b h1:X5/5QuvV4m+vtRtjs8DfVEt/l6EXbiTiS6lDQuHKg1o=
-github.com/pingcap/tidb/parser v0.0.0-20211118075747-4fad89c46b3b/go.mod h1:MAa22tagoj7nv5b1NBcxPkc5CiUNhqj1wuSQnw4f9WE=
+github.com/pingcap/tidb/parser v0.0.0-20211130051352-37e0dac25981 h1:cuJx6z+9q1wtMLRtA4ECaap/+N7az46GzZ5nIiwpa+Y=
+github.com/pingcap/tidb/parser v0.0.0-20211130051352-37e0dac25981/go.mod h1:ElJiub4lRy6UZDb+0JHDkGEdr6aOli+ykhyej7VCLoI=
 github.com/pingcap/tipb v0.0.0-20211116093845-e9b045a0bdf8 h1:Vu/6oq8EFNWgyXRHiclNzTKIu+YKHPCSI/Ba5oVrLtM=
 github.com/pingcap/tipb v0.0.0-20211116093845-e9b045a0bdf8/go.mod h1:A7mrd7WHBl1o63LE2bIBGEJMTNWXqhgmYiOvMLxozfs=
->>>>>>> txnkv: read through locks
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -749,10 +747,6 @@ github.com/xitongsys/parquet-go-source v0.0.0-20200817004010-026bad9b25d0/go.mod
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
-github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde h1:gynz5k6dOojz6pUFI8Kcizxl/JXxInySSS+7oybVGhQ=
-github.com/youjiali1995/kvproto v0.0.0-20211117113944-498284457dde/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42 h1:gUGNDRXM4yCDp23AXuEom2fbAvELsdf06J1pQct7fuc=
-github.com/youjiali1995/tidb v1.1.0-beta.0.20211118073243-bdfb8ddc8e42/go.mod h1:ALJkQU35R9AOIIbPgOgIgchNrnmi23cWwJ71XhLlHzU=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
@@ -826,6 +820,7 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rB
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20181106170214-d68db9428509/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1142,6 +1137,7 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20181004005441-af9cb2a35e7f/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1263,7 +1259,19 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-modernc.org/mathutil v1.2.2/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=
+modernc.org/fileutil v1.0.0/go.mod h1:JHsWpkrk/CnVV1H/eGlFf85BEpfkrp56ro8nojIq9Q8=
+modernc.org/golex v1.0.1/go.mod h1:QCA53QtsT1NdGkaZZkF5ezFwk4IXh4BGNafAARTC254=
+modernc.org/lex v1.0.0/go.mod h1:G6rxMTy3cH2iA0iXL/HRRv4Znu8MK4higxph/lE7ypk=
+modernc.org/lexer v1.0.0/go.mod h1:F/Dld0YKYdZCLQ7bD0USbWL4YKCyTDRDHiDTOs0q0vk=
+modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
+modernc.org/mathutil v1.4.1/go.mod h1:mZW8CKdRPY1v87qxC/wUdX5O1qDzXMP5TH3wjfpga6E=
+modernc.org/parser v1.0.0/go.mod h1:H20AntYJ2cHHL6MHthJ8LZzXCdDCHMWt1KZXtIMjejA=
+modernc.org/parser v1.0.2/go.mod h1:TXNq3HABP3HMaqLK7brD1fLA/LfN0KS6JxZn71QdDqs=
+modernc.org/scanner v1.0.1/go.mod h1:OIzD2ZtjYk6yTuyqZr57FmifbM9fIH74SumloSsajuE=
+modernc.org/sortutil v1.0.0/go.mod h1:1QO0q8IlIlmjBIwm6t/7sof874+xCfZouyqZMLIAtxM=
+modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
+modernc.org/strutil v1.1.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
+modernc.org/y v1.0.1/go.mod h1:Ho86I+LVHEI+LYXoUKlmOMAM1JTXOCfj8qi1T8PsClE=
 moul.io/zapgorm2 v1.1.0/go.mod h1:emRfKjNqSzVj5lcgasBdovIXY1jSOwFz2GQZn1Rddks=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -78,7 +78,7 @@ func (s *testLockSuite) TearDownTest() {
 	s.store.Close()
 }
 
-func (s *testLockSuite) lockKey(key, value, primaryKey, primaryValue []byte, commitPrimary bool) (uint64, uint64) {
+func (s *testLockSuite) lockKey(key, value, primaryKey, primaryValue []byte, commitPrimary bool, asyncCommit bool) (uint64, uint64) {
 	txn, err := s.store.Begin()
 	s.Nil(err)
 	if len(value) > 0 {
@@ -97,6 +97,9 @@ func (s *testLockSuite) lockKey(key, value, primaryKey, primaryValue []byte, com
 	tpc, err := txn.NewCommitter(0)
 	s.Nil(err)
 	tpc.SetPrimaryKey(primaryKey)
+	if asyncCommit {
+		tpc.SetUseAsyncCommit()
+	}
 
 	ctx := context.Background()
 	err = tpc.PrewriteAllMutations(ctx)
@@ -130,11 +133,11 @@ func (s *testLockSuite) putKV(key, value []byte) (uint64, uint64) {
 
 func (s *testLockSuite) prepareAlphabetLocks() {
 	s.putKV([]byte("c"), []byte("cc"))
-	s.lockKey([]byte("c"), []byte("c"), []byte("z1"), []byte("z1"), true)
-	s.lockKey([]byte("d"), []byte("dd"), []byte("z2"), []byte("z2"), false)
-	s.lockKey([]byte("foo"), []byte("foo"), []byte("z3"), []byte("z3"), false)
+	s.lockKey([]byte("c"), []byte("c"), []byte("z1"), []byte("z1"), true, false)
+	s.lockKey([]byte("d"), []byte("dd"), []byte("z2"), []byte("z2"), false, false)
+	s.lockKey([]byte("foo"), []byte("foo"), []byte("z3"), []byte("z3"), false, false)
 	s.putKV([]byte("bar"), []byte("bar"))
-	s.lockKey([]byte("bar"), nil, []byte("z4"), []byte("z4"), true)
+	s.lockKey([]byte("bar"), nil, []byte("z4"), []byte("z4"), true, false)
 }
 
 func (s *testLockSuite) TestScanLockResolveWithGet() {
@@ -205,7 +208,7 @@ func (s *testLockSuite) TestScanLockResolveWithBatchGet() {
 func (s *testLockSuite) TestCleanLock() {
 	for ch := byte('a'); ch <= byte('z'); ch++ {
 		k := []byte{ch}
-		s.lockKey(k, k, k, k, false)
+		s.lockKey(k, k, k, k, false, false)
 	}
 	txn, err := s.store.Begin()
 	s.Nil(err)
@@ -224,13 +227,13 @@ func (s *testLockSuite) TestGetTxnStatus() {
 	s.True(status.IsCommitted())
 	s.Equal(status.CommitTS(), commitTS)
 
-	startTS, commitTS = s.lockKey([]byte("a"), []byte("a"), []byte("a"), []byte("a"), true)
+	startTS, commitTS = s.lockKey([]byte("a"), []byte("a"), []byte("a"), []byte("a"), true, false)
 	status, err = s.store.GetLockResolver().GetTxnStatus(startTS, startTS, []byte("a"))
 	s.Nil(err)
 	s.True(status.IsCommitted())
 	s.Equal(status.CommitTS(), commitTS)
 
-	startTS, _ = s.lockKey([]byte("a"), []byte("a"), []byte("a"), []byte("a"), false)
+	startTS, _ = s.lockKey([]byte("a"), []byte("a"), []byte("a"), []byte("a"), false, false)
 	status, err = s.store.GetLockResolver().GetTxnStatus(startTS, startTS, []byte("a"))
 	s.Nil(err)
 	s.False(status.IsCommitted())
@@ -257,7 +260,8 @@ func (s *testLockSuite) TestCheckTxnStatusTTL() {
 
 	// Rollback the txn.
 	lock := s.mustGetLock([]byte("key"))
-	err = s.store.NewLockResolver().ResolveLock(context.Background(), lock)
+
+	err = s.store.NewLockResolver().ForceResolveLock(context.Background(), lock)
 	s.Nil(err)
 
 	// Check its status is rollbacked.
@@ -290,7 +294,7 @@ func (s *testLockSuite) TestTxnHeartBeat() {
 	s.Equal(newTTL, uint64(6666))
 
 	lock := s.mustGetLock([]byte("key"))
-	err = s.store.NewLockResolver().ResolveLock(context.Background(), lock)
+	err = s.store.NewLockResolver().ForceResolveLock(context.Background(), lock)
 	s.Nil(err)
 
 	newTTL, err = s.store.SendTxnHeartbeat(context.Background(), []byte("key"), txn.StartTS(), 6666)
@@ -322,13 +326,13 @@ func (s *testLockSuite) TestCheckTxnStatus() {
 
 	// Test the ResolveLocks API
 	lock := s.mustGetLock([]byte("second"))
-	timeBeforeExpire, _, err := resolver.ResolveLocks(bo, currentTS, []*txnkv.Lock{lock})
+	timeBeforeExpire, err := resolver.ResolveLocks(bo, currentTS, []*txnkv.Lock{lock})
 	s.Nil(err)
 	s.True(timeBeforeExpire > int64(0))
 
 	// Force rollback the lock using lock.TTL = 0.
 	lock.TTL = uint64(0)
-	timeBeforeExpire, _, err = resolver.ResolveLocks(bo, currentTS, []*txnkv.Lock{lock})
+	timeBeforeExpire, err = resolver.ResolveLocks(bo, currentTS, []*txnkv.Lock{lock})
 	s.Nil(err)
 	s.Equal(timeBeforeExpire, int64(0))
 
@@ -572,19 +576,19 @@ func (s *testLockSuite) TestZeroMinCommitTS() {
 	s.Nil(failpoint.Disable("tikvclient/mockZeroCommitTS"))
 
 	lock := s.mustGetLock([]byte("key"))
-	expire, pushed, err := s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+	expire, pushed, _, err := s.store.NewLockResolver().ResolveLocksForRead(bo, 0, []*txnkv.Lock{lock}, true)
 	s.Nil(err)
 	s.Len(pushed, 0)
 	s.Greater(expire, int64(0))
 
-	expire, pushed, err = s.store.NewLockResolver().ResolveLocks(bo, math.MaxUint64, []*txnkv.Lock{lock})
+	expire, pushed, _, err = s.store.NewLockResolver().ResolveLocksForRead(bo, math.MaxUint64, []*txnkv.Lock{lock}, true)
 	s.Nil(err)
 	s.Len(pushed, 1)
-	s.Greater(expire, int64(0))
+	s.Equal(expire, int64(0))
 
 	// Clean up this test.
 	lock.TTL = uint64(0)
-	expire, _, err = s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+	expire, err = s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
 	s.Nil(err)
 	s.Equal(expire, int64(0))
 }
@@ -641,10 +645,9 @@ func (s *testLockSuite) TestResolveTxnFallenBackFromAsyncCommit() {
 	lock := s.mustGetLock([]byte("fb1"))
 	s.True(lock.UseAsyncCommit)
 	bo := tikv.NewBackoffer(context.Background(), getMaxBackoff)
-	expire, pushed, err := s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+	expire, err := s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
 	s.Nil(err)
 	s.Equal(expire, int64(0))
-	s.Equal(len(pushed), 0)
 
 	t3, err := s.store.Begin()
 	s.Nil(err)
@@ -892,4 +895,69 @@ func (s *testLockSuite) TestPrewriteEncountersLargerTsLock() {
 
 	s.Nil(failpoint.Disable("tikvclient/prewritePrimary"))
 	<-ch
+}
+
+func (s *testLockSuite) TestResolveLocksForRead() {
+	ctx := context.Background()
+	var resolvedLocks, committedLocks []uint64
+	var locks []*txnlock.Lock
+
+	// commitTS < readStartTS
+	startTS, _ := s.lockKey([]byte("k1"), []byte("v1"), []byte("k11"), []byte("v11"), true, false)
+	committedLocks = append(committedLocks, startTS)
+	lock := s.mustGetLock([]byte("k1"))
+	locks = append(locks, lock)
+
+	// rolled back
+	startTS, _ = s.lockKey([]byte("k2"), []byte("v2"), []byte("k22"), []byte("v22"), false, false)
+	lock = s.mustGetLock([]byte("k22"))
+	err := s.store.NewLockResolver().ForceResolveLock(ctx, lock)
+	s.Nil(err)
+	resolvedLocks = append(resolvedLocks, startTS)
+	lock = s.mustGetLock([]byte("k2"))
+	locks = append(locks, lock)
+
+	// pushed
+	startTS, _ = s.lockKey([]byte("k3"), []byte("v3"), []byte("k33"), []byte("v33"), false, false)
+	resolvedLocks = append(resolvedLocks, startTS)
+	lock = s.mustGetLock([]byte("k3"))
+	locks = append(locks, lock)
+
+	// can't be pushed and isn't expired
+	_, _ = s.lockKey([]byte("k4"), []byte("v4"), []byte("k44"), []byte("v44"), false, true)
+	lock = s.mustGetLock([]byte("k4"))
+	locks = append(locks, lock)
+
+	// commitTS > readStartTS
+	var readStartTS uint64
+	{
+		t, err := s.store.Begin()
+		s.Nil(err)
+		resolvedLocks = append(resolvedLocks, t.StartTS())
+		s.Nil(t.Set([]byte("k5"), []byte("v5")))
+		s.Nil(t.Set([]byte("k55"), []byte("v55")))
+		committer, err := t.NewCommitter(1)
+		s.Nil(err)
+		s.Nil(committer.PrewriteAllMutations(ctx))
+		committer.SetPrimaryKey([]byte("k55"))
+
+		readStartTS, err = s.store.GetOracle().GetTimestamp(ctx, &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+		s.Nil(err)
+
+		commitTS, err := s.store.GetOracle().GetTimestamp(ctx, &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+		s.Nil(err)
+		s.Greater(commitTS, readStartTS)
+		committer.SetCommitTS(commitTS)
+		err = committer.CommitMutations(ctx)
+		s.Nil(err)
+		lock = s.mustGetLock([]byte("k5"))
+		locks = append(locks, lock)
+	}
+
+	bo := tikv.NewBackoffer(context.Background(), getMaxBackoff)
+	msBeforeExpired, resolved, committed, err := s.store.NewLockResolver().ResolveLocksForRead(bo, readStartTS, locks, false)
+	s.Nil(err)
+	s.Greater(msBeforeExpired, int64(0))
+	s.Equal(resolvedLocks, resolved)
+	s.Equal(committedLocks, committed)
 }

--- a/integration_tests/snapshot_fail_test.go
+++ b/integration_tests/snapshot_fail_test.go
@@ -310,7 +310,7 @@ func (s *testSnapshotFailSuite) TestResetSnapshotTS() {
 	s.Equal(val, []byte("y1"))
 }
 
-func (s *testSnapshotFailSuite) mustGetLock(key []byte) *txnkv.Lock {
+func (s *testSnapshotFailSuite) getLock(key []byte) *txnkv.Lock {
 	ver, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
 	s.Nil(err)
 	bo := tikv.NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
@@ -324,45 +324,70 @@ func (s *testSnapshotFailSuite) mustGetLock(key []byte) *txnkv.Lock {
 	s.Nil(err)
 	s.NotNil(resp.Resp)
 	keyErr := resp.Resp.(*kvrpcpb.GetResponse).GetError()
-	s.NotNil(keyErr)
+	if keyErr == nil {
+		return nil
+	}
 	lock, err := txnlock.ExtractLockFromKeyErr(keyErr)
-	s.Nil(err)
+	if err != nil {
+		return nil
+	}
 	return lock
 }
 
 func (s *testSnapshotFailSuite) TestSnapshotUseResolveForRead() {
-	x := []byte("x_key_TestSnapshotUseResolveForRead")
-	y := []byte("y_key_TestSnapshotUseResolveForRead")
-	txn, err := s.store.Begin()
-	s.Nil(err)
-	s.Nil(txn.Set(x, []byte("x")))
-	s.Nil(txn.Set(y, []byte("y")))
-	ctx := context.Background()
-	committer, err := txn.NewCommitter(1)
-	s.Nil(err)
-	committer.SetLockTTL(3000)
-	s.Nil(committer.PrewriteAllMutations(ctx))
-	committer.SetCommitTS(committer.GetStartTS() + 1)
-	committer.CommitMutations(ctx)
-	s.Equal(committer.GetPrimaryKey(), x)
-	s.NotNil(s.mustGetLock(y))
+	s.Nil(failpoint.Enable("tikvclient/resolveLock", "sleep(500)"))
+	s.Nil(failpoint.Enable("tikvclient/resolveAsyncResolveData", "sleep(500)"))
+	defer func() {
+		s.Nil(failpoint.Disable("tikvclient/resolveAsyncResolveData"))
+		s.Nil(failpoint.Disable("tikvclient/resolveLock"))
+	}()
 
-	s.Nil(failpoint.Enable("tikvclient/resolveLock", `sleep(1000)`))
-	defer s.Nil(failpoint.Disable("tikvclient/resolveLock"))
+	for _, asyncCommit := range []bool{false, true} {
+		x := []byte("x_key_TestSnapshotUseResolveForRead")
+		y := []byte("y_key_TestSnapshotUseResolveForRead")
+		txn, err := s.store.Begin()
+		s.Nil(err)
+		s.Nil(txn.Set(x, []byte("x")))
+		s.Nil(txn.Set(y, []byte("y")))
+		txn.SetEnableAsyncCommit(asyncCommit)
+		ctx := context.Background()
+		committer, err := txn.NewCommitter(1)
+		s.Nil(err)
+		committer.SetLockTTL(3000)
+		s.Nil(committer.PrewriteAllMutations(ctx))
+		committer.SetCommitTS(committer.GetStartTS() + 1)
+		committer.CommitMutations(ctx)
+		s.Equal(committer.GetPrimaryKey(), x)
+		s.NotNil(s.getLock(y))
 
-	txn, err = s.store.Begin()
-	s.Nil(err)
-	snapshot := txn.GetSnapshot()
+		txn, err = s.store.Begin()
+		s.Nil(err)
+		snapshot := txn.GetSnapshot()
+		start := time.Now()
+		val, err := snapshot.Get(ctx, y)
+		s.Nil(err)
+		s.Equal([]byte("y"), val)
+		s.Less(time.Since(start), 200*time.Millisecond)
+		s.NotNil(s.getLock(y))
 
-	start := time.Now()
-	val, err := snapshot.Get(ctx, y)
-	s.Nil(err)
-	s.Equal([]byte("y"), val)
-	s.Less(time.Since(start), 500*time.Millisecond)
+		txn, err = s.store.Begin()
+		s.Nil(err)
+		snapshot = txn.GetSnapshot()
+		start = time.Now()
+		res, err := snapshot.BatchGet(ctx, [][]byte{y})
+		s.Nil(err)
+		s.Equal([]byte("y"), res[string(y)])
+		s.Less(time.Since(start), 200*time.Millisecond)
+		s.NotNil(s.getLock(y))
 
-	start = time.Now()
-	res, err := snapshot.BatchGet(ctx, [][]byte{y})
-	s.Nil(err)
-	s.Equal([]byte("y"), res[string(y)])
-	s.Less(time.Since(start), 500*time.Millisecond)
+		var lock *txnkv.Lock
+		for i := 0; i < 10; i++ {
+			time.Sleep(100 * time.Millisecond)
+			lock = s.getLock(y)
+			if lock == nil {
+				break
+			}
+		}
+		s.Nil(lock, "failed to resolve lock timely")
+	}
 }

--- a/integration_tests/snapshot_fail_test.go
+++ b/integration_tests/snapshot_fail_test.go
@@ -348,6 +348,7 @@ func (s *testSnapshotFailSuite) TestSnapshotUseResolveForRead() {
 	s.NotNil(s.mustGetLock(y))
 
 	s.Nil(failpoint.Enable("tikvclient/resolveLock", `sleep(1000)`))
+	defer s.Nil(failpoint.Disable("tikvclient/resolveLock"))
 
 	txn, err = s.store.Begin()
 	s.Nil(err)

--- a/integration_tests/snapshot_fail_test.go
+++ b/integration_tests/snapshot_fail_test.go
@@ -41,10 +41,15 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/stretchr/testify/suite"
 	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/txnkv"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
 )
 
 func TestSnapshotFail(t *testing.T) {
@@ -303,4 +308,60 @@ func (s *testSnapshotFailSuite) TestResetSnapshotTS() {
 	val, err = txn2.Get(ctx, y)
 	s.Nil(err)
 	s.Equal(val, []byte("y1"))
+}
+
+func (s *testSnapshotFailSuite) mustGetLock(key []byte) *txnkv.Lock {
+	ver, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+	s.Nil(err)
+	bo := tikv.NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{
+		Key:     key,
+		Version: ver,
+	})
+	loc, err := s.store.GetRegionCache().LocateKey(bo, key)
+	s.Nil(err)
+	resp, err := s.store.SendReq(bo, req, loc.Region, tikv.ReadTimeoutShort)
+	s.Nil(err)
+	s.NotNil(resp.Resp)
+	keyErr := resp.Resp.(*kvrpcpb.GetResponse).GetError()
+	s.NotNil(keyErr)
+	lock, err := txnlock.ExtractLockFromKeyErr(keyErr)
+	s.Nil(err)
+	return lock
+}
+
+func (s *testSnapshotFailSuite) TestSnapshotUseResolveForRead() {
+	x := []byte("x_key_TestSnapshotUseResolveForRead")
+	y := []byte("y_key_TestSnapshotUseResolveForRead")
+	txn, err := s.store.Begin()
+	s.Nil(err)
+	s.Nil(txn.Set(x, []byte("x")))
+	s.Nil(txn.Set(y, []byte("y")))
+	ctx := context.Background()
+	committer, err := txn.NewCommitter(1)
+	s.Nil(err)
+	committer.SetLockTTL(3000)
+	s.Nil(committer.PrewriteAllMutations(ctx))
+	committer.SetCommitTS(committer.GetStartTS() + 1)
+	committer.CommitMutations(ctx)
+	s.Equal(committer.GetPrimaryKey(), x)
+	s.NotNil(s.mustGetLock(y))
+
+	s.Nil(failpoint.Enable("tikvclient/resolveLock", `sleep(1000)`))
+
+	txn, err = s.store.Begin()
+	s.Nil(err)
+	snapshot := txn.GetSnapshot()
+
+	start := time.Now()
+	val, err := snapshot.Get(ctx, y)
+	s.Nil(err)
+	s.Equal([]byte("y"), val)
+	s.Less(time.Since(start), 500*time.Millisecond)
+
+	start = time.Now()
+	res, err := snapshot.BatchGet(ctx, [][]byte{y})
+	s.Nil(err)
+	s.Equal([]byte("y"), res[string(y)])
+	s.Less(time.Since(start), 500*time.Millisecond)
 }

--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -316,7 +316,7 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 		a.pendingRequests.Observe(float64(len(a.batchCommandsCh)))
 		a.batchSize.Observe(float64(a.reqBuilder.len()))
 
-		// curl -X PUT -d 'return(true)' http://0.0.0.0:10080/fail/github.com/tikv/client-go/v2/mockBlockOnBatchClient
+		// curl -X PUT -d 'return(true)' http://0.0.0.0:10080/fail/tikvclient/mockBlockOnBatchClient
 		if val, err := util.EvalFailpoint("mockBlockOnBatchClient"); err == nil {
 			if val.(bool) {
 				time.Sleep(1 * time.Hour)

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -330,6 +330,7 @@ func (s *KVStore) Close() error {
 
 	s.oracle.Close()
 	s.pdClient.Close()
+	s.lockResolver.Close()
 
 	if err := s.GetTiKVClient().Close(); err != nil {
 		return err

--- a/tikv/test_probe.go
+++ b/tikv/test_probe.go
@@ -120,6 +120,15 @@ func NewLockResolverProb(r *txnlock.LockResolver) *LockResolverProbe {
 	return &LockResolverProbe{&resolver}
 }
 
+// ForceResolveLock forces to resolve a single lock. It's a helper function only for writing test.
+func (l LockResolverProbe) ForceResolveLock(ctx context.Context, lock *txnlock.Lock) error {
+	bo := retry.NewBackofferWithVars(ctx, transaction.ConfigProbe{}.GetPessimisticLockMaxBackoff(), nil)
+	// make use of forcing resolving lock
+	lock.TTL = 0
+	_, err := l.LockResolverProbe.ResolveLocks(bo, 0, []*txnlock.Lock{lock})
+	return err
+}
+
 // ResolveLock resolves single lock.
 func (l LockResolverProbe) ResolveLock(ctx context.Context, lock *txnlock.Lock) error {
 	bo := retry.NewBackofferWithVars(ctx, transaction.ConfigProbe{}.GetPessimisticLockMaxBackoff(), nil)

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -209,7 +209,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		// Because we already waited on tikv, no need to Backoff here.
 		// tikv default will wait 3s(also the maximum wait value) when lock error occurs
 		startTime = time.Now()
-		msBeforeTxnExpired, _, err := c.store.GetLockResolver().ResolveLocks(bo, 0, locks)
+		msBeforeTxnExpired, err := c.store.GetLockResolver().ResolveLocks(bo, 0, locks)
 		if err != nil {
 			return err
 		}

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -345,7 +345,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *retry.B
 			locks = append(locks, lock)
 		}
 		start := time.Now()
-		msBeforeExpired, err := c.store.GetLockResolver().ResolveLocksForWrite(bo, c.startTS, c.forUpdateTS, locks)
+		msBeforeExpired, err := c.store.GetLockResolver().ResolveLocks(bo, c.startTS, locks)
 		if err != nil {
 			return err
 		}

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -45,9 +45,10 @@ type LockResolverProbe struct {
 	*LockResolver
 }
 
-// ResolveLockAsync tries to resolve a lock using the txn states.
-func (l LockResolverProbe) ResolveLockAsync(bo *retry.Backoffer, lock *Lock, status TxnStatus) error {
-	return l.resolveLockAsync(bo, lock, status)
+// ResolveAsyncCommitLock tries to resolve a lock using the txn states.
+func (l LockResolverProbe) ResolveAsyncCommitLock(bo *retry.Backoffer, lock *Lock, status TxnStatus) error {
+	_, err := l.resolveAsyncCommitLock(bo, lock, status, false)
+	return err
 }
 
 // ResolveLock resolves single lock.
@@ -57,7 +58,7 @@ func (l LockResolverProbe) ResolveLock(bo *retry.Backoffer, lock *Lock) error {
 
 // ResolvePessimisticLock resolves single pessimistic lock.
 func (l LockResolverProbe) ResolvePessimisticLock(bo *retry.Backoffer, lock *Lock) error {
-	return l.resolvePessimisticLock(bo, lock, make(map[locate.RegionVerID]struct{}))
+	return l.resolvePessimisticLock(bo, lock)
 }
 
 // GetTxnStatus sends the CheckTxnStatus request to the TiKV server.

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -283,7 +283,7 @@ func (s *Scanner) getData(bo *retry.Backoffer) error {
 			if err != nil {
 				return err
 			}
-			msBeforeExpired, _, err := txnlock.NewLockResolver(s.snapshot.store).ResolveLocks(bo, s.snapshot.version, []*txnlock.Lock{lock})
+			msBeforeExpired, err := txnlock.NewLockResolver(s.snapshot.store).ResolveLocks(bo, s.snapshot.version, []*txnlock.Lock{lock})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

TiKV supports read-through-lock https://github.com/tikv/tikv/pull/11238. This PR makes use of it:
1. I removed the `forWrite` parameter of `resolveLocks` because it's useless(https://github.com/tikv/client-go/pull/367) and add the `forRead`. If `forRead` is true, resolving secondary locks is asynchronous and `committedLocks` or `resolvedLocks` is returned to the user.
2. `ClientHelper` passes the `resolvedLocks` to `Context` to make use of read-through-lock.

Should be merged after https://github.com/pingcap/tidb/pull/29898