### PR TITLE
Fix incorrect LockNoWait value (#435)

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -37,10 +37,11 @@ type ReturnedValue struct {
 
 // Used for pessimistic lock wait time
 // these two constants are special for lock protocol with tikv
-// math.MaxInt64 means always wait, 0 means nowait, others meaning lock wait in milliseconds
+// math.MaxInt64 means always wait, -1 means nowait, 0 means the default wait duration in TiKV,
+// others meaning lock wait in milliseconds
 const (
 	LockAlwaysWait = int64(math.MaxInt64)
-	LockNoWait     = int64(0)
+	LockNoWait     = int64(-1)
 )
 
 type lockWaitTimeInMs struct {


### PR DESCRIPTION
Cherry picks https://github.com/tikv/client-go/pull/435 to tidb-5.3 branch