### PR TITLE
txnkv/transaction: add a kv option for cached table lock lease

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1369,7 +1369,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		return err
 	}
 	if c.txn.cachedTableWriteLease != nil {
-		for i:=0; i<len(c.txn.cachedTableWriteLease); i++ {
+		for i := 0; i < len(c.txn.cachedTableWriteLease); i++ {
 			writeLease := atomic.LoadUint64(&c.txn.cachedTableWriteLease[i])
 			if commitTS >= writeLease {
 				err = errors.Errorf("session %d txn on cached table write lock lease %d gone, txnStartTS: %d, comm: %d",

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1369,8 +1369,8 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 	}
 	if c.txn.commitTSUpperBoundCheck != nil {
 		if !c.txn.commitTSUpperBoundCheck(commitTS) {
-			err = errors.Errorf("session %d txn on cached table write lock lease %d gone, txnStartTS: %d, comm: %d",
-				c.sessionID, writeLease, c.startTS, c.commitTS)
+			err = errors.Errorf("session %d check commit ts upper bound fail, txnStartTS: %d, comm: %d",
+				c.sessionID, c.startTS, c.commitTS)
 		}
 	}
 

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1369,11 +1369,13 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		return err
 	}
 	if c.txn.cachedTableWriteLease != nil {
-		writeLease := atomic.LoadUint64(c.txn.cachedTableWriteLease)
-		if commitTS >= writeLease {
-			err = errors.Errorf("session %d txn on cached table write lock lease %d gone, txnStartTS: %d, comm: %d",
-				c.sessionID, writeLease, c.startTS, c.commitTS)
-			return err
+		for i:=0; i<len(c.txn.cachedTableWriteLease); i++ {
+			writeLease := atomic.LoadUint64(&c.txn.cachedTableWriteLease[i])
+			if commitTS >= writeLease {
+				err = errors.Errorf("session %d txn on cached table write lock lease %d gone, txnStartTS: %d, comm: %d",
+					c.sessionID, writeLease, c.startTS, c.commitTS)
+				return err
+			}
 		}
 	}
 

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -112,7 +112,7 @@ type KVTxn struct {
 	resourceGroupTag      []byte
 	resourceGroupTagger   tikvrpc.ResourceGroupTagger // use this when resourceGroupTag is nil
 	diskFullOpt           kvrpcpb.DiskFullOpt
-	cachedTableWriteLease *uint64
+	cachedTableWriteLease []uint64
 }
 
 // NewTiKVTxn creates a new KVTxn.
@@ -285,8 +285,8 @@ func (txn *KVTxn) SetKVFilter(filter KVFilter) {
 // SetCachedTableWriteLease set the cached table write lease when the transaction used cached table.
 // If this value is set, the transaction must ensure the final commit ts is less than atomic.LoadUint64(leasePtr)
 // leasePtr point to a lease variable whose value is updated by a renew lease goroutine.
-func (txn *KVTxn) SetCachedTableWriteLease(leasePtr *uint64) {
-	txn.cachedTableWriteLease = leasePtr
+func (txn *KVTxn) SetCachedTableWriteLease(leases []uint64) {
+	txn.cachedTableWriteLease = leases
 }
 
 // SetDiskFullOpt sets whether current operation is allowed in each TiKV disk usage level.


### PR DESCRIPTION
This is used by the cached table https://github.com/pingcap/tidb/pull/30206

A brief description of the [cached table](https://github.com/pingcap/tidb/issues/25293):

We cache the table data directly in TiDB.
The cached table need to maintain a READ lock and renew the lock lease for caching.
For write operation, it first wait the READ lock lease to expire, then it changes to WRITE lock mode, and maintain the write lock lease for writing (prevent caching).

When transaction commit, we must guarantee **the final commitTS is less than the write lock lease** of a cached table,
otherwise the transaction should abort.

This PR add the transaction option.
