### PR TITLE
Fix that histogram is not inserted into rpcNetLatencyHistCache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,6 @@ jobs:
 
       - name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          version: v1.47.3
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -446,7 +446,7 @@ func (c *RPCClient) updateTiKVSendReqHistogram(req *tikvrpc.Request, resp *tikvr
 				storeIDStr = strconv.FormatUint(storeID, 10)
 			}
 			latHist = metrics.TiKVRPCNetLatencyHistogram.WithLabelValues(storeIDStr)
-			sendReqHistCache.Store(storeID, latHist)
+			rpcNetLatencyHistCache.Store(storeID, latHist)
 		}
 		latency := elapsed - time.Duration(execDetail.TimeDetail.TotalRpcWallTimeNs)*time.Nanosecond
 		latHist.(prometheus.Observer).Observe(latency.Seconds())


### PR DESCRIPTION
`latHist` should be inserted into `rpcNetLatencyHistCache` while we inserted it into `sendReqHistCache` due to a code-paste mistake.