### PR TITLE
*: fix data race on the SetResourceGroupTagger

### DIFF
--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -119,14 +119,14 @@ func (s *Scanner) Next() error {
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")
 	}
-	s.snapshot.interceptorMutex.RLock()
-	if s.snapshot.interceptor != nil {
+	s.snapshot.mu.RLock()
+	if s.snapshot.mu.interceptor != nil {
 		// User has called snapshot.SetRPCInterceptor() to explicitly set an interceptor, we
 		// need to bind it to ctx so that the internal client can perceive and execute
 		// it before initiating an RPC request.
-		bo.SetCtx(interceptor.WithRPCInterceptor(bo.GetCtx(), s.snapshot.interceptor))
+		bo.SetCtx(interceptor.WithRPCInterceptor(bo.GetCtx(), s.snapshot.mu.interceptor))
 	}
-	s.snapshot.interceptorMutex.RUnlock()
+	s.snapshot.mu.RUnlock()
 	var err error
 	for {
 		s.idx++
@@ -228,7 +228,7 @@ func (s *Scanner) getData(bo *retry.Backoffer) error {
 				Priority:         s.snapshot.priority.ToPB(),
 				NotFillCache:     s.snapshot.notFillCache,
 				IsolationLevel:   s.snapshot.isolationLevel.ToPB(),
-				ResourceGroupTag: s.snapshot.resourceGroupTag,
+				ResourceGroupTag: s.snapshot.mu.resourceGroupTag,
 			},
 			StartKey:   s.nextStartKey,
 			EndKey:     reqEndKey,
@@ -247,11 +247,11 @@ func (s *Scanner) getData(bo *retry.Backoffer) error {
 			Priority:         s.snapshot.priority.ToPB(),
 			NotFillCache:     s.snapshot.notFillCache,
 			TaskId:           s.snapshot.mu.taskID,
-			ResourceGroupTag: s.snapshot.resourceGroupTag,
+			ResourceGroupTag: s.snapshot.mu.resourceGroupTag,
 			IsolationLevel:   s.snapshot.isolationLevel.ToPB(),
 		})
-		if s.snapshot.resourceGroupTag == nil && s.snapshot.resourceGroupTagger != nil {
-			s.snapshot.resourceGroupTagger(req)
+		if s.snapshot.mu.resourceGroupTag == nil && s.snapshot.mu.resourceGroupTagger != nil {
+			s.snapshot.mu.resourceGroupTagger(req)
 		}
 		s.snapshot.mu.RUnlock()
 		resp, err := sender.SendReq(bo, req, loc.Region, client.ReadTimeoutMedium)

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -746,6 +746,8 @@ func (s *KVSnapshot) SetMatchStoreLabels(labels []*metapb.StoreLabel) {
 
 // SetResourceGroupTag sets resource group tag of the kv request.
 func (s *KVSnapshot) SetResourceGroupTag(tag []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.mu.resourceGroupTag = tag
 }
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -755,6 +755,8 @@ func (s *KVSnapshot) SetResourceGroupTag(tag []byte) {
 // Before sending the request, if resourceGroupTag is not nil, use
 // resourceGroupTag directly, otherwise use resourceGroupTagger.
 func (s *KVSnapshot) SetResourceGroupTagger(tagger tikvrpc.ResourceGroupTagger) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.resourceGroupTagger = tagger
 }
 


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

```
==================
WARNING: DATA RACE
Write at 0x00c001ff5c98 by goroutine 80:
  github.com/tikv/client-go/v2/txnkv/txnsnapshot.(*KVSnapshot).SetResourceGroupTagger()
      /home/prow/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.1-0.20220406091203-f73ec0e675f4/txnkv/txnsnapshot/snapshot.go:756 +0x78a
  github.com/pingcap/tidb/store/driver/txn.(*tikvSnapshot).SetOption()
      /go/tidb/store/driver/txn/snapshot.go:119 +0x73c
  github.com/pingcap/tidb/executor.setOptionForTopSQL()
      /go/tidb/executor/executor.go:2016 +0x67
  github.com/pingcap/tidb/executor.(*PointGetExecutor).Open()
      /go/tidb/executor/point_get.go:197 +0x10eb
  github.com/pingcap/tidb/executor.(*baseExecutor).Open()
      /go/tidb/executor/executor.go:186 +0x2ad
  github.com/pingcap/tidb/executor.(*ProjectionExec).Open()
      /go/tidb/executor/projection.go:86 +0x4b
  github.com/pingcap/tidb/executor.(*UnionExec).resultPuller()
      /go/tidb/executor/executor.go:1660 +0x3d4
  github.com/pingcap/tidb/executor.(*UnionExec).initialize.func1()
      /go/tidb/executor/executor.go:1627 +0x64
Previous write at 0x00c001ff5c98 by goroutine 71:
  github.com/tikv/client-go/v2/txnkv/txnsnapshot.(*KVSnapshot).SetResourceGroupTagger()
      /home/prow/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.1-0.20220406091203-f73ec0e675f4/txnkv/txnsnapshot/snapshot.go:756 +0x78a
  github.com/pingcap/tidb/store/driver/txn.(*tikvSnapshot).SetOption()
      /go/tidb/store/driver/txn/snapshot.go:119 +0x73c
  github.com/pingcap/tidb/executor.setOptionForTopSQL()
      /go/tidb/executor/executor.go:2016 +0x67
  github.com/pingcap/tidb/executor.(*PointGetExecutor).Open()
      /go/tidb/executor/point_get.go:197 +0x10eb
  github.com/pingcap/tidb/executor.(*baseExecutor).Open()
      /go/tidb/executor/executor.go:186 +0x2ad
  github.com/pingcap/tidb/executor.(*ProjectionExec).Open()
      /go/tidb/executor/projection.go:86 +0x4b
  github.com/pingcap/tidb/executor.(*UnionExec).resultPuller()
      /go/tidb/executor/executor.go:1660 +0x3d4
  github.com/pingcap/tidb/executor.(*UnionExec).initialize.func1()
      /go/tidb/executor/executor.go:1627 +0x64
Goroutine 80 (running) created at:
  github.com/pingcap/tidb/executor.(*UnionExec).initialize()
      /go/tidb/executor/executor.go:1627 +0x4d0
  github.com/pingcap/tidb/executor.(*UnionExec).Next()
      /go/tidb/executor/executor.go:1703 +0xc4
  github.com/pingcap/tidb/executor.Next()
      /go/tidb/executor/executor.go:306 +0x5af
  github.com/pingcap/tidb/executor.(*HashAggExec).fetchChildData()
      /go/tidb/executor/aggregate.go:791 +0x319
  github.com/pingcap/tidb/executor.(*HashAggExec).prepare4ParallelExec.func3()
      /go/tidb/executor/aggregate.go:828 +0x64
Goroutine 71 (running) created at:
  github.com/pingcap/tidb/executor.(*UnionExec).initialize()
      /go/tidb/executor/executor.go:1627 +0x4d0
  github.com/pingcap/tidb/executor.(*UnionExec).Next()
      /go/tidb/executor/executor.go:1703 +0xc4
  github.com/pingcap/tidb/executor.Next()
      /go/tidb/executor/executor.go:306 +0x5af
  github.com/pingcap/tidb/executor.(*HashAggExec).fetchChildData()
      /go/tidb/executor/aggregate.go:791 +0x319
  github.com/pingcap/tidb/executor.(*HashAggExec).prepare4ParallelExec.func3()
      /go/tidb/executor/aggregate.go:828 +0x64
================== 
```