### PR TITLE
[tidb-6.1] retry: make backoff more reasonable for DataNotReady (#550)

### DIFF
--- a/internal/retry/backoff_test.go
+++ b/internal/retry/backoff_test.go
@@ -52,10 +52,10 @@ func TestBackoffWithMax(t *testing.T) {
 
 func TestBackoffErrorType(t *testing.T) {
 	// the actual maxSleep is multiplied by weight, which is 480ms
-	b := NewBackofferWithVars(context.TODO(), 250, nil)
+	b := NewBackofferWithVars(context.TODO(), 210, nil)
 	err := b.Backoff(BoRegionMiss, errors.New("region miss")) // 2ms sleep
 	assert.Nil(t, err)
-	// 300ms sleep at most in total
+	// 6ms sleep at most in total
 	for i := 0; i < 2; i++ {
 		err = b.Backoff(BoMaxDataNotReady, errors.New("data not ready"))
 		assert.Nil(t, err)
@@ -72,7 +72,7 @@ func TestBackoffErrorType(t *testing.T) {
 		err = b.Backoff(BoTxnNotFound, errors.New("txn not found"))
 		if err != nil {
 			// Next backoff should return error of backoff that sleeps for longest time.
-			assert.ErrorIs(t, err, BoMaxDataNotReady.err)
+			assert.ErrorIs(t, err, BoTxnNotFound.err)
 			return
 		}
 	}
@@ -81,7 +81,7 @@ func TestBackoffErrorType(t *testing.T) {
 
 func TestBackoffDeepCopy(t *testing.T) {
 	var err error
-	b := NewBackofferWithVars(context.TODO(), 200, nil)
+	b := NewBackofferWithVars(context.TODO(), 4, nil)
 	// 700 ms sleep in total and the backoffer will return an error next time.
 	for i := 0; i < 3; i++ {
 		err = b.Backoff(BoMaxDataNotReady, errors.New("data not ready"))

--- a/internal/retry/config.go
+++ b/internal/retry/config.go
@@ -123,7 +123,7 @@ var (
 	BoTxnNotFound              = NewConfig("txnNotFound", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrResolveLockTimeout)
 	BoStaleCmd                 = NewConfig("staleCommand", &metrics.BackoffHistogramStaleCmd, NewBackoffFnCfg(2, 1000, NoJitter), tikverr.ErrTiKVStaleCommand)
 	BoMaxTsNotSynced           = NewConfig("maxTsNotSynced", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrTiKVMaxTimestampNotSynced)
-	BoMaxDataNotReady          = NewConfig("dataNotReady", &metrics.BackoffHistogramDataNotReady, NewBackoffFnCfg(100, 2000, NoJitter), tikverr.ErrRegionDataNotReady)
+	BoMaxDataNotReady          = NewConfig("dataNotReady", &metrics.BackoffHistogramDataNotReady, NewBackoffFnCfg(2, 2000, NoJitter), tikverr.ErrRegionDataNotReady)
 	BoMaxRegionNotInitialized  = NewConfig("regionNotInitialized", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 1000, NoJitter), tikverr.ErrRegionNotInitialized)
 	// TxnLockFast's `base` load from vars.BackoffLockFast when create BackoffFn.
 	BoTxnLockFast = NewConfig(txnLockFastName, &metrics.BackoffHistogramLockFast, NewBackoffFnCfg(2, 3000, EqualJitter), tikverr.ErrResolveLockTimeout)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>
pick #550 