### PR TITLE
integration_tests: speed up TestCommitOnTiKVDiskFullOpt

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -230,7 +230,9 @@ func (s *testCommitterSuite) TestCommitOnTiKVDiskFullOpt() {
 	s.Nil(failpoint.Enable("tikvclient/rpcAllowedOnAlmostFull", `return("true")`))
 	txn = s.begin()
 	txn.Set([]byte("c"), []byte("c1"))
-	err = txn.Commit(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	err = txn.Commit(ctx)
 	s.NotNil(err)
 	s.Nil(failpoint.Disable("tikvclient/rpcAllowedOnAlmostFull"))
 }


### PR DESCRIPTION
TestCommitOnTiKVDiskFullOpt usually makes integration tests run too long. Use a timeout context to speed it up.

Signed-off-by: Yilin Chen <sticnarf@gmail.com>