### PR TITLE
extend the scope of using lock_only_if_exists 

### DIFF
--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -93,7 +93,7 @@ func (txn TxnProbe) GetStartTime() time.Time {
 }
 
 // GetLcokedCount is used for testcase
-func (txn TxnProbe) GetLcokedCount() int {
+func (txn TxnProbe) GetLockedCount() int {
 	return txn.lockedCnt
 }
 

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -92,7 +92,7 @@ func (txn TxnProbe) GetStartTime() time.Time {
 	return txn.startTime
 }
 
-// GetLockedCount is used for testcase
+// GetLockedCount returns the count of locks acquired by the transaction
 func (txn TxnProbe) GetLockedCount() int {
 	return txn.lockedCnt
 }

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -92,7 +92,7 @@ func (txn TxnProbe) GetStartTime() time.Time {
 	return txn.startTime
 }
 
-// GetLcokedCount is used for testcase
+// GetLockedCount is used for testcase
 func (txn TxnProbe) GetLockedCount() int {
 	return txn.lockedCnt
 }

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -763,8 +763,12 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 			checkedExistence = true
 		}
 	}
-	if assignedPrimaryKey && lockCtx.LockOnlyIfExists && len(keys) == 1 {
-		txn.unsetPrimaryKeyIfNeed(lockCtx)
+	if assignedPrimaryKey && lockCtx.LockOnlyIfExists {
+		if len(keys) != 1 {
+			panic("When using the LockOnlyIfExists mode to lock keys, if one of the keys is selected as " +
+				"the primary key, the number of input keys must be one.")
+		}
+		txn.unsetPrimaryKeyIfNeeded(lockCtx)
 	}
 	skipedLockKeys := 0
 	for _, key := range keys {
@@ -792,22 +796,20 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 	return nil
 }
 
-// unsetPrimaryKeyIfNeed is used to unset pk of the transaction after performing LockOnlyIfExists.
+// unsetPrimaryKeyIfNeed is used to unset primary key of the transaction after performing LockOnlyIfExists.
 // When locking only one key with LockOnlyIfExists flag, the key will be selected as primary if
 // it's the first lock of the transaction. If the key doesn't exist on TiKV, the key won't be
 // locked, in which case we should unset the primary of the transaction.
-// The caller must ensure bellow conditions:
+// The caller must ensure the conditions bellow:
 // (1) only one key to be locked (2) primary is not selected before (2) with LockOnlyIfExists
 // Returns true if the primary has been unset.
-func (txn *KVTxn) unsetPrimaryKeyIfNeed(lockCtx *tikv.LockCtx) bool {
+func (txn *KVTxn) unsetPrimaryKeyIfNeeded(lockCtx *tikv.LockCtx) {
 	if val, ok := lockCtx.Values[string(txn.committer.primaryKey)]; ok {
 		if !val.Exists {
 			txn.committer.primaryKey = nil
 			txn.committer.ttlManager.reset()
-			return true
 		}
 	}
-	return false
 }
 
 // deduplicateKeys deduplicate the keys, it use sort instead of map to avoid memory allocation.

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -665,7 +665,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 		// It can't transform LockOnlyIfExists mode to normal mode. If so, it can add a lock to a key
 		// which doesn't exist in tikv. TiDB should ensure that primary key must be set when it sends
 		// a LockOnlyIfExists pessmistic lock request.
-		if txn.committer == nil || txn.committer.primaryKey == nil {
+		if (txn.committer == nil || txn.committer.primaryKey == nil) && len(keys) != 1 {
 			return &tikverr.ErrLockOnlyIfExistsNoPrimaryKey{
 				StartTS:     txn.startTS,
 				ForUpdateTs: lockCtx.ForUpdateTS,

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -766,7 +766,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 	if assignedPrimaryKey && lockCtx.LockOnlyIfExists && len(keys) == 1 {
 		if !txn.unsetPrimaryKeyIfNeed(lockCtx) {
 			memBuf.UpdateFlags(keys[0], tikv.SetKeyLocked, tikv.DelNeedCheckExists, tikv.SetKeyLockedValueExists)
-			txn.lockedCnt += 1
+			txn.lockedCnt++
 		}
 		return nil
 	}

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -800,7 +800,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 // When locking only one key with LockOnlyIfExists flag, the key will be selected as primary if
 // it's the first lock of the transaction. If the key doesn't exist on TiKV, the key won't be
 // locked, in which case we should unset the primary of the transaction.
-// The caller must ensure the conditions bellow:
+// The caller must ensure the conditions below:
 // (1) only one key to be locked (2) primary is not selected before (2) with LockOnlyIfExists
 // Returns true if the primary has been unset.
 func (txn *KVTxn) unsetPrimaryKeyIfNeeded(lockCtx *tikv.LockCtx) {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -765,8 +765,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 	}
 	if assignedPrimaryKey && lockCtx.LockOnlyIfExists {
 		if len(keys) != 1 {
-			panic("When using the LockOnlyIfExists mode to lock keys, if one of the keys is selected as " +
-				"the primary key, the number of input keys must be one.")
+			panic("LockOnlyIfExists only assigns the primary key when locking only one key")
 		}
 		txn.unsetPrimaryKeyIfNeeded(lockCtx)
 	}
@@ -802,7 +801,6 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 // locked, in which case we should unset the primary of the transaction.
 // The caller must ensure the conditions below:
 // (1) only one key to be locked (2) primary is not selected before (2) with LockOnlyIfExists
-// Returns true if the primary has been unset.
 func (txn *KVTxn) unsetPrimaryKeyIfNeeded(lockCtx *tikv.LockCtx) {
 	if val, ok := lockCtx.Values[string(txn.committer.primaryKey)]; ok {
 		if !val.Exists {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -764,11 +764,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 		}
 	}
 	if assignedPrimaryKey && lockCtx.LockOnlyIfExists && len(keys) == 1 {
-		if !txn.unsetPrimaryKeyIfNeed(lockCtx) {
-			memBuf.UpdateFlags(keys[0], tikv.SetKeyLocked, tikv.DelNeedCheckExists, tikv.SetKeyLockedValueExists)
-			txn.lockedCnt++
-		}
-		return nil
+		txn.unsetPrimaryKeyIfNeed(lockCtx)
 	}
 	skipedLockKeys := 0
 	for _, key := range keys {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -665,7 +665,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 		// It can't transform LockOnlyIfExists mode to normal mode. If so, it can add a lock to a key
 		// which doesn't exist in tikv. TiDB should ensure that primary key must be set when it sends
 		// a LockOnlyIfExists pessmistic lock request.
-		if (txn.committer == nil || txn.committer.primaryKey == nil) && len(keys) != 1 {
+		if (txn.committer == nil || txn.committer.primaryKey == nil) && len(keys) > 1 {
 			return &tikverr.ErrLockOnlyIfExistsNoPrimaryKey{
 				StartTS:     txn.startTS,
 				ForUpdateTs: lockCtx.ForUpdateTS,
@@ -675,6 +675,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 	}
 	keys = deduplicateKeys(keys)
 	checkedExistence := false
+	var assignedPrimaryKey bool
 	if txn.IsPessimistic() && lockCtx.ForUpdateTS > 0 {
 		if txn.committer == nil {
 			// sessionID is used for log.
@@ -689,7 +690,6 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 				return err
 			}
 		}
-		var assignedPrimaryKey bool
 		if txn.committer.primaryKey == nil {
 			txn.committer.primaryKey = keys[0]
 			assignedPrimaryKey = true
@@ -763,6 +763,13 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 			checkedExistence = true
 		}
 	}
+	if assignedPrimaryKey && lockCtx.LockOnlyIfExists && len(keys) == 1 {
+		if !txn.unsetPrimaryKeyIfNeed(lockCtx) {
+			memBuf.UpdateFlags(keys[0], tikv.SetKeyLocked, tikv.DelNeedCheckExists, tikv.SetKeyLockedValueExists)
+			txn.lockedCnt += 1
+		}
+		return nil
+	}
 	skipedLockKeys := 0
 	for _, key := range keys {
 		valExists := tikv.SetKeyLockedValueExists
@@ -787,6 +794,23 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tikv.LockCtx, keysInput
 	}
 	txn.lockedCnt += len(keys) - skipedLockKeys
 	return nil
+}
+
+// unsetPrimaryKeyIfNeed is used to unset pk of current transaction.
+// When lock only one key with LockOnlyIfExists flag, this key is selected as pk, if the key doesn't
+// exist on TiKV, it doesn't generate a lock for this key, we should unset this pk for this scene.
+// The caller should ensure bellow conditions.
+// (1) only one key to be locked (2) pk is not selected before (2) with LockOnlyIfExists
+// retun true means the pk has been unseted
+func (txn *KVTxn) unsetPrimaryKeyIfNeed(lockCtx *tikv.LockCtx) bool {
+	if val, ok := lockCtx.Values[string(txn.committer.primaryKey)]; ok {
+		if !val.Exists {
+			txn.committer.primaryKey = nil
+			txn.committer.ttlManager.reset()
+			return true
+		}
+	}
+	return false
 }
 
 // deduplicateKeys deduplicate the keys, it use sort instead of map to avoid memory allocation.


### PR DESCRIPTION
Signed-off-by: TonsnakeLin <lpbgytong@163.com>
At first, we enable  lock_only_if_exists mode only when the primary key of the current transaction is selected when lock keys.
We expand the use scope, if the number of  keys to be locked is one, we also enable lock_only_if_exists even though the primary key is not selected.