### PR TITLE
client: fix nil dereference when closing conns

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -239,8 +239,10 @@ func (a *connArray) Close() {
 	}
 
 	for _, c := range a.v {
-		err := c.Close()
-		tikverr.Log(err)
+		if c != nil {
+			err := c.Close()
+			tikverr.Log(err)
+		}
 	}
 
 	close(a.done)


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

Introduced by https://github.com/tikv/client-go/issues/464. Connections can be nil if fails to connect some stores.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1a39f6b]

goroutine 47779631 [running]:
google.golang.org/grpc.(*ClientConn).Close(0x0)
	/go/pkg/mod/google.golang.org/grpc@v1.44.0/clientconn.go:1059 +0x4b
github.com/tikv/client-go/v2/internal/client.(*connArray).Close(0xc326b88140)
	/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.1-0.20220530055857-75d3f86f3ba8/internal/client/client.go:242 +0x56
github.com/tikv/client-go/v2/internal/client.(*connArray).Init(0xc326b88140, {0xc001cd8978, 0x12}, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, ...}}, ...)
	/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.1-0.20220530055857-75d3f86f3ba8/internal/client/client.go:202 +0xee6
```