### PR TITLE
precompute min safe ts

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2367,6 +2367,16 @@ func isStoreContainLabel(labels []*metapb.StoreLabel, key string, val string) (r
 	return res
 }
 
+// GetLabelValue returns the value of the label
+func (s *Store) GetLabelValue(key string) (string, bool) {
+	for _, label := range s.labels {
+		if label.Key == key {
+			return label.Value, true
+		}
+	}
+	return "", false
+}
+
 // getLivenessState gets the cached liveness state of the store.
 // When it's not reachable, a goroutine will update the state in background.
 // To get the accurate liveness state, use checkLiveness instead.

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -564,18 +564,10 @@ func (s *KVStore) updateSafeTS(ctx context.Context) {
 
 	txnScopeMap := make(map[string][]uint64)
 	for _, store := range stores {
-		storeIDs, ok := txnScopeMap[oracle.GlobalTxnScope]
-		if !ok {
-			storeIDs = make([]uint64, 0)
-		}
-		txnScopeMap[oracle.GlobalTxnScope] = append(storeIDs, store.StoreID())
+		txnScopeMap[oracle.GlobalTxnScope] = append(txnScopeMap[oracle.GlobalTxnScope], store.StoreID())
 
 		if label, ok := store.GetLabelValue(DCLabelKey); ok {
-			storeIDs, ok = txnScopeMap[label]
-			if !ok {
-				storeIDs = make([]uint64, 0)
-			}
-			txnScopeMap[label] = append(storeIDs, store.StoreID())
+			txnScopeMap[label] = append(txnScopeMap[label], store.StoreID())
 		}
 	}
 	for txnScope, storeIDs := range txnScopeMap {

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -47,7 +47,6 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/config"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -121,6 +120,9 @@ type KVStore struct {
 	// safeTS here will be used during the Stale Read process,
 	// it indicates the safe timestamp point that can be used to read consistent but may not the latest data.
 	safeTSMap sync.Map
+
+	// MinSafeTs stores the minimum ts value for each txnScope
+	minSafeTS sync.Map
 
 	replicaReadSeed uint32 // this is used to load balance followers / learners when replica read is enabled
 
@@ -443,23 +445,10 @@ func (s *KVStore) GetTiKVClient() (client Client) {
 
 // GetMinSafeTS return the minimal safeTS of the storage with given txnScope.
 func (s *KVStore) GetMinSafeTS(txnScope string) uint64 {
-	stores := make([]*locate.Store, 0)
-	allStores := s.regionCache.GetStoresByType(tikvrpc.TiKV)
-	if txnScope != oracle.GlobalTxnScope {
-		for _, store := range allStores {
-			if store.IsLabelsMatch([]*metapb.StoreLabel{
-				{
-					Key:   DCLabelKey,
-					Value: txnScope,
-				},
-			}) {
-				stores = append(stores, store)
-			}
-		}
-	} else {
-		stores = allStores
+	if val, ok := s.minSafeTS.Load(txnScope); ok {
+		return val.(uint64)
 	}
-	return s.getMinSafeTSByStores(stores)
+	return 0
 }
 
 // Ctx returns ctx.
@@ -500,18 +489,14 @@ func (s *KVStore) setSafeTS(storeID, safeTS uint64) {
 	s.safeTSMap.Store(storeID, safeTS)
 }
 
-func (s *KVStore) getMinSafeTSByStores(stores []*locate.Store) uint64 {
-	if val, err := util.EvalFailpoint("injectSafeTS"); err == nil {
-		injectTS := val.(int)
-		return uint64(injectTS)
-	}
+func (s *KVStore) updateMinSafeTS(txnScope string, storeIDs []uint64) {
 	minSafeTS := uint64(math.MaxUint64)
 	// when there is no store, return 0 in order to let minStartTS become startTS directly
-	if len(stores) < 1 {
-		return 0
+	if len(storeIDs) < 1 {
+		s.minSafeTS.Store(txnScope, 0)
 	}
-	for _, store := range stores {
-		ok, safeTS := s.getSafeTS(store.StoreID())
+	for _, store := range storeIDs {
+		ok, safeTS := s.getSafeTS(store)
 		if ok {
 			if safeTS != 0 && safeTS < minSafeTS {
 				minSafeTS = safeTS
@@ -520,7 +505,7 @@ func (s *KVStore) getMinSafeTSByStores(stores []*locate.Store) uint64 {
 			minSafeTS = 0
 		}
 	}
-	return minSafeTS
+	s.minSafeTS.Store(txnScope, minSafeTS)
 }
 
 func (s *KVStore) safeTSUpdater() {
@@ -575,6 +560,26 @@ func (s *KVStore) updateSafeTS(ctx context.Context) {
 			safeTSTime := oracle.GetTimeFromTS(safeTS)
 			metrics.TiKVMinSafeTSGapSeconds.WithLabelValues(storeIDStr).Set(time.Since(safeTSTime).Seconds())
 		}(ctx, wg, storeID, storeAddr)
+	}
+
+	txnScopeMap := make(map[string][]uint64)
+	for _, store := range stores {
+		storeIDs, ok := txnScopeMap[oracle.GlobalTxnScope]
+		if !ok {
+			storeIDs = make([]uint64, 0)
+		}
+		txnScopeMap[oracle.GlobalTxnScope] = append(storeIDs, store.StoreID())
+
+		if label, ok := store.GetLabelValue(DCLabelKey); ok {
+			storeIDs, ok = txnScopeMap[label]
+			if !ok {
+				storeIDs = make([]uint64, 0)
+			}
+			txnScopeMap[label] = append(storeIDs, store.StoreID())
+		}
+	}
+	for txnScope, storeIDs := range txnScopeMap {
+		s.updateMinSafeTS(txnScope, storeIDs)
 	}
 	wg.Wait()
 }


### PR DESCRIPTION
compute the min safe ts on the query path is expensive because it has to allocate thousands of small objects with lock, when there are hundreds of tikv node. this makes stale read using session variable `tidb_read_staleness` noticeable slower than normal read.

the safe ts from tikv are only updated every 2 seconds, thus the min safe ts could be precomputed on the update path to avoid the expensive computation on query path.

result on our benchmark 
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-74d134e2-7fff-1006-4985-b6a1f5d8d040"><div dir="ltr" style="margin-left:0pt;" align="left">

  | p99 | p999 | Cpu usage
-- | -- | -- | --
Leader read + tidb_low_resolution_tso | 4.0ms | 14.1ms | 413%
Stale read | 10.1ms | 40.3ms | 486%
Stale read with precomputed min safe ts | 5.5ms | 13.6ms | 416%

</div></b>

normal read:
![Screen Shot 2022-11-23 at 10 22 26 AM](https://user-images.githubusercontent.com/4716375/203620840-eef75afd-0e84-4eee-bf45-58533c9ca3ab.png)

stale read before the change:
![Screen Shot 2022-11-23 at 10 22 45 AM](https://user-images.githubusercontent.com/4716375/203620891-83b4803f-b050-4603-8a6e-3ef1cc30e3b3.png)
zoom in:
![Screen Shot 2022-11-23 at 10 23 00 AM](https://user-images.githubusercontent.com/4716375/203620957-e8a299f8-8187-46a3-b095-8042ec256728.png)

stale read after the change:
![Screen Shot 2022-11-23 at 10 30 14 AM](https://user-images.githubusercontent.com/4716375/203621975-648d2d66-c7a0-4317-9182-4275568ebf8a.png)
zoom in:
![Screen Shot 2022-11-23 at 10 31 05 AM](https://user-images.githubusercontent.com/4716375/203622134-33aa4fd1-b323-4164-a5eb-a86479c2f759.png)

to further reduce the cpu usage, could remove the warning logging from https://github.com/pingcap/tidb/blob/v6.5.0-alpha/expression/builtin_time.go#L6576