### PR TITLE
Try to fix issue265. When 'store' is filtered, resolve agagin

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -174,13 +174,13 @@ func (r *regionStore) clone() *regionStore {
 
 // return next follower store's index
 func (r *regionStore) follower(seed uint32, op *storeSelectorOp) AccessIndex {
-	filteredStore := []*Store{}
-	defer func(filteredStore []*Store) {
+	var filteredStore []*Store
+	defer func() {
 		for _, s := range filteredStore {
 			_, err := s.reResolve(r.regionCache)
 			tikverr.Log(err)
 		}
-	}(filteredStore)
+	}()
 
 	l := uint32(r.accessStoreNum(tiKVOnly))
 	if l <= 1 {


### PR DESCRIPTION
Try to fix [issue265](https://github.com/tikv/client-go/issues/265).
When the 'store' is filtered, save to 'filteredStore'. At the end of function, call 'reResolve' function for 'store' which save to 'filteredStore'.