### PR TITLE
txnkv: export DefaultScanBatchSize variable

### DIFF
--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -72,7 +72,7 @@ type Scanner struct {
 func newScanner(snapshot *KVSnapshot, startKey []byte, endKey []byte, batchSize int, reverse bool) (*Scanner, error) {
 	// It must be > 1. Otherwise scanner won't skipFirst.
 	if batchSize <= 1 {
-		batchSize = defaultScanBatchSize
+		batchSize = DefaultScanBatchSize
 	}
 	scanner := &Scanner{
 		snapshot:     snapshot,

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -65,7 +65,8 @@ import (
 )
 
 const (
-	defaultScanBatchSize = 256
+	// DefaultScanBatchSize is the default scan batch size.
+	DefaultScanBatchSize = 256
 	batchGetSize         = 5120
 	maxTimestamp         = math.MaxUint64
 )
@@ -160,7 +161,7 @@ func NewTiKVSnapshot(store kvstore, ts uint64, replicaReadSeed uint32) *KVSnapsh
 	return &KVSnapshot{
 		store:           store,
 		version:         ts,
-		scanBatchSize:   defaultScanBatchSize,
+		scanBatchSize:   DefaultScanBatchSize,
 		priority:        txnutil.PriorityNormal,
 		vars:            kv.DefaultVars,
 		replicaReadSeed: replicaReadSeed,

--- a/txnkv/txnsnapshot/test_probe.go
+++ b/txnkv/txnsnapshot/test_probe.go
@@ -63,7 +63,7 @@ type ConfigProbe struct{}
 
 // GetScanBatchSize returns the batch size to scan ranges.
 func (c ConfigProbe) GetScanBatchSize() int {
-	return defaultScanBatchSize
+	return DefaultScanBatchSize
 }
 
 // GetGetMaxBackoff returns the max sleep for get command.


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

This is used for https://github.com/pingcap/tidb/pull/37466