### PR TITLE
Add miss register for TiKVUnsafeDestroyRangeFailuresCounterVec

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -605,6 +605,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVTxnCommitBackoffCount)
 	prometheus.MustRegister(TiKVSmallReadDuration)
 	prometheus.MustRegister(TiKVReadThroughput)
+	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 }
 
 // readCounter reads the value of a prometheus.Counter.


### PR DESCRIPTION
`TiKVUnsafeDestroyRangeFailuresCounterVec` seems forget to register