### PR TITLE
client: fix the race between connArray.Close() and connArray.Get()

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -137,7 +137,7 @@ func newConnArray(maxSize uint, addr string, security config.Security, idleNotif
 func (a *connArray) Init(addr string, security config.Security, idleNotify *uint32, enableBatch bool) error {
 	a.target = addr
 
-	opt := grpc.WithInsecure() //nolint
+	opt := grpc.WithInsecure()
 	if len(security.ClusterSSLCA) != 0 {
 		tlsConfig, err := security.ToTLSConfig()
 		if err != nil {
@@ -238,10 +238,8 @@ func (a *connArray) Close() {
 	}
 
 	for _, c := range a.v {
-		if c != nil {
-			err := c.Close()
-			tikverr.Log(err)
-		}
+		err := c.Close()
+		tikverr.Log(err)
 	}
 
 	close(a.done)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -237,11 +237,10 @@ func (a *connArray) Close() {
 		a.batchConn.Close()
 	}
 
-	for i, c := range a.v {
+	for _, c := range a.v {
 		if c != nil {
 			err := c.Close()
 			tikverr.Log(err)
-			a.v[i] = nil
 		}
 	}
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -80,6 +81,18 @@ func TestConn(t *testing.T) {
 	conn4, err := client.getConnArray(addr, true)
 	assert.NotNil(t, err)
 	assert.Nil(t, conn4)
+}
+
+func TestGetConnAfterClose(t *testing.T) {
+	client := NewRPCClient()
+
+	addr := "127.0.0.1:6379"
+	connArray, err := client.getConnArray(addr, true)
+	assert.Nil(t, err)
+	assert.Nil(t, client.CloseAddr(addr))
+	conn := connArray.Get()
+	state := conn.GetState()
+	assert.True(t, state == connectivity.Shutdown)
 }
 
 func TestCancelTimeoutRetErr(t *testing.T) {

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2347,7 +2347,7 @@ func createKVHealthClient(ctx context.Context, addr string) (*grpc.ClientConn, h
 
 	cfg := config.GetGlobalConfig()
 
-	opt := grpc.WithInsecure() //nolint
+	opt := grpc.WithInsecure()
 	if len(cfg.Security.ClusterSSLCA) != 0 {
 		tlsConfig, err := cfg.Security.ToTLSConfig()
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

Make `v` immutable after initialization.