### PR TITLE
Fix incorrect clear of resolving array

### DIFF
--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -369,7 +369,7 @@ func (lr *LockResolver) UpdateResolvingLocks(locks []*Lock, callerStartTS uint64
 // ResolveLocksDone will remove resolving locks information related with callerStartTS
 func (lr *LockResolver) ResolveLocksDone(callerStartTS uint64, token int) {
 	lr.mu.Lock()
-	lr.mu.resolving[callerStartTS] = nil
+	lr.mu.resolving[callerStartTS][token] = nil
 	lr.mu.resolvingConcurrency[callerStartTS]--
 	if lr.mu.resolvingConcurrency[callerStartTS] == 0 {
 		delete(lr.mu.resolving, callerStartTS)


### PR DESCRIPTION
`ResolveLocksDone` incorrectly clear all arrays in `resolving[callerStartTS]`. It will cause panic when `UpdateResolvingLocks` updates resolving.