### PR TITLE
backoff: deep copy the needed fields for backoffer type

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1372,7 +1372,6 @@ func (s *RegionRequestSender) onRegionError(bo *retry.Backoffer, ctx *RPCContext
 	// Retry it when tikv disk full happens.
 	if diskFull := regionErr.GetDiskFull(); diskFull != nil {
 		if err = bo.Backoff(retry.BoTiKVDiskFull, errors.Errorf("tikv disk full: %v ctx: %v", diskFull.String(), ctx.String())); err != nil {
-			retry.BoTiKVDiskFull.SetErrors(errors.Errorf("tikv disk full: %v", diskFull.String()))
 			return false, nil
 		}
 		return true, nil

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -150,10 +150,14 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 				errMsg += "\n" + err.Error()
 			}
 		}
-		errMsg += fmt.Sprintf("\nlongest sleep type: %s, time: %dms", longestSleepCfg.String(), longestSleepTime)
+		returnedErr := err
+		if longestSleepCfg != nil {
+			errMsg += fmt.Sprintf("\nlongest sleep type: %s, time: %dms", longestSleepCfg.String(), longestSleepTime)
+			returnedErr = longestSleepCfg.err
+		}
 		logutil.BgLogger().Warn(errMsg)
 		// Use the backoff type that contributes most to the timeout to generate a MySQL error.
-		return errors.WithStack(longestSleepCfg.err)
+		return errors.WithStack(returnedErr)
 	}
 	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
 	b.configs = append(b.configs, cfg)
@@ -219,32 +223,51 @@ func (b *Backoffer) String() string {
 	return fmt.Sprintf(" backoff(%dms %v)", b.totalSleep, b.configs)
 }
 
+// copyMapWithoutRecursive is only used to deep copy map fields in the Backoffer type.
+func copyMapWithoutRecursive(srcMap map[string]int) map[string]int {
+	result := map[string]int{}
+	for k, v := range srcMap {
+		result[k] = v
+	}
+	return result
+}
+
 // Clone creates a new Backoffer which keeps current Backoffer's sleep time and errors, and shares
 // current Backoffer's context.
+// Some fields like `configs` and `vars` are concurrently used by all the backoffers in different threads,
+// try not to modify the referenced content directly.
 func (b *Backoffer) Clone() *Backoffer {
 	return &Backoffer{
-		ctx:           b.ctx,
-		maxSleep:      b.maxSleep,
-		totalSleep:    b.totalSleep,
-		excludedSleep: b.excludedSleep,
-		errors:        b.errors,
-		vars:          b.vars,
-		parent:        b.parent,
+		ctx:            b.ctx,
+		maxSleep:       b.maxSleep,
+		totalSleep:     b.totalSleep,
+		excludedSleep:  b.excludedSleep,
+		vars:           b.vars,
+		errors:         append([]error{}, b.errors...),
+		configs:        append([]*Config{}, b.configs...),
+		backoffSleepMS: copyMapWithoutRecursive(b.backoffSleepMS),
+		backoffTimes:   copyMapWithoutRecursive(b.backoffTimes),
+		parent:         b.parent,
 	}
 }
 
 // Fork creates a new Backoffer which keeps current Backoffer's sleep time and errors, and holds
 // a child context of current Backoffer's context.
+// Some fields like `configs` and `vars` are concurrently used by all the backoffers in different threads,
+// try not to modify the referenced content directly.
 func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(b.ctx)
 	return &Backoffer{
-		ctx:           ctx,
-		maxSleep:      b.maxSleep,
-		totalSleep:    b.totalSleep,
-		excludedSleep: b.excludedSleep,
-		errors:        b.errors,
-		vars:          b.vars,
-		parent:        b,
+		ctx:            ctx,
+		maxSleep:       b.maxSleep,
+		totalSleep:     b.totalSleep,
+		excludedSleep:  b.excludedSleep,
+		errors:         append([]error{}, b.errors...),
+		configs:        append([]*Config{}, b.configs...),
+		backoffSleepMS: copyMapWithoutRecursive(b.backoffSleepMS),
+		backoffTimes:   copyMapWithoutRecursive(b.backoffTimes),
+		vars:           b.vars,
+		parent:         b,
 	}, cancel
 }
 


### PR DESCRIPTION
Close: https://github.com/pingcap/tidb/issues/33265

Related changes:
- Avoid possible race changing the global backoff type config.
- Check nil before using the `longestSleepCfg` result.
- Copy the `configs`, `backoffSleepMS` and `backoffTimes` fields more deeply but not complete deeply.

The `Backoffer` is not very robust by now and it's easy to make mistakes, maybe we need to open a enhancement task for it in the future to avoid data races and related risks.

Signed-off-by: cfzjywxk <lsswxrxr@163.com>