### PR TITLE
tikv: check nil response of split region

### DIFF
--- a/tikv/split_region.go
+++ b/tikv/split_region.go
@@ -144,6 +144,13 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch kvrpc.Batch, scatte
 		resp.Header.Error = &pdpb.Error{Message: err.Error()}
 		return resp
 	}
+	if resp == nil {
+		return &pdpb.SplitRegionsResponse{
+			Header: &pdpb.ResponseHeader{
+				Error: &pdpb.Error{Message: "empty response"},
+			},
+		}
+	}
 	regionIDs := resp.GetRegionsId()
 	if len(regionIDs) > 0 {
 		// Divide a region into n, one of them may not need to be scattered,


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

This doesn't usually happen, but if it uses the mock version of PD (for example, run tidb with unistore), it may get nil, so it's better to double-check.