### PR TITLE
update dependency of integration test

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20220423142525-ae43b7f4e5c3
 	github.com/pingcap/kvproto v0.0.0-20220804022843-f006036b1277
-	github.com/pingcap/tidb v1.1.0-beta.0.20220724090709-5484002f1963
+	github.com/pingcap/tidb v1.1.0-beta.0.20220824151221-29b57e356929
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/gjson v1.14.1
-	github.com/tikv/client-go/v2 v2.0.1-0.20220815094724-025596b7a20a
+	github.com/tikv/client-go/v2 v2.0.1-0.20220818084834-0d0ae0dcfb1f
 	github.com/tikv/pd/client v0.0.0-20220725055910-7187a7ab72db
 	go.uber.org/goleak v1.1.12
 )
@@ -87,5 +87,3 @@ require (
 )
 
 replace github.com/tikv/client-go/v2 => ../
-
-replace github.com/pingcap/tidb => github.com/cfzjywxk/tidb v1.1.0-beta.0.20220818072433-0272d5dcb987

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -317,6 +317,8 @@ github.com/pingcap/log v0.0.0-20211215031037-e024ba4eb0ee/go.mod h1:DWQW5jICDR7U
 github.com/pingcap/log v1.1.0 h1:ELiPxACz7vdo1qAvvaWJg1NrYFoY6gqAh/+Uo6aXdD8=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4 h1:HYbcxtnkN3s5tqrZ/z3eJS4j3Db8wMphEm1q10lY/TM=
+github.com/pingcap/tidb v1.1.0-beta.0.20220824151221-29b57e356929 h1:QDwyoUCZuIiw1mHDrmbOykbzS8/lkEzLGeDJsnsU0BY=
+github.com/pingcap/tidb v1.1.0-beta.0.20220824151221-29b57e356929/go.mod h1:ibrqg2O6i98YbT6al8tpoz824bcHQlQKyV7VxpC1RH0=
 github.com/pingcap/tidb/parser v0.0.0-20220724090709-5484002f1963 h1:tklVQTGqsCkx531sxFNUQ8sFWicgPSczpESZbF9uEwE=
 github.com/pingcap/tidb/parser v0.0.0-20220724090709-5484002f1963/go.mod h1:wjvp+T3/T9XYt0nKqGX3Kc1AKuyUcfno6LTc6b2A6ew=
 github.com/pingcap/tipb v0.0.0-20220718022156-3e2483c20a9e h1:FBaTXU8C3xgt/drM58VHxojHo/QoG1oPsgWTGvaSpO4=


### PR DESCRIPTION
Signed-off-by: cfzjywxk <lsswxrxr@163.com>

Change back the tidb dependency in the integration test as it's temporarily changed in https://github.com/tikv/client-go/pull/567.