### PR TITLE
txnkv: decrease some max and base backoff time

### DIFF
--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -293,12 +293,12 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	bo := tikv.NewBackofferWithVars(context.Background(), 2000, nil)
-	err := bo.BackoffWithMaxSleepTxnLockFast(30, errors.New("test"))
+	err := bo.BackoffWithMaxSleepTxnLockFast(5, errors.New("test"))
 	s.Nil(err)
 	snapshot.RecordBackoffInfo(bo)
 	snapshot.RecordBackoffInfo(bo)
-	expect := "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:60ms}"
-	s.Equal(snapshot.FormatStats(), expect)
+	expect := "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:10ms}"
+	s.Equal(expect, snapshot.FormatStats())
 	detail := &kvrpcpb.ExecDetailsV2{
 		TimeDetail: &kvrpcpb.TimeDetail{
 			WaitWallTimeMs:    100,
@@ -316,7 +316,7 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 		},
 	}
 	snapshot.MergeExecDetail(detail)
-	expect = "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:60ms}, " +
+	expect = "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:10ms}, " +
 		"total_process_time: 100ms, total_wait_time: 100ms, " +
 		"scan_detail: {total_process_keys: 10, " +
 		"total_process_keys_size: 10, " +
@@ -324,9 +324,9 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 		"rocksdb: {delete_skipped_count: 5, " +
 		"key_skipped_count: 1, " +
 		"block: {cache_hit_count: 10, read_count: 20, read_byte: 15 Bytes}}}"
-	s.Equal(snapshot.FormatStats(), expect)
+	s.Equal(expect, snapshot.FormatStats())
 	snapshot.MergeExecDetail(detail)
-	expect = "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:60ms}, " +
+	expect = "Get:{num_rpc:4, total_time:2s},txnLockFast_backoff:{num:2, total_time:10ms}, " +
 		"total_process_time: 200ms, total_wait_time: 200ms, " +
 		"scan_detail: {total_process_keys: 20, " +
 		"total_process_keys_size: 20, " +
@@ -334,5 +334,5 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 		"rocksdb: {delete_skipped_count: 10, " +
 		"key_skipped_count: 2, " +
 		"block: {cache_hit_count: 20, read_count: 40, read_byte: 30 Bytes}}}"
-	s.Equal(snapshot.FormatStats(), expect)
+	s.Equal(expect, snapshot.FormatStats())
 }

--- a/internal/retry/backoff_test.go
+++ b/internal/retry/backoff_test.go
@@ -44,8 +44,8 @@ import (
 
 func TestBackoffWithMax(t *testing.T) {
 	b := NewBackofferWithVars(context.TODO(), 2000, nil)
-	err := b.BackoffWithMaxSleepTxnLockFast(30, errors.New("test"))
+	err := b.BackoffWithMaxSleepTxnLockFast(5, errors.New("test"))
 
 	assert.Nil(t, err)
-	assert.Equal(t, 30, b.totalSleep)
+	assert.Equal(t, 5, b.totalSleep)
 }

--- a/internal/retry/config.go
+++ b/internal/retry/config.go
@@ -111,7 +111,7 @@ var (
 	// TODO: distinguish tikv and tiflash in metrics
 	BoTiKVRPC    = NewConfig("tikvRPC", &metrics.BackoffHistogramRPC, NewBackoffFnCfg(100, 2000, EqualJitter), tikverr.ErrTiKVServerTimeout)
 	BoTiFlashRPC = NewConfig("tiflashRPC", &metrics.BackoffHistogramRPC, NewBackoffFnCfg(100, 2000, EqualJitter), tikverr.ErrTiFlashServerTimeout)
-	BoTxnLock    = NewConfig("txnLock", &metrics.BackoffHistogramLock, NewBackoffFnCfg(200, 3000, EqualJitter), tikverr.ErrResolveLockTimeout)
+	BoTxnLock    = NewConfig("txnLock", &metrics.BackoffHistogramLock, NewBackoffFnCfg(100, 3000, EqualJitter), tikverr.ErrResolveLockTimeout)
 	BoPDRPC      = NewConfig("pdRPC", &metrics.BackoffHistogramPD, NewBackoffFnCfg(500, 3000, EqualJitter), tikverr.NewErrPDServerTimeout(""))
 	// change base time to 2ms, because it may recover soon.
 	BoRegionMiss              = NewConfig("regionMiss", &metrics.BackoffHistogramRegionMiss, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrRegionUnavailable)

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -63,6 +63,6 @@ var DefaultVars = NewVariables(&ignoreKill)
 
 // Default values
 const (
-	DefBackoffLockFast = 100
+	DefBackoffLockFast = 10
 	DefBackOffWeight   = 2
 )

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -900,8 +900,8 @@ func (tm *ttlManager) reset() {
 	close(tm.ch)
 }
 
-const keepAliveMaxBackoff = 20000        // 20 seconds
-const pessimisticLockMaxBackoff = 600000 // 10 minutes
+const keepAliveMaxBackoff = 20000
+const pessimisticLockMaxBackoff = 20000
 const maxConsecutiveFailure = 10
 
 func keepAlive(c *twoPhaseCommitter, closeCh chan struct{}, primaryKey []byte, lockCtx *kv.LockCtx) {

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -515,6 +515,7 @@ func (lr *LockResolver) getTxnStatusFromLock(bo *retry.Backoffer, l *Lock, calle
 			// For pessimistic lock resolving, if the primary lock does not exist and rollbackIfNotExist is true,
 			// The Action_LockNotExistDoNothing will be returned as the status.
 			rollbackIfNotExist = true
+			continue
 		} else {
 			// For the Rollback statement from user, the pessimistic locks will be rollbacked and the primary key in store
 			// has no related information. There are possibilities that some other transactions do checkTxnStatus on these

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -110,7 +110,7 @@ func (s *Scanner) Value() []byte {
 	return nil
 }
 
-const scannerNextMaxBackoff = 600000 // 10 minutes
+const scannerNextMaxBackoff = 20000
 
 // Next return next element.
 func (s *Scanner) Next() error {

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -155,7 +155,7 @@ func NewTiKVSnapshot(store kvstore, ts uint64, replicaReadSeed uint32) *KVSnapsh
 	}
 }
 
-const batchGetMaxBackoff = 600000 // 10 minutes
+const batchGetMaxBackoff = 20000
 
 // SetSnapshotTS resets the timestamp for reads.
 func (s *KVSnapshot) SetSnapshotTS(ts uint64) {
@@ -458,7 +458,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 	}
 }
 
-const getMaxBackoff = 600000 // 10 minutes
+const getMaxBackoff = 20000
 
 // Get gets the value for key k from snapshot.
 func (s *KVSnapshot) Get(ctx context.Context, k []byte) ([]byte, error) {


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

1. Decrease some `MaxBackoff` to its old value.
2. Decrease the base backoff time of `BoTxnLockFast` from 100ms to 10ms, because 100ms is too big to endure for a small read request.
3. Decrease the base backoff time of `BoTxnLock` from 200ms to 100ms as the same reason for read. Because `BoTxnLock` is seldom used, I didn't decrease it a lot.