### PR TITLE
Rewind after region cache GC reaches the end

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1924,7 +1924,8 @@ func (c *RegionCache) cacheGC() {
 	ticker := time.NewTicker(cleanCacheInterval)
 	defer ticker.Stop()
 
-	iterItem := newBtreeSearchItem([]byte(""))
+	beginning := newBtreeSearchItem([]byte(""))
+	iterItem := beginning
 	expired := make([]*btreeItem, cleanRegionNumPerRound)
 	for {
 		select {
@@ -1949,6 +1950,11 @@ func (c *RegionCache) cacheGC() {
 				return true
 			})
 			c.mu.RUnlock()
+
+			// Reach the end of the region cache, start from the beginning
+			if count <= cleanRegionNumPerRound {
+				iterItem = beginning
+			}
 
 			if len(expired) > 0 {
 				c.mu.Lock()

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -1648,8 +1648,8 @@ func (s *testRegionCacheSuite) TestShouldNotRetryFlashback() {
 }
 
 func (s *testRegionCacheSuite) TestBackgroundCacheGC() {
-	// Prepare 50 regions
-	regionCnt := 50
+	// Prepare 100 regions
+	regionCnt := 100
 	regions := s.cluster.AllocIDs(regionCnt)
 	regions = append([]uint64{s.region1}, regions...)
 	peers := [][]uint64{{s.peer1, s.peer2}}
@@ -1679,6 +1679,26 @@ func (s *testRegionCacheSuite) TestBackgroundCacheGC() {
 		s.cache.mu.RLock()
 		defer s.cache.mu.RUnlock()
 		return len(s.cache.mu.regions) == remaining
-	}, 2*time.Second, 200*time.Millisecond)
+	}, 3*time.Second, 200*time.Millisecond)
+	s.checkCache(remaining)
+
+	// Make another part of the regions stale
+	remaining = 0
+	s.cache.mu.Lock()
+	now = time.Now().Unix()
+	for verID, r := range s.cache.mu.regions {
+		if verID.id%3 == 1 {
+			atomic.StoreInt64(&r.lastAccess, now-regionCacheTTLSec-10)
+		} else {
+			remaining++
+		}
+	}
+	s.cache.mu.Unlock()
+
+	s.Eventually(func() bool {
+		s.cache.mu.RLock()
+		defer s.cache.mu.RUnlock()
+		return len(s.cache.mu.regions) == remaining
+	}, 3*time.Second, 200*time.Millisecond)
 	s.checkCache(remaining)
 }


### PR DESCRIPTION
https://github.com/tikv/client-go/pull/664 was incomplete. The searching cursor increases monotonically without rewinding. So, if the regions split after the cursor passes their start keys, they will not be cleared after being stale.

This PR rewinds the cursor after reaching the end.