### PR TITLE
fix data race and panic when exiting

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -90,6 +90,8 @@ var (
 	ErrUnknown = errors.New("unknow")
 	// ErrResultUndetermined is the error when execution result is unknown.
 	ErrResultUndetermined = errors.New("execution result undetermined")
+	// ErrStoreIsExiting is the error when store is exiting.
+	ErrStoreIsExiting = errors.New("store is exiting")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.

--- a/error/error.go
+++ b/error/error.go
@@ -90,8 +90,6 @@ var (
 	ErrUnknown = errors.New("unknow")
 	// ErrResultUndetermined is the error when execution result is unknown.
 	ErrResultUndetermined = errors.New("execution result undetermined")
-	// ErrStoreIsExiting is the error when store is exiting.
-	ErrStoreIsExiting = errors.New("store is exiting")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.

--- a/internal/unionstore/memdb_norace_test.go
+++ b/internal/unionstore/memdb_norace_test.go
@@ -32,6 +32,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !race
 // +build !race
 
 package unionstore

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -68,6 +68,7 @@ import (
 	"github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	"go.etcd.io/etcd/clientv3"
+	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
@@ -126,6 +127,7 @@ type KVStore struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+	close  atomicutil.Bool
 }
 
 // UpdateSPCache updates cached safepoint.
@@ -295,6 +297,7 @@ func (s *KVStore) GetSnapshot(ts uint64) *txnsnapshot.KVSnapshot {
 
 // Close store
 func (s *KVStore) Close() error {
+	s.close.Store(true)
 	s.cancel()
 	s.wg.Wait()
 
@@ -454,6 +457,11 @@ func (s *KVStore) GetMinSafeTS(txnScope string) uint64 {
 // Ctx returns ctx.
 func (s *KVStore) Ctx() context.Context {
 	return s.ctx
+}
+
+// IsClose checks whether the store is closed.
+func (s *KVStore) IsClose() bool {
+	return s.close.Load()
 }
 
 // WaitGroup returns wg

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -778,6 +778,9 @@ func (c *twoPhaseCommitter) doActionOnGroupMutations(bo *retry.Backoffer, action
 	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
 		secondaryBo := retry.NewBackofferWithVars(c.store.Ctx(), CommitSecondaryMaxBackoff, c.txn.vars)
 		if c.store.IsClose() {
+			logutil.Logger(bo.GetCtx()).Warn("the store is closed",
+				zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
+				zap.Uint64("sessionID", c.sessionID))
 			return nil
 		}
 		c.store.WaitGroup().Add(1)
@@ -1413,6 +1416,9 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
 			zap.Uint64("sessionID", c.sessionID))
 		if c.store.IsClose() {
+			logutil.Logger(ctx).Warn("2PC will use async commit protocol to commit this txn but the store is closed",
+				zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
+				zap.Uint64("sessionID", c.sessionID))
 			return nil
 		}
 		c.store.WaitGroup().Add(1)

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -778,7 +778,7 @@ func (c *twoPhaseCommitter) doActionOnGroupMutations(bo *retry.Backoffer, action
 	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
 		secondaryBo := retry.NewBackofferWithVars(c.store.Ctx(), CommitSecondaryMaxBackoff, c.txn.vars)
 		if c.store.IsClose() {
-			return tikverr.ErrStoreIsExiting
+			return nil
 		}
 		c.store.WaitGroup().Add(1)
 		go func() {
@@ -1106,7 +1106,7 @@ const (
 
 func (c *twoPhaseCommitter) cleanup(ctx context.Context) {
 	if c.store.IsClose() {
-		logutil.Logger(ctx).Error("twoPhaseCommitter fail to cleanup because the store exited",
+		logutil.Logger(ctx).Warn("twoPhaseCommitter fail to cleanup because the store exited",
 			zap.Uint64("txnStartTS", c.startTS), zap.Bool("isPessimistic", c.isPessimistic),
 			zap.Bool("isOnePC", c.isOnePC()))
 		return
@@ -1413,7 +1413,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
 			zap.Uint64("sessionID", c.sessionID))
 		if c.store.IsClose() {
-			return tikverr.ErrStoreIsExiting
+			return nil
 		}
 		c.store.WaitGroup().Add(1)
 		go func() {

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -112,6 +112,8 @@ type kvstore interface {
 	// TxnLatches returns txnLatches.
 	TxnLatches() *latch.LatchesScheduler
 	GetClusterID() uint64
+	// IsClose checks whether the store is closed.
+	IsClose() bool
 }
 
 // twoPhaseCommitter executes a two-phase commit protocol.
@@ -775,6 +777,9 @@ func (c *twoPhaseCommitter) doActionOnGroupMutations(bo *retry.Backoffer, action
 	// Already spawned a goroutine for async commit transaction.
 	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
 		secondaryBo := retry.NewBackofferWithVars(c.store.Ctx(), CommitSecondaryMaxBackoff, c.txn.vars)
+		if c.store.IsClose() {
+			return tikverr.ErrStoreIsExiting
+		}
 		c.store.WaitGroup().Add(1)
 		go func() {
 			defer c.store.WaitGroup().Done()
@@ -1100,6 +1105,12 @@ const (
 )
 
 func (c *twoPhaseCommitter) cleanup(ctx context.Context) {
+	if c.store.IsClose() {
+		logutil.Logger(ctx).Error("twoPhaseCommitter fail to cleanup because the store exited",
+			zap.Uint64("txnStartTS", c.startTS), zap.Bool("isPessimistic", c.isPessimistic),
+			zap.Bool("isOnePC", c.isOnePC()))
+		return
+	}
 	c.cleanWg.Add(1)
 	c.store.WaitGroup().Add(1)
 	go func() {
@@ -1401,6 +1412,9 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		logutil.Logger(ctx).Debug("2PC will use async commit protocol to commit this txn",
 			zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
 			zap.Uint64("sessionID", c.sessionID))
+		if c.store.IsClose() {
+			return tikverr.ErrStoreIsExiting
+		}
 		c.store.WaitGroup().Add(1)
 		go func() {
 			defer c.store.WaitGroup().Done()


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

When you exit the KVStore, Some task will still call ```WaitGroup.Add```. It is a dangerous way to make DATA RACE and panic between ```WaitGroup.Wait``` and ```WaitGroup.Add```. 

https://github.com/pingcap/tidb/issues/30658
https://github.com/pingcap/tidb/issues/30651