### PR TITLE
Fix the missing unlock in extractKeyExistsErr

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -1953,3 +1953,24 @@ func (s *testCommitterSuite) TestFlagsInMemBufferMutations() {
 		s.Equal(assertNotExist, mutations.IsAssertNotExist(i))
 	})
 }
+
+func (s *testCommitterSuite) TestExtractKeyExistsErr() {
+	txn := s.begin()
+	err := txn.Set([]byte("de"), []byte("ef"))
+	s.Nil(err)
+	err = txn.Commit(context.Background())
+	s.Nil(err)
+
+	txn = s.begin()
+	err = txn.GetMemBuffer().SetWithFlags([]byte("de"), []byte("fg"), kv.SetPresumeKeyNotExists)
+	s.Nil(err)
+	committer, err := txn.NewCommitter(0)
+	s.Nil(err)
+	// Forcibly construct a case when Op_Insert is prewritten while not having KeyNotExists flag.
+	// In real use cases, it should only happen when enabling amending transactions.
+	txn.GetMemBuffer().UpdateFlags([]byte("de"), kv.DelPresumeKeyNotExists)
+	err = committer.PrewriteAllMutations(context.Background())
+	s.ErrorContains(err, "existErr")
+	s.True(txn.GetMemBuffer().TryLock())
+	txn.GetMemBuffer().Unlock()
+}

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -459,10 +459,10 @@ func newTwoPhaseCommitter(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, err
 
 func (c *twoPhaseCommitter) extractKeyExistsErr(err *tikverr.ErrKeyExist) error {
 	c.txn.GetMemBuffer().RLock()
+	defer c.txn.GetMemBuffer().RUnlock()
 	if !c.txn.us.HasPresumeKeyNotExists(err.GetKey()) {
 		return errors.Errorf("session %d, existErr for key:%s should not be nil", c.sessionID, err.GetKey())
 	}
-	c.txn.GetMemBuffer().RUnlock()
 	return errors.WithStack(err)
 }
 


### PR DESCRIPTION
I forgot to unlock in all branches in `extractKeyExistsErr`. So, if it goes into `!c.txn.us.HasPresumeKeyNotExists(err.GetKey())` branch, the lock is never released.

Actually, it's unlikely to reach that branch because `Op_Insert` is only generated when there is a PresumeKeyNotExists flag. The only exception I find is amending transaction. It directly generates `Op_Insert` entries.
