### PR TITLE
internal/retry: return the longest-sleeping type on backoff timeout

### DIFF
--- a/internal/retry/backoff_test.go
+++ b/internal/retry/backoff_test.go
@@ -49,3 +49,26 @@ func TestBackoffWithMax(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 5, b.totalSleep)
 }
+
+func TestBackoffErrorType(t *testing.T) {
+	// the actual maxSleep is multiplied by weight, which is 400ms
+	b := NewBackofferWithVars(context.TODO(), 200, nil)
+	err := b.Backoff(BoRegionMiss, errors.New("region miss")) // 2ms sleep
+	assert.Nil(t, err)
+	// 300 ms sleep in total
+	for i := 0; i < 2; i++ {
+		err = b.Backoff(BoMaxDataNotReady, errors.New("data not ready"))
+		assert.Nil(t, err)
+	}
+	// sleep from ServerIsBusy is not counted
+	err = b.Backoff(BoTiKVServerBusy, errors.New("server is busy"))
+	assert.Nil(t, err)
+	// 126ms sleep in total
+	for i := 0; i < 6; i++ {
+		err = b.Backoff(BoTxnNotFound, errors.New("txn not found"))
+		assert.Nil(t, err)
+	}
+	// Next backoff should return error of backoff that sleeps for longest time.
+	err = b.Backoff(BoTxnNotFound, errors.New("tikv rpc"))
+	assert.ErrorIs(t, err, BoMaxDataNotReady.err)
+}

--- a/internal/retry/config.go
+++ b/internal/retry/config.go
@@ -128,8 +128,8 @@ var (
 	BoTxnLockFast = NewConfig(txnLockFastName, &metrics.BackoffHistogramLockFast, NewBackoffFnCfg(2, 3000, EqualJitter), tikverr.ErrResolveLockTimeout)
 )
 
-var isSleepExcluded = map[*Config]struct{}{
-	BoTiKVServerBusy: {},
+var isSleepExcluded = map[string]struct{}{
+	BoTiKVServerBusy.name: {},
 	// add BoTiFlashServerBusy if appropriate
 }
 


### PR DESCRIPTION
Closes https://github.com/tikv/client-go/issues/415

Before this PR, when `maxSleep` of a backoff is exceeded, the first error causing the backoff is returned. However, the first error may be just an accidental and temporary error.

For example, the first error can be a `txnLockFast` that is resolved very soon but later backoffs are all `regionMiss`. In this case, we expect the error returned should be "Region is unavailable", but the actual returned error is "resolve lock timeout", which is the error corresponding to `txnLockFast`.

We will encounter the similar problem if we use the last backoff type. The last error may be a temporary error, but most errors that causing the timeout can be something else. Then, the user may receive an unrepresentative error.

So this PR changes to return the error which sleeps for the longest time. Not using the most frequent backoff is because different backoff types have different base and caps. Those errors with shorter base and caps may be much easier to be the most frequent one, but these events may only contributes a small portion to the timeout.