### PR TITLE
support adding `ExecDetailsV2` to tracing

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -483,7 +483,7 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		}
 		c.updateTiKVSendReqHistogram(req, resp, start, staleRead)
 
-		if spanRPC != nil && util.TraceExecEnabled(ctx) {
+		if spanRPC != nil && util.TraceExecDetailsEnabled(ctx) {
 			traceExecDetails(spanRPC, start, resp)
 		}
 	}()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -493,8 +493,7 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	if config.GetGlobalConfig().TiKVClient.MaxBatchSize > 0 && enableBatch {
 		if batchReq := req.ToBatchCommandsRequest(); batchReq != nil {
 			defer trace.StartRegion(ctx, req.Type.String()).End()
-			resp, err = sendBatchRequest(ctx, addr, req.ForwardedHost, connArray.batchConn, batchReq, timeout)
-			return
+			return sendBatchRequest(ctx, addr, req.ForwardedHost, connArray.batchConn, batchReq, timeout)
 		}
 	}
 
@@ -508,8 +507,7 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		client := debugpb.NewDebugClient(clientConn)
 		ctx1, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		resp, err = tikvrpc.CallDebugRPC(ctx1, client, req)
-		return
+		return tikvrpc.CallDebugRPC(ctx1, client, req)
 	}
 
 	client := tikvpb.NewTikvClient(clientConn)
@@ -520,20 +518,16 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	}
 	switch req.Type {
 	case tikvrpc.CmdBatchCop:
-		resp, err = c.getBatchCopStreamResponse(ctx, client, req, timeout, connArray)
-		return
+		return c.getBatchCopStreamResponse(ctx, client, req, timeout, connArray)
 	case tikvrpc.CmdCopStream:
-		resp, err = c.getCopStreamResponse(ctx, client, req, timeout, connArray)
-		return
+		return c.getCopStreamResponse(ctx, client, req, timeout, connArray)
 	case tikvrpc.CmdMPPConn:
-		resp, err = c.getMPPStreamResponse(ctx, client, req, timeout, connArray)
-		return
+		return c.getMPPStreamResponse(ctx, client, req, timeout, connArray)
 	}
 	// Or else it's a unary call.
 	ctx1, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	resp, err = tikvrpc.CallRPC(ctx1, client, req)
-	return
+	return tikvrpc.CallRPC(ctx1, client, req)
 }
 
 // SendRequest sends a Request to server and receives Response.

--- a/internal/mockstore/mocktikv/cluster.go
+++ b/internal/mockstore/mocktikv/cluster.go
@@ -42,7 +42,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto" //nolint
+	"github.com/golang/protobuf/proto" //nolint:staticcheck
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/client-go/v2/internal/mockstore/cluster"

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -70,8 +70,8 @@ func ContextWithTraceExecDetails(ctx context.Context) context.Context {
 	return context.WithValue(ctx, traceExecDetailsKey, struct{}{})
 }
 
-// TraceExecEnabled checks whether trace-exec-details enabled
-func TraceExecEnabled(ctx context.Context) bool {
+// TraceExecDetailsEnabled checks whether trace-exec-details enabled
+func TraceExecDetailsEnabled(ctx context.Context) bool {
 	return ctx.Value(traceExecDetailsKey) != nil
 }
 

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -36,6 +36,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"strconv"
 	"sync"
@@ -48,6 +49,7 @@ import (
 type commitDetailCtxKeyType struct{}
 type lockKeysDetailCtxKeyType struct{}
 type execDetailsCtxKeyType struct{}
+type traceExecDetailsCtxKeyType struct{}
 
 var (
 	// CommitDetailCtxKey presents CommitDetail info key in context.
@@ -58,7 +60,20 @@ var (
 
 	// ExecDetailsKey presents ExecDetail info key in context.
 	ExecDetailsKey = execDetailsCtxKeyType{}
+
+	// traceExecDetailsKey is a context key whose value indicates whether to add ExecDetails to trace.
+	traceExecDetailsKey = traceExecDetailsCtxKeyType{}
 )
+
+// ContextWithTraceExecDetails returns a context with trace-exec-details enabled
+func ContextWithTraceExecDetails(ctx context.Context) context.Context {
+	return context.WithValue(ctx, traceExecDetailsKey, struct{}{})
+}
+
+// TraceExecEnabled checks whether trace-exec-details enabled
+func TraceExecEnabled(ctx context.Context) bool {
+	return ctx.Value(traceExecDetailsKey) != nil
+}
 
 // TiKVExecDetails is the detail execution information at TiKV side.
 type TiKVExecDetails struct {


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

In order to show `ExecDetailsV2` in the [trace statement](https://docs.pingcap.com/tidb/dev/sql-statement-trace), we have to convert the struct to spans of opentracing. This PR add the ability to do it.

<details>
<summary>Here is an example.</summary>

```sql
/* a */ drop table if exists t;
-- a >> 0 rows affected
/* a */ create table t (a int, b int, primary key(a), key sk(b));
-- a >> 0 rows affected
/* a */ insert into t values (1, 10), (5, 50);
-- a >> 2 rows affected
/* a:query */ trace select * from t where b < 100;
-- a >> +------------------------------------------------------------+-----------------+------------+
-- a    |                         operation                          |     startTS     |  duration  |
-- a    +------------------------------------------------------------+-----------------+------------+
-- a    | trace                                                      | 17:08:50.470834 | 2.061809ms |
-- a    |   ├─session.ExecuteStmt                                    | 17:08:50.470840 | 727.421µs  |
-- a    |   │ ├─executor.Compile                                     | 17:08:50.470856 | 454.383µs  |
-- a    |   │ └─session.runStmt                                      | 17:08:50.471333 | 205.569µs  |
-- a    |   │   └─distsql.Select                                     | 17:08:50.471448 | 45.941µs   |
-- a    |   │     └─regionRequest.SendReqCtx                         | 17:08:50.471649 | 1.122398ms |
-- a    |   │       └─rpcClient.SendRequest, region ID: 2, type: Cop | 17:08:50.471674 | 1.078549ms |
-- a    |   │         └─tikv.RPC                                     | 17:08:50.471677 | 406.226µs  |
-- a    |   │           └─tikv.Wait                                  | 17:08:50.471677 | 35.375µs   |
-- a    |   │             └─tikv.GetSnapshot                         | 17:08:50.471677 | 35.375µs   |
-- a    |   ├─*executor.IndexReaderExecutor.Next                     | 17:08:50.471583 | 1.266974ms |
-- a    |   └─*executor.IndexReaderExecutor.Next                     | 17:08:50.472861 | 2.676µs    |
-- a    +------------------------------------------------------------+-----------------+------------+
/* a:query */ trace update t set a = a+10, b = b+100 where a > 0; 
-- a >> +-----------------------------------------------------------------------+-----------------+------------+
-- a    |                               operation                               |     startTS     |  duration  |
-- a    +-----------------------------------------------------------------------+-----------------+------------+
-- a    | trace                                                                 | 17:08:50.518808 | 5.875638ms |
-- a    |   └─session.ExecuteStmt                                               | 17:08:50.518814 | 5.841205ms |
-- a    |     ├─executor.Compile                                                | 17:08:50.518831 | 323.468µs  |
-- a    |     └─session.runStmt                                                 | 17:08:50.519178 | 5.461207ms |
-- a    |       ├─TableReaderExecutor.Open                                      | 17:08:50.519280 | 77.151µs   |
-- a    |       │ └─distsql.Select                                              | 17:08:50.519298 | 48.703µs   |
-- a    |       │   └─regionRequest.SendReqCtx                                  | 17:08:50.519477 | 1.039391ms |
-- a    |       │     └─rpcClient.SendRequest, region ID: 2, type: Cop          | 17:08:50.519497 | 970.776µs  |
-- a    |       │       └─tikv.RPC                                              | 17:08:50.519499 | 382.585µs  |
-- a    |       │         └─tikv.Wait                                           | 17:08:50.519499 | 32.789µs   |
-- a    |       │           └─tikv.GetSnapshot                                  | 17:08:50.519499 | 32.789µs   |
-- a    |       ├─executor.handleNoDelayExecutor                                | 17:08:50.519400 | 2.850728ms |
-- a    |       │ └─*executor.UpdateExec.Next                                   | 17:08:50.519404 | 2.82959ms  |
-- a    |       │   ├─*executor.TableReaderExecutor.Next                        | 17:08:50.519413 | 1.171011ms |
-- a    |       │   ├─executor.updateRecord                                     | 17:08:50.520616 | 827.476µs  |
-- a    |       │   │ └─table.AddRecord                                         | 17:08:50.520677 | 758.839µs  |
-- a    |       │   │   ├─tikvSnapshot.get                                      | 17:08:50.520692 | 715.601µs  |
-- a    |       │   │   └─regionRequest.SendReqCtx                              | 17:08:50.520699 | 670.142µs  |
-- a    |       │   │     └─rpcClient.SendRequest, region ID: 2, type: Get      | 17:08:50.520709 | 647.845µs  |
-- a    |       │   │       └─tikv.RPC                                          | 17:08:50.520710 | 227.137µs  |
-- a    |       │   │         └─tikv.Wait                                       | 17:08:50.520710 | 21.354µs   |
-- a    |       │   │           └─tikv.GetSnapshot                              | 17:08:50.520710 | 21.354µs   |
-- a    |       │   ├─executor.updateRecord                                     | 17:08:50.521460 | 695.629µs  |
-- a    |       │   │ └─table.AddRecord                                         | 17:08:50.521474 | 674.012µs  |
-- a    |       │   │   ├─tikvSnapshot.get                                      | 17:08:50.521484 | 637.735µs  |
-- a    |       │   │   └─regionRequest.SendReqCtx                              | 17:08:50.521494 | 616.441µs  |
-- a    |       │   │     └─rpcClient.SendRequest, region ID: 2, type: Get      | 17:08:50.521503 | 592.414µs  |
-- a    |       │   │       └─tikv.RPC                                          | 17:08:50.521504 | 158.352µs  |
-- a    |       │   │         └─tikv.Wait                                       | 17:08:50.521504 | 19.715µs   |
-- a    |       │   │           └─tikv.GetSnapshot                              | 17:08:50.521504 | 19.715µs   |
-- a    |       │   └─*executor.TableReaderExecutor.Next                        | 17:08:50.522198 | 13.537µs   |
-- a    |       └─session.CommitTxn                                             | 17:08:50.522263 | 2.35599ms  |
-- a    |         └─session.doCommitWitRetry                                    | 17:08:50.522266 | 2.344049ms |
-- a    |           └─tikvTxn.Commit                                            | 17:08:50.522278 | 2.314455ms |
-- a    |             └─twoPhaseCommitter.prewriteMutations                     | 17:08:50.522295 | 2.277919ms |
-- a    |               └─regionRequest.SendReqCtx                              | 17:08:50.522311 | 2.24855ms  |
-- a    |                 └─rpcClient.SendRequest, region ID: 2, type: Prewrite | 17:08:50.522320 | 2.226142ms |
-- a    |                   └─tikv.RPC                                          | 17:08:50.522321 | 1.560567ms |
-- a    |                     ├─tikv.Wait                                       | 17:08:50.522321 | 19.363µs   |
-- a    |                     │ └─tikv.GetSnapshot                              | 17:08:50.522321 | 19.363µs   |
-- a    |                     └─tikv.AsyncWrite                                 | 17:08:50.522340 | 987.634µs  |
-- a    |                       ├─tikv.StoreBatchWait                           | 17:08:50.522340 | 64.35µs    |
-- a    |                       ├─tikv.PersistLog                               | 17:08:50.522405 | 589.398µs  |
-- a    |                       │ ├─tikv.RaftDBWriteWait                        | 17:08:50.522405 | 205ns      |
-- a    |                       │ ├─tikv.RaftDBWriteWAL                         | 17:08:50.522405 | 539.524µs  |
-- a    |                       │ └─tikv.RaftDBWriteMemtable                    | 17:08:50.522944 | 4.425µs    |
-- a    |                       ├─tikv.CommitLog                                | 17:08:50.522405 | 623.559µs  |
-- a    |                       ├─tikv.ApplyBatchWait                           | 17:08:50.523028 | 79.677µs   |
-- a    |                       └─tikv.ApplyLog                                 | 17:08:50.523108 | 220.048µs  |
-- a    |                         ├─tikv.ApplyMutexLock                         | 17:08:50.523108 | 268ns      |
-- a    |                         ├─tikv.ApplyWriteWAL                          | 17:08:50.523108 | 79.677µs   |
-- a    |                         └─tikv.ApplyWriteMemtable                     | 17:08:50.523188 | 97.938µs   |
-- a    +-----------------------------------------------------------------------+-----------------+------------+
/* a */ begin;
-- a >> 0 rows affected
/* b */ begin;
-- b >> 0 rows affected
/* b */ select * from t where a = 2 for update;
-- b >> +---+---+
-- b    | a | b |
-- b    +---+---+
-- b    +---+---+
/* a:query */ trace insert into t values (2, 2); 
-- a >> blocked
/* b */ commit;
-- b >> 0 rows affected
-- a >> resumed
-- a >> +--------------------------------------------------------------------------+-----------------+--------------+
-- a    |                                operation                                 |     startTS     |   duration   |
-- a    +--------------------------------------------------------------------------+-----------------+--------------+
-- a    | trace                                                                    | 17:08:50.702909 | 2.004659737s |
-- a    |   └─session.ExecuteStmt                                                  | 17:08:50.702915 | 2.004644455s |
-- a    |     ├─executor.Compile                                                   | 17:08:50.702931 | 48.948µs     |
-- a    |     └─session.runStmt                                                    | 17:08:50.703000 | 2.004533913s |
-- a    |       ├─executor.handleNoDelayExecutor                                   | 17:08:50.703027 | 98.154µs     |
-- a    |       │ └─*executor.InsertExec.Next                                      | 17:08:50.703030 | 83.492µs     |
-- a    |       │   └─table.AddRecord                                              | 17:08:50.703054 | 50.416µs     |
-- a    |       ├─regionRequest.SendReqCtx                                         | 17:08:50.703161 | 1.002458857s |
-- a    |       │ ├─rpcClient.SendRequest, region ID: 2, type: PessimisticLock     | 17:08:50.703175 | 1.00241369s  |
-- a    |       │ │ └─tikv.RPC                                                     | 17:08:50.703176 | 1.001523057s |
-- a    |       │ └─regionRequest.SendReqCtx                                       | 17:08:51.705668 | 928.119µs    |
-- a    |       │   ├─rpcClient.SendRequest, region ID: 2, type: CheckTxnStatus    | 17:08:51.705700 | 880.716µs    |
-- a    |       │   │ └─tikv.RPC                                                   | 17:08:51.705703 | 353.76µs     |
-- a    |       │   └─regionRequest.SendReqCtx                                     | 17:08:51.706613 | 998.936651ms |
-- a    |       │     └─rpcClient.SendRequest, region ID: 2, type: PessimisticLock | 17:08:51.706623 | 998.88378ms  |
-- a    |       │       └─tikv.RPC                                                 | 17:08:51.706624 | 998.288998ms |
-- a    |       ├─executor.handleNoDelayExecutor                                   | 17:08:52.706078 | 200.928µs    |
-- a    |       │ └─*executor.InsertExec.Next                                      | 17:08:52.706087 | 148.948µs    |
-- a    |       │   └─table.AddRecord                                              | 17:08:52.706154 | 57.245µs     |
-- a    |       └─regionRequest.SendReqCtx                                         | 17:08:52.706323 | 786.595µs    |
-- a    |         └─rpcClient.SendRequest, region ID: 2, type: PessimisticLock     | 17:08:52.706346 | 743.883µs    |
-- a    |           └─tikv.RPC                                                     | 17:08:52.706347 | 244.309µs    |
-- a    |             └─tikv.Wait                                                  | 17:08:52.706347 | 16.798µs     |
-- a    |               └─tikv.GetSnapshot                                         | 17:08:52.706347 | 16.798µs     |
-- a    +--------------------------------------------------------------------------+-----------------+--------------+
```

</details>