### PR TITLE
Fix the missing unlock in extractKeyExistsErr (tidb-6.1)

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -435,10 +435,10 @@ func newTwoPhaseCommitter(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, err
 
 func (c *twoPhaseCommitter) extractKeyExistsErr(err *tikverr.ErrKeyExist) error {
 	c.txn.GetMemBuffer().RLock()
+	defer c.txn.GetMemBuffer().RUnlock()
 	if !c.txn.us.HasPresumeKeyNotExists(err.GetKey()) {
 		return errors.Errorf("session %d, existErr for key:%s should not be nil", c.sessionID, err.GetKey())
 	}
-	c.txn.GetMemBuffer().RUnlock()
 	return errors.WithStack(err)
 }
 


### PR DESCRIPTION
In https://github.com/tikv/client-go/pull/585, I forgot to unlock in all branches in extractKeyExistsErr. So, if it goes into !c.txn.us.HasPresumeKeyNotExists(err.GetKey()) branch, the lock is never released.

Actually, it's unlikely to reach that branch because Op_Insert is only generated when there is a PresumeKeyNotExists flag. The only exception I find is amending transaction. It directly generates Op_Insert entries.