### PR TITLE
Bug fix: fix the Round-Robin algorithm when "ReadMode == ReplicaReadMixed".

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -264,8 +264,9 @@ type replicaSelector struct {
 // selectorState is the interface of states of the replicaSelector.
 // Here is the main state transition diagram:
 //
-//                                    exceeding maxReplicaAttempt
-//           +-------------------+   || RPC failure && unreachable && no forwarding
+//	                         exceeding maxReplicaAttempt
+//	+-------------------+   || RPC failure && unreachable && no forwarding
+//
 // +-------->+ accessKnownLeader +----------------+
 // |         +------+------------+                |
 // |                |                             |
@@ -282,7 +283,8 @@ type replicaSelector struct {
 // | leader becomes   v                           +---+---+
 // | reachable  +-----+-----+ all proxies are tried   ^
 // +------------+tryNewProxy+-------------------------+
-//              +-----------+
+//
+//	+-----------+
 type selectorState interface {
 	next(*retry.Backoffer, *replicaSelector) (*RPCContext, error)
 	onSendSuccess(*replicaSelector)
@@ -523,15 +525,16 @@ type accessFollower struct {
 }
 
 func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector) (*RPCContext, error) {
+	replicaSize := len(selector.replicas)
 	if state.lastIdx < 0 {
 		if state.tryLeader {
-			state.lastIdx = AccessIndex(rand.Intn(len(selector.replicas)))
+			state.lastIdx = AccessIndex(rand.Intn(replicaSize))
 		} else {
-			if len(selector.replicas) <= 1 {
+			if replicaSize <= 1 {
 				state.lastIdx = state.leaderIdx
 			} else {
 				// Randomly select a non-leader peer
-				state.lastIdx = AccessIndex(rand.Intn(len(selector.replicas) - 1))
+				state.lastIdx = AccessIndex(rand.Intn(replicaSize - 1))
 				if state.lastIdx >= state.leaderIdx {
 					state.lastIdx++
 				}
@@ -547,8 +550,13 @@ func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector
 		state.lastIdx++
 	}
 
-	for i := 0; i < len(selector.replicas) && !state.option.leaderOnly; i++ {
-		idx := AccessIndex((int(state.lastIdx) + i) % len(selector.replicas))
+	for i := 0; i < replicaSize && !state.option.leaderOnly; i++ {
+		idx := AccessIndex((int(state.lastIdx) + i) % replicaSize)
+		// If the given store is abnormal to be accessed under `ReplicaReadMixed` mode, we should choose other followers or leader
+		// as candidates to serve the Read request. Meanwhile, we should make the choice of next() meet Uniform Distribution.
+		for cnt := 0; cnt < replicaSize && !state.isCandidate(idx, selector.replicas[idx]); cnt++ {
+			idx = AccessIndex((int(idx) + rand.Intn(replicaSize)) % replicaSize)
+		}
 		if state.isCandidate(idx, selector.replicas[idx]) {
 			state.lastIdx = idx
 			selector.targetIdx = idx

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -264,9 +264,8 @@ type replicaSelector struct {
 // selectorState is the interface of states of the replicaSelector.
 // Here is the main state transition diagram:
 //
-//	                         exceeding maxReplicaAttempt
-//	+-------------------+   || RPC failure && unreachable && no forwarding
-//
+//                                    exceeding maxReplicaAttempt
+//           +-------------------+   || RPC failure && unreachable && no forwarding
 // +-------->+ accessKnownLeader +----------------+
 // |         +------+------------+                |
 // |                |                             |
@@ -283,8 +282,7 @@ type replicaSelector struct {
 // | leader becomes   v                           +---+---+
 // | reachable  +-----+-----+ all proxies are tried   ^
 // +------------+tryNewProxy+-------------------------+
-//
-//	+-----------+
+//              +-----------+
 type selectorState interface {
 	next(*retry.Backoffer, *replicaSelector) (*RPCContext, error)
 	onSendSuccess(*replicaSelector)


### PR DESCRIPTION
Signed-off-by: Lucasliang <nkcs_lykx@hotmail.com>

## Bug report
When I was doing relevant optimization on ReadMode, I found there existed a bug on Round-Robin strategy when `ReadMode == ReplicaReadMixed`.

Supposing that we have a TiKV cluster with 3 nodes - [node 1, node 2, node 3].
Firstly, the cluster keeps in normal state, the Read flows sent to each nodes are in Uniform Distribution.
And if we made one node abnormal, taking Node 1 as the choice, all flows sent to Node 1 would be redirected to Node 3.
#### With current Round-Robin strategy

```Go
//       [Node 1]                                         [Node 1]
//      /        \                                       /        \
//     /          \          [Node 2] abrnomal ===>     /          \  
//    /            \                                   /            \
// [Node 2] --- [Node 3]                            [Node 2] ---> [Node 3]
//                                                     [x]
```
Because the following steps:
- The choice of `state.lastIdx` is randomly generated    ==>    Could be any one of [node 1, node 2, node 3].
https://github.com/tikv/client-go/blob/f313ddf58d730fca115c7800023df118e4736f0e/internal/locate/region_request.go#L526-L528
-  if the previous step set `state.lastIdx` == [Node 2], it will be filtered by `isCandidate`.
https://github.com/tikv/client-go/blob/f313ddf58d730fca115c7800023df118e4736f0e/internal/locate/region_request.go#L550-L552
- As the checking always starts from `i == 0` and `state.lastIdx + i`, so the first choice, that is [Node 2], will be filtered. And then loops with `i == 1`, getting the next choice `[Node 3]`, it's a normal node, then exit.
- Finally, all flows sent to the abnormal [Node 2] will be redirect to [Node 3], making the flows do not meet ***Uniform Distribution*** as expected.

And we made a test, the following CPU metrics of TiKV cluster proved it:

![image](https://user-images.githubusercontent.com/18441614/211715315-5235dd6d-2dd2-48d4-88d5-124ddbb56791.png)

#### What we expect
What we expect is that, if Node 2 is abnormal, all flows originally sent to this node should be uniformly redirected to other nodes.

## Solution
I made a minor optimization on the original Round-Robin strategy as the following shows. After we try to filter out abnormal node choice, we should randomly choose one which meets the requirements.
``` Go
for cnt := 0; cnt < replicaSize && !state.isCandidate(idx, selector.replicas[idx]); cnt++ {
	idx = AccessIndex((int(idx) + rand.Intn(replicaSize)) % replicaSize)
}
```
And after this supplementary strategy is introduced, we get the expected results:

![image](https://user-images.githubusercontent.com/18441614/211716500-5eef08d1-929b-4b98-88ef-54e11ab5e83f.png)

