### PR TITLE
Do not format error when response does not include ExecDetailsV2

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -437,8 +437,8 @@ func (c *RPCClient) updateTiKVSendReqHistogram(req *tikvrpc.Request, resp *tikvr
 	counter.(sendReqCounterCacheValue).counter.Inc()
 	counter.(sendReqCounterCacheValue).timeCounter.Add(secs)
 
-	if execDetail, err := resp.GetExecDetailsV2(); err == nil &&
-		execDetail != nil && execDetail.TimeDetail != nil && execDetail.TimeDetail.TotalRpcWallTimeNs > 0 {
+	if execDetail := resp.GetExecDetailsV2(); execDetail != nil &&
+		execDetail.TimeDetail != nil && execDetail.TimeDetail.TotalRpcWallTimeNs > 0 {
 		latHist, ok := rpcNetLatencyHistCache.Load(storeID)
 		if !ok {
 			if len(storeIDStr) == 0 {

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -931,18 +931,15 @@ type getExecDetailsV2 interface {
 }
 
 // GetExecDetailsV2 returns the ExecDetailsV2 of the underlying concrete response.
-func (resp *Response) GetExecDetailsV2() (*kvrpcpb.ExecDetailsV2, error) {
+func (resp *Response) GetExecDetailsV2() *kvrpcpb.ExecDetailsV2 {
 	if resp == nil || resp.Resp == nil {
-		return nil, nil
+		return nil
 	}
 	details, ok := resp.Resp.(getExecDetailsV2)
 	if !ok {
-		if _, isEmpty := resp.Resp.(*tikvpb.BatchCommandsEmptyResponse); isEmpty {
-			return nil, nil
-		}
-		return nil, errors.Errorf("invalid response type %v", resp)
+		return nil
 	}
-	return details.GetExecDetailsV2(), nil
+	return details.GetExecDetailsV2()
 }
 
 // CallRPC launches a rpc call.


### PR DESCRIPTION
When a response does not include `ExecDetailsV2`, `GetExecDetailsV2` will return an error. It formats a string to generate the error. It is useless but may cost much resource. Let's just don't produce that error.

![origin_img_v2_661cf42e-a8b0-434c-9c5b-82b8c94faabg](https://user-images.githubusercontent.com/17217495/179942645-bbc8b385-9b8d-422c-8764-425e93b11a2d.jpg)
