### PR TITLE
bugfix:os.ReadFile, module requires Go 1.16

### DIFF
--- a/config/security.go
+++ b/config/security.go
@@ -37,9 +37,8 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"os"
-
 	"github.com/pkg/errors"
+	"io/ioutil"
 )
 
 // Security is the security section of the config.
@@ -66,7 +65,7 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 		certPool := x509.NewCertPool()
 		// Create a certificate pool from the certificate authority
 		var ca []byte
-		ca, err = os.ReadFile(s.ClusterSSLCA)
+		ca, err = ioutil.ReadFile(s.ClusterSSLCA)
 		if err != nil {
 			err = errors.Errorf("could not read ca certificate: %s", err)
 			return


### PR DESCRIPTION
client-go Compatible with go1.16 and below