### PR TITLE
client: skip update backward safets

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -540,6 +540,11 @@ func (s *KVStore) updateSafeTS(ctx context.Context) {
 				return
 			}
 			safeTS := resp.Resp.(*kvrpcpb.StoreSafeTSResponse).GetSafeTs()
+			preSafeTS := s.getSafeTS(storeID)
+			if preSafeTS > safeTS {
+				metrics.TiKVSafeTSUpdateCounter.WithLabelValues("skip", storeIDStr).Inc()
+				return
+			}
 			s.setSafeTS(storeID, safeTS)
 			metrics.TiKVSafeTSUpdateCounter.WithLabelValues("success", storeIDStr).Inc()
 			safeTSTime := oracle.GetTimeFromTS(safeTS)

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -543,6 +543,8 @@ func (s *KVStore) updateSafeTS(ctx context.Context) {
 			preSafeTS := s.getSafeTS(storeID)
 			if preSafeTS > safeTS {
 				metrics.TiKVSafeTSUpdateCounter.WithLabelValues("skip", storeIDStr).Inc()
+				preSafeTSTime := oracle.GetTimeFromTS(preSafeTS)
+				metrics.TiKVMinSafeTSGapSeconds.WithLabelValues(storeIDStr).Set(time.Since(preSafeTSTime).Seconds())
 				return
 			}
 			s.setSafeTS(storeID, safeTS)


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

During tikv restarted, the safeTS might be 0 in a short period. This requests forbid tidb update backward safets. 