### PR TITLE
metrics: make batch client requests more accurate

### DIFF
--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -313,8 +313,6 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 		a.reqBuilder.reset()
 
 		start := a.fetchAllPendingRequests(int(cfg.MaxBatchSize))
-		a.pendingRequests.Observe(float64(len(a.batchCommandsCh)))
-		a.batchSize.Observe(float64(a.reqBuilder.len()))
 
 		// curl -X PUT -d 'return(true)' http://0.0.0.0:10080/fail/tikvclient/mockBlockOnBatchClient
 		if val, err := util.EvalFailpoint("mockBlockOnBatchClient"); err == nil {
@@ -330,6 +328,8 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 				a.fetchMorePendingRequests(int(cfg.MaxBatchSize), int(bestBatchWaitSize), cfg.MaxBatchWaitTime)
 			}
 		}
+		a.pendingRequests.Observe(float64(len(a.batchCommandsCh)))
+		a.batchSize.Observe(float64(a.reqBuilder.len()))
 		length := a.reqBuilder.len()
 		if uint(length) == 0 {
 			// The batch command channel is closed.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -300,7 +300,7 @@ func initMetrics(namespace, subsystem string) {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "batch_pending_requests",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 11), // 1 ~ 1024
 			Help:      "number of requests pending in the batch channel",
 		}, []string{"store"})
 
@@ -309,7 +309,7 @@ func initMetrics(namespace, subsystem string) {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "batch_requests",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 8),
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 11), // 1 ~ 1024
 			Help:      "number of requests in one batch",
 		}, []string{"store"})
 


### PR DESCRIPTION
Because of the mechanism of getting more requests, it is possible for the batch client to get more requests than the max-batch-size, so the original metrics observe position is not very accurate and the upper limit of metrics is too low, only 128.