### PR TITLE
txnkv: fix the issue that deleteRange cannot use nil as endkey

### DIFF
--- a/integration_tests/delete_range_test.go
+++ b/integration_tests/delete_range_test.go
@@ -118,7 +118,7 @@ func (s *testDeleteRangeSuite) deleteRange(startKey []byte, endKey []byte) int {
 func deleteRangeFromMap(m map[string]string, startKey []byte, endKey []byte) {
 	for keyStr := range m {
 		key := []byte(keyStr)
-		if bytes.Compare(startKey, key) <= 0 && bytes.Compare(key, endKey) < 0 {
+		if bytes.Compare(startKey, key) <= 0 && (len(endKey) == 0 || bytes.Compare(key, endKey) < 0) {
 			delete(m, keyStr)
 		}
 	}
@@ -160,4 +160,5 @@ func (s *testDeleteRangeSuite) TestDeleteRange() {
 	s.mustDeleteRange([]byte("d0\x00"), []byte("d1\x00"), testData, 1)
 	s.mustDeleteRange([]byte("c5"), []byte("d5"), testData, 2)
 	s.mustDeleteRange([]byte("a"), []byte("z"), testData, 4)
+	s.mustDeleteRange(nil, nil, testData, 4)
 }

--- a/internal/mockstore/mocktikv/mvcc_leveldb.go
+++ b/internal/mockstore/mocktikv/mvcc_leveldb.go
@@ -1538,7 +1538,11 @@ func (mvcc *MVCCLevelDB) GC(startKey, endKey []byte, safePoint uint64) error {
 
 // DeleteRange implements the MVCCStore interface.
 func (mvcc *MVCCLevelDB) DeleteRange(startKey, endKey []byte) error {
-	return mvcc.doRawDeleteRange(codec.EncodeBytes(nil, startKey), codec.EncodeBytes(nil, endKey))
+	var end []byte
+	if len(endKey) > 0 {
+		end = codec.EncodeBytes(nil, endKey)
+	}
+	return mvcc.doRawDeleteRange(codec.EncodeBytes(nil, startKey), end)
 }
 
 // Close calls leveldb's Close to free resources.


### PR DESCRIPTION
See https://github.com/tikv/client-go/issues/428

Note: it only fix the issue on client side. We need to update tikv to resolve it completely.

Signed-off-by: disksing <i@disksing.com>