### PR TITLE
util: update GCTimeFormat to be the same as the value stored in PD

### DIFF
--- a/util/misc.go
+++ b/util/misc.go
@@ -60,7 +60,8 @@ const gcTimeFormatOld = "20060102-15:04:05 -0700"
 // gc_worker. We have changed the format that gc_worker saves time (removed the last field), but when loading times it
 // should be compatible with the old format.
 func CompatibleParseGCTime(value string) (time.Time, error) {
-	// The old format could parse the value with new format, the `GCTimeFormat` only be used when store.
+	// The old format could parse the value with new format,
+	// let `GCTimeFormat` only be used when store the time.
 	t, err := time.Parse(gcTimeFormatOld, value)
 	if err != nil {
 		// Remove the last field that separated by space

--- a/util/misc.go
+++ b/util/misc.go
@@ -52,24 +52,21 @@ import (
 // GCTimeFormat is the format that gc_worker used to store times.
 const GCTimeFormat = "20060102-15:04:05.000 -0700"
 
-// GCTimeFormatOld is the format that gc_worker used to store times before, for compatibility we should keep it.
-const GCTimeFormatOld = "20060102-15:04:05 -0700"
+// gcTimeFormatOld is the format that gc_worker used to store times before, for compatibility we keep it.
+const gcTimeFormatOld = "20060102-15:04:05 -0700"
 
 // CompatibleParseGCTime parses a string with `GCTimeFormat` and returns a time.Time. If `value` can't be parsed as that
 // format, truncate to last space and try again. This function is only useful when loading times that saved by
 // gc_worker. We have changed the format that gc_worker saves time (removed the last field), but when loading times it
 // should be compatible with the old format.
 func CompatibleParseGCTime(value string) (time.Time, error) {
-	t, err := time.Parse(GCTimeFormat, value)
-
+	// The old format could parse the value with new format, the `GCTimeFormat` only be used when store.
+	t, err := time.Parse(gcTimeFormatOld, value)
 	if err != nil {
-		t, err = time.Parse(GCTimeFormatOld, value)
-		if err != nil {
-			// Remove the last field that separated by space
-			parts := strings.Split(value, " ")
-			prefix := strings.Join(parts[:len(parts)-1], " ")
-			t, err = time.Parse(GCTimeFormatOld, prefix)
-		}
+		// Remove the last field that separated by space
+		parts := strings.Split(value, " ")
+		prefix := strings.Join(parts[:len(parts)-1], " ")
+		t, err = time.Parse(gcTimeFormatOld, prefix)
 	}
 
 	if err != nil {

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -53,6 +53,8 @@ func TestCompatibleParseGCTime(t *testing.T) {
 		"20181218-19:53:37 +0800",
 		"20181218-19:53:37 +0800 ",
 		"20181218-11:53:37 +0000",
+		"20181218-11:53:37.000 +0000",
+		"20181218-19:53:37.000 +0800 +08",
 	}
 
 	invalidValues := []string{
@@ -67,7 +69,7 @@ func TestCompatibleParseGCTime(t *testing.T) {
 	}
 
 	expectedTime := time.Date(2018, 12, 18, 11, 53, 37, 0, time.UTC)
-	expectedTimeFormatted := "20181218-19:53:37 +0800"
+	expectedTimeFormatted := "20181218-19:53:37.000 +0800"
 
 	beijing, err := time.LoadLocation("Asia/Shanghai")
 	require.Nil(err)
@@ -82,7 +84,7 @@ func TestCompatibleParseGCTime(t *testing.T) {
 	}
 
 	for _, value := range invalidValues {
-		_, err := CompatibleParseGCTime(value)
+		_, err = CompatibleParseGCTime(value)
 		assert.NotNil(err)
 	}
 }


### PR DESCRIPTION
The GC-related time stored in TiKV is inconsistent with the time stored in PD. The value in TiKV, the time format is "20060102-15:04:05 -0700", and the precision is only seconds. In PD, it stores a uint64 with millisecond precision.

The if we use the value got from TiKV to do some processes, it will got a error like this,

```
mysql> flashback cluster to timestamp '2022-11-07 10:34:00';
ERROR 9006 (HY000): GC life time is shorter than transaction duration, transaction starts at 2022-11-07 10:34:00 +0800 CST, GC safe point is 2022-11-07 10:34:00.366 +0800 CST
```