### PR TITLE
region_cache: rename LocateBucketV2 to LocateBucket and let the old LocateBucket be the internal function of the new LocateBucket

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -756,8 +756,8 @@ func (l *KeyLocation) GetBucketVersion() uint64 {
 }
 
 // LocateBucket calls locateBucket and check the result.
-// When the key is in [ KeyLocation.StartKey, first Bucket key ), the result returned by locateBucket will be nil
-// as there's no bucket containing this key. LocateBucket will return Bucket{ KeyLocation.StartKey, first Bucket key }
+// When the key is in [KeyLocation.StartKey, first Bucket key), the result returned by locateBucket will be nil
+// as there's no bucket containing this key. LocateBucket will return Bucket{KeyLocation.StartKey, first Bucket key}
 //  --- it's reasonable to assume that Bucket{KeyLocation.StartKey, first Bucket key} is a bucket belonging to the region.
 // Key in [last Bucket key, KeyLocation.EndKey) is handled similarly.
 func (l *KeyLocation) LocateBucket(key []byte) *Bucket {

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -755,12 +755,12 @@ func (l *KeyLocation) GetBucketVersion() uint64 {
 	return l.Buckets.GetVersion()
 }
 
-// LocateBucketV2 will not return nil if the key is in the region.
-// LocateBucketV2 is similar with LocateBucket. The difference is that when the key is in [KeyLocation.StartKey, first Bucket key)
-// it will return Bucket{KeyLocation.StartKey, first Bucket key} rather than nil --- it's reasonable to assume that
-// Bucket{KeyLocation.StartKey, first Bucket key} is a bucket belonging to the region. Key in [last Bucket key, KeyLocation.EndKey)
-// is handled similarly.
-func (l *KeyLocation) LocateBucketV2(key []byte) *Bucket {
+// LocateBucketMoreRobust is similar to the LocateBucket except for that it will not return nil if the key is in the region.
+// Specifically, when the key is in [ KeyLocation.StartKey, first Bucket key ), LocateBucket will return nil
+// as there's no bucket containing this key.  LocateBucketMoreRobust will return Bucket{ KeyLocation.StartKey, first Bucket key }
+//  --- it's reasonable to assume that Bucket{KeyLocation.StartKey, first Bucket key} is a bucket belonging to the region.
+// Key in [last Bucket key, KeyLocation.EndKey) is handled similarly.
+func (l *KeyLocation) LocateBucketMoreRobust(key []byte) *Bucket {
 	bucket := l.LocateBucket(key)
 	if bucket != nil || !l.Contains(key) {
 		return bucket

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -755,8 +755,7 @@ func (l *KeyLocation) GetBucketVersion() uint64 {
 	return l.Buckets.GetVersion()
 }
 
-// LocateBucket
-// It calls locateBucket and check the result.
+// LocateBucket calls locateBucket and check the result.
 // When the key is in [ KeyLocation.StartKey, first Bucket key ), the result returned by locateBucket will be nil
 // as there's no bucket containing this key. LocateBucket will return Bucket{ KeyLocation.StartKey, first Bucket key }
 //  --- it's reasonable to assume that Bucket{KeyLocation.StartKey, first Bucket key} is a bucket belonging to the region.

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -790,7 +790,7 @@ func (l *KeyLocation) LocateBucket(key []byte) *Bucket {
 	return bucket
 }
 
-// LocateBucket returns the bucket the key is located.
+// locateBucket returns the bucket the key is located.
 func (l *KeyLocation) locateBucket(key []byte) *Bucket {
 	keys := l.Buckets.GetKeys()
 	searchLen := len(keys) - 1

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -755,13 +755,14 @@ func (l *KeyLocation) GetBucketVersion() uint64 {
 	return l.Buckets.GetVersion()
 }
 
-// LocateBucketMoreRobust is similar to the LocateBucket except for that it will not return nil if the key is in the region.
-// Specifically, when the key is in [ KeyLocation.StartKey, first Bucket key ), LocateBucket will return nil
-// as there's no bucket containing this key.  LocateBucketMoreRobust will return Bucket{ KeyLocation.StartKey, first Bucket key }
+// LocateBucket
+// It calls locateBucket and check the result.
+// When the key is in [ KeyLocation.StartKey, first Bucket key ), the result returned by locateBucket will be nil
+// as there's no bucket containing this key. LocateBucket will return Bucket{ KeyLocation.StartKey, first Bucket key }
 //  --- it's reasonable to assume that Bucket{KeyLocation.StartKey, first Bucket key} is a bucket belonging to the region.
 // Key in [last Bucket key, KeyLocation.EndKey) is handled similarly.
-func (l *KeyLocation) LocateBucketMoreRobust(key []byte) *Bucket {
-	bucket := l.LocateBucket(key)
+func (l *KeyLocation) LocateBucket(key []byte) *Bucket {
+	bucket := l.locateBucket(key)
 	if bucket != nil || !l.Contains(key) {
 		return bucket
 	}
@@ -790,7 +791,7 @@ func (l *KeyLocation) LocateBucketMoreRobust(key []byte) *Bucket {
 }
 
 // LocateBucket returns the bucket the key is located.
-func (l *KeyLocation) LocateBucket(key []byte) *Bucket {
+func (l *KeyLocation) locateBucket(key []byte) *Bucket {
 	keys := l.Buckets.GetKeys()
 	searchLen := len(keys) - 1
 	i := sort.Search(searchLen, func(i int) bool {

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -1506,7 +1506,7 @@ func (s *testRegionCacheSuite) TestBuckets() {
 	waitUpdateBuckets(newBuckets, []byte("a"))
 }
 
-func (s *testRegionCacheSuite) TestLocateBucketV2() {
+func (s *testRegionCacheSuite) TestLocateBucketMoreRobust() {
 	// proto.Clone clones []byte{} to nil and [][]byte{nil or []byte{}} to [][]byte{[]byte{}}.
 	// nilToEmtpyBytes unifies it for tests.
 	nilToEmtpyBytes := func(s []byte) []byte {
@@ -1544,7 +1544,7 @@ func (s *testRegionCacheSuite) TestLocateBucketV2() {
 	for _, key := range [][]byte{{'a' - 1}, []byte("c")} {
 		b := loc.LocateBucket(key)
 		s.Nil(b)
-		b = loc.LocateBucketV2(key)
+		b = loc.LocateBucketMoreRobust(key)
 		s.NotNil(b)
 		s.True(b.Contains(key))
 	}

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -1411,14 +1411,14 @@ func (s *testRegionCacheSuite) TestBuckets() {
 	buckets := cachedRegion.getStore().buckets
 	s.Equal(defaultBuckets, buckets)
 
-	// test LocateBucket
+	// test locateBucket
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	s.NotNil(loc)
 	s.Nil(err)
 	s.Equal(buckets, loc.Buckets)
 	s.Equal(buckets.GetVersion(), loc.GetBucketVersion())
 	for _, key := range [][]byte{{}, {'a' - 1}, []byte("a"), []byte("a0"), []byte("b"), []byte("c")} {
-		b := loc.LocateBucket(key)
+		b := loc.locateBucket(key)
 		s.NotNil(b)
 		s.True(b.Contains(key))
 	}
@@ -1426,7 +1426,7 @@ func (s *testRegionCacheSuite) TestBuckets() {
 	loc.Buckets = proto.Clone(loc.Buckets).(*metapb.Buckets)
 	loc.Buckets.Keys = [][]byte{[]byte("b"), []byte("c"), []byte("d")}
 	for _, key := range [][]byte{[]byte("a"), []byte("d"), []byte("e")} {
-		b := loc.LocateBucket(key)
+		b := loc.locateBucket(key)
 		s.Nil(b)
 	}
 
@@ -1506,7 +1506,7 @@ func (s *testRegionCacheSuite) TestBuckets() {
 	waitUpdateBuckets(newBuckets, []byte("a"))
 }
 
-func (s *testRegionCacheSuite) TestLocateBucketMoreRobust() {
+func (s *testRegionCacheSuite) TestLocateBucket() {
 	// proto.Clone clones []byte{} to nil and [][]byte{nil or []byte{}} to [][]byte{[]byte{}}.
 	// nilToEmtpyBytes unifies it for tests.
 	nilToEmtpyBytes := func(s []byte) []byte {
@@ -1525,7 +1525,7 @@ func (s *testRegionCacheSuite) TestLocateBucketMoreRobust() {
 	s.NotNil(loc)
 	s.Nil(err)
 	for _, key := range [][]byte{{}, {'a' - 1}, []byte("a"), []byte("a0"), []byte("b"), []byte("c")} {
-		b := loc.LocateBucket(key)
+		b := loc.locateBucket(key)
 		s.NotNil(b)
 		s.True(b.Contains(key))
 	}
@@ -1542,9 +1542,9 @@ func (s *testRegionCacheSuite) TestLocateBucketMoreRobust() {
 	s.NotNil(loc)
 	s.Nil(err)
 	for _, key := range [][]byte{{'a' - 1}, []byte("c")} {
-		b := loc.LocateBucket(key)
+		b := loc.locateBucket(key)
 		s.Nil(b)
-		b = loc.LocateBucketMoreRobust(key)
+		b = loc.LocateBucket(key)
 		s.NotNil(b)
 		s.True(b.Contains(key))
 	}


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>