### PR TITLE
integration: replace some unistore with mockstore

### DIFF
--- a/integration_tests/assertion_test.go
+++ b/integration_tests/assertion_test.go
@@ -43,7 +43,7 @@ type testAssertionSuite struct {
 }
 
 func (s *testAssertionSuite) SetupTest() {
-	s.store = tikv.StoreProbe{KVStore: NewTestStore(s.T())}
+	s.store = tikv.StoreProbe{KVStore: NewTestUniStore(s.T())}
 }
 
 func (s *testAssertionSuite) TearDownTest() {

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -71,7 +71,7 @@ type testLockSuite struct {
 }
 
 func (s *testLockSuite) SetupTest() {
-	s.store = tikv.StoreProbe{KVStore: NewTestStore(s.T())}
+	s.store = tikv.StoreProbe{KVStore: NewTestUniStore(s.T())}
 }
 
 func (s *testLockSuite) TearDownTest() {

--- a/integration_tests/prewrite_test.go
+++ b/integration_tests/prewrite_test.go
@@ -38,9 +38,9 @@ import (
 	"testing"
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 )
@@ -48,9 +48,9 @@ import (
 func TestSetMinCommitTSInAsyncCommit(t *testing.T) {
 	require, assert := require.New(t), assert.New(t)
 
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
 	require.Nil(err)
-	unistore.BootstrapWithSingleStore(cluster)
+	testutils.BootstrapWithSingleStore(cluster)
 	store, err := tikv.NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	require.Nil(err)
 	defer store.Close()

--- a/integration_tests/snapshot_fail_test.go
+++ b/integration_tests/snapshot_fail_test.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/stretchr/testify/suite"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/oracle"
@@ -62,11 +61,7 @@ type testSnapshotFailSuite struct {
 }
 
 func (s *testSnapshotFailSuite) SetupSuite() {
-	client, pdClient, cluster, err := unistore.New("")
-	s.Require().Nil(err)
-	unistore.BootstrapWithSingleStore(cluster)
-	store, err := tikv.NewTestTiKVStore(fpClient{Client: client}, pdClient, nil, nil, 0)
-	s.Require().Nil(err)
+	store := NewTestUniStore(s.T())
 	s.store = tikv.StoreProbe{KVStore: store}
 }
 


### PR DESCRIPTION
add `NewTestUniStore` to create unistore for test. Original `NewTestStore` turns to use mockstore afterwards.
Some features are not supported by mockstore so we use unistore for now.