### PR TITLE
fix the vulnerability of atomicity in async commit

### DIFF
--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -620,9 +620,9 @@ func (s *testAsyncCommitSuite) TestRollbackAsyncCommitEnforcesFallback() {
 	s.True(committer.IsAsyncCommit())
 	lock := s.mustGetLock([]byte("a"))
 	resolver := tikv.NewLockResolverProb(s.store.GetLockResolver())
-	currentTS, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
-	s.Nil(err)
 	for {
+		currentTS, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+		s.Nil(err)
 		status, err := resolver.GetTxnStatus(s.bo, lock.TxnID, []byte("a"), currentTS, currentTS, false, false, nil)
 		s.Nil(err)
 		if status.IsRolledBack() {

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -52,6 +52,7 @@ import (
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/internal/retry"
 	"github.com/tikv/client-go/v2/metrics"
+	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
 	"github.com/tikv/client-go/v2/util"
@@ -107,6 +108,20 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize u
 	}
 
 	ttl := c.lockTTL
+
+	// ref: https://github.com/pingcap/tidb/issues/33641
+	// we make TTL to satisfy the following condition:
+	// 	max_commit_ts.physical < start_ts.physical + TTL < (current_ts of some check_txn_status that wants to resolve this lock).physical
+	// and we have:
+	//  current_ts <= max_ts <= min_commit_ts of this lock
+	// such that
+	// 	max_commit_ts < min_commit_ts, so if this lock is resolved, it will be forced to fall back to normal 2PC, thus resolving the issue.
+	if c.isAsyncCommit() && c.isPessimistic {
+		safeTTL := uint64(oracle.ExtractPhysical(c.maxCommitTS)-oracle.ExtractPhysical(c.startTS)) + 1
+		if safeTTL > ttl {
+			ttl = safeTTL
+		}
+	}
 
 	if c.sessionID > 0 {
 		if _, err := util.EvalFailpoint("twoPCShortLockTTL"); err == nil {

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -110,7 +110,7 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize u
 	ttl := c.lockTTL
 
 	// ref: https://github.com/pingcap/tidb/issues/33641
-	// we make TTL to satisfy the following condition:
+	// we make the TTL satisfy the following condition:
 	// 	max_commit_ts.physical < start_ts.physical + TTL < (current_ts of some check_txn_status that wants to resolve this lock).physical
 	// and we have:
 	//  current_ts <= max_ts <= min_commit_ts of this lock


### PR DESCRIPTION
To fix https://github.com/pingcap/tidb/issues/33641

- For a pessimistic async commit txn, set its TTL to be at least (max commit ts - start ts)