### PR TITLE
Add interfaces needed for TiDB avoiding statement retry on pessimistic lock WriteConflict conflict in aggressive locking mode

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -246,7 +246,7 @@ type ErrAssertionFailed struct {
 	*kvrpcpb.AssertionFailed
 }
 
-// ErrLockOnlyIfExistsNoReturnValue is used when the flag `LockOnlyIfExists` of `LockCtx` is set, but `ReturnValues`` is not.
+// ErrLockOnlyIfExistsNoReturnValue is used when the flag `LockOnlyIfExists` of `LockCtx` is set, but `ReturnValues“ is not.
 type ErrLockOnlyIfExistsNoReturnValue struct {
 	StartTS     uint64
 	ForUpdateTs uint64

--- a/kv/key.go
+++ b/kv/key.go
@@ -51,10 +51,10 @@ func NextKey(k []byte) []byte {
 //
 // Assume there are keys like:
 //
-//   rowkey1
-//   rowkey1_column1
-//   rowkey1_column2
-//   rowKey2
+//	rowkey1
+//	rowkey1_column1
+//	rowkey1_column2
+//	rowKey2
 //
 // If we seek 'rowkey1' NextKey, we will get 'rowkey1_column1'.
 // If we seek 'rowkey1' PrefixNextKey, we will get 'rowkey2'.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -73,6 +73,12 @@ type LockCtx struct {
 	LockExpired             *uint32
 	Stats                   *util.LockKeysDetails
 	ResourceGroupTag        []byte
+
+	// When aggressive locking is used (in which case locking-with-conflict is allowed), usually when some keys are
+	// locked with conflict, the caller should update the forUpdateTS and retry the current operation (statement).
+	// However, in some cases, the caller may be able to guarantee the consistency in some way without retrying.
+	CheckAggressiveLockedKeys bool
+
 	// ResourceGroupTagger is a special tagger used only for PessimisticLockRequest.
 	// We did not use tikvrpc.ResourceGroupTagger here because the kv package is a
 	// more basic component, and we cannot rely on tikvrpc.Request here, so we treat

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -96,6 +96,7 @@ var (
 	TiKVReadThroughput                       prometheus.Histogram
 	TiKVUnsafeDestroyRangeFailuresCounterVec *prometheus.CounterVec
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
+	TiKVAggressiveLockedKeysCounter          *prometheus.CounterVec
 )
 
 // Label constants.
@@ -589,6 +590,14 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Counter of assertions used in prewrite requests",
 		}, []string{LblType})
 
+	TiKVAggressiveLockedKeysCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "aggressive_locking_count",
+			Help:      "Counter of keys locked in aggressive locking mode",
+		}, []string{LblType})
+
 	initShortcuts()
 }
 
@@ -659,6 +668,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVReadThroughput)
 	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
+	prometheus.MustRegister(TiKVAggressiveLockedKeysCounter)
 }
 
 // readCounter reads the value of a prometheus.Counter.

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -136,6 +136,11 @@ var (
 	PrewriteAssertionUsageCounterExist    prometheus.Counter
 	PrewriteAssertionUsageCounterNotExist prometheus.Counter
 	PrewriteAssertionUsageCounterUnknown  prometheus.Counter
+
+	AggressiveLockedKeysNew                prometheus.Counter
+	AggressiveLockedKeysDerived            prometheus.Counter
+	AggressiveLockedKeysLockedWithConflict prometheus.Counter
+	AggressiveLockedKeysNonForceLock       prometheus.Counter
 )
 
 func initShortcuts() {
@@ -237,4 +242,8 @@ func initShortcuts() {
 	PrewriteAssertionUsageCounterExist = TiKVPrewriteAssertionUsageCounter.WithLabelValues("exist")
 	PrewriteAssertionUsageCounterNotExist = TiKVPrewriteAssertionUsageCounter.WithLabelValues("not-exist")
 	PrewriteAssertionUsageCounterUnknown = TiKVPrewriteAssertionUsageCounter.WithLabelValues("unknown")
+
+	AggressiveLockedKeysNew = TiKVAggressiveLockedKeysCounter.WithLabelValues("new")
+	AggressiveLockedKeysDerived = TiKVAggressiveLockedKeysCounter.WithLabelValues("derived")
+	AggressiveLockedKeysLockedWithConflict = TiKVAggressiveLockedKeysCounter.WithLabelValues("locked_with_conflict")
 }

--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -37,7 +37,9 @@ import (
 
 // GC does garbage collection (GC) of the TiKV cluster.
 // GC deletes MVCC records whose timestamp is lower than the given `safepoint`. We must guarantee
-//  that all transactions started before this timestamp had committed. We can keep an active
+//
+//	that all transactions started before this timestamp had committed. We can keep an active
+//
 // transaction list in application to decide which is the minimal start timestamp of them.
 //
 // For each key, the last mutation record (unless it's a deletion) before `safepoint` is retained.

--- a/tikvrpc/interceptor/interceptor.go
+++ b/tikvrpc/interceptor/interceptor.go
@@ -32,29 +32,33 @@ import (
 //
 // We can implement an RPCInterceptor like this:
 // ```
-// func LogInterceptor(next InterceptorFunc) RPCInterceptorFunc {
-//     return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
-//         log.Println("before")
-//         resp, err := next(target, req)
-//         log.Println("after")
-//         return resp, err
-//     }
-// }
+//
+//	func LogInterceptor(next InterceptorFunc) RPCInterceptorFunc {
+//	    return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+//	        log.Println("before")
+//	        resp, err := next(target, req)
+//	        log.Println("after")
+//	        return resp, err
+//	    }
+//	}
+//
 // txn.SetRPCInterceptor(LogInterceptor)
 // ```
 //
 // Or you want to inject some dependent modules:
 // ```
-// func GetLogInterceptor(lg *log.Logger) RPCInterceptor {
-//     return func(next RPCInterceptorFunc) RPCInterceptorFunc {
-//         return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
-//             lg.Println("before")
-//             resp, err := next(target, req)
-//             lg.Println("after")
-//             return resp, err
-//         }
-//     }
-// }
+//
+//	func GetLogInterceptor(lg *log.Logger) RPCInterceptor {
+//	    return func(next RPCInterceptorFunc) RPCInterceptorFunc {
+//	        return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+//	            lg.Println("before")
+//	            resp, err := next(target, req)
+//	            lg.Println("after")
+//	            return resp, err
+//	        }
+//	    }
+//	}
+//
 // txn.SetRPCInterceptor(GetLogInterceptor())
 // ```
 //
@@ -62,8 +66,9 @@ import (
 // This is because there may be some exceptions, such as: request batched, no
 // valid connection etc. If you have questions about the execution location of
 // RPCInterceptor, please refer to:
-//     tikv/kv.go#NewKVStore()
-//     internal/client/client_interceptor.go#SendRequest.
+//
+//	tikv/kv.go#NewKVStore()
+//	internal/client/client_interceptor.go#SendRequest.
 type RPCInterceptor func(next RPCInterceptorFunc) RPCInterceptorFunc
 
 // RPCInterceptorFunc is a callable function used to initiate a request to TiKV.
@@ -77,20 +82,23 @@ type RPCInterceptorFunc func(target string, req *tikvrpc.Request) (*tikvrpc.Resp
 //
 // We can use RPCInterceptorChain like this:
 // ```
-// func Interceptor1(next InterceptorFunc) RPCInterceptorFunc {
-//     return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
-//         fmt.Println("begin-interceptor-1")
-//         defer fmt.Println("end-interceptor-1")
-//         return next(target, req)
-//     }
-// }
-// func Interceptor2(next InterceptorFunc) RPCInterceptorFunc {
-//     return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
-//         fmt.Println("begin-interceptor-2")
-//         defer fmt.Println("end-interceptor-2")
-//         return next(target, req)
-//     }
-// }
+//
+//	func Interceptor1(next InterceptorFunc) RPCInterceptorFunc {
+//	    return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+//	        fmt.Println("begin-interceptor-1")
+//	        defer fmt.Println("end-interceptor-1")
+//	        return next(target, req)
+//	    }
+//	}
+//
+//	func Interceptor2(next InterceptorFunc) RPCInterceptorFunc {
+//	    return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+//	        fmt.Println("begin-interceptor-2")
+//	        defer fmt.Println("end-interceptor-2")
+//	        return next(target, req)
+//	    }
+//	}
+//
 // txn.SetRPCInterceptor(NewRPCInterceptorChain().Link(Interceptor1).Link(Interceptor2).Build())
 // ```
 //

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -70,6 +70,10 @@ type Scanner struct {
 }
 
 func newScanner(snapshot *KVSnapshot, startKey []byte, endKey []byte, batchSize int, reverse bool) (*Scanner, error) {
+	err := snapshot.handleLazyVersion()
+	if err != nil {
+		return nil, err
+	}
 	// It must be > 1. Otherwise scanner won't skipFirst.
 	if batchSize <= 1 {
 		batchSize = DefaultScanBatchSize
@@ -83,7 +87,7 @@ func newScanner(snapshot *KVSnapshot, startKey []byte, endKey []byte, batchSize 
 		reverse:      reverse,
 		nextEndKey:   endKey,
 	}
-	err := scanner.Next()
+	err = scanner.Next()
 	if tikverr.IsErrNotFound(err) {
 		return scanner, nil
 	}

--- a/util/codec/bytes.go
+++ b/util/codec/bytes.go
@@ -53,14 +53,18 @@ var (
 
 // EncodeBytes guarantees the encoded value is in ascending order for comparison,
 // encoding with the following rule:
-//  [group1][marker1]...[groupN][markerN]
-//  group is 8 bytes slice which is padding with 0.
-//  marker is `0xFF - padding 0 count`
+//
+//	[group1][marker1]...[groupN][markerN]
+//	group is 8 bytes slice which is padding with 0.
+//	marker is `0xFF - padding 0 count`
+//
 // For example:
-//   [] -> [0, 0, 0, 0, 0, 0, 0, 0, 247]
-//   [1, 2, 3] -> [1, 2, 3, 0, 0, 0, 0, 0, 250]
-//   [1, 2, 3, 0] -> [1, 2, 3, 0, 0, 0, 0, 0, 251]
-//   [1, 2, 3, 4, 5, 6, 7, 8] -> [1, 2, 3, 4, 5, 6, 7, 8, 255, 0, 0, 0, 0, 0, 0, 0, 0, 247]
+//
+//	[] -> [0, 0, 0, 0, 0, 0, 0, 0, 247]
+//	[1, 2, 3] -> [1, 2, 3, 0, 0, 0, 0, 0, 250]
+//	[1, 2, 3, 0] -> [1, 2, 3, 0, 0, 0, 0, 0, 251]
+//	[1, 2, 3, 4, 5, 6, 7, 8] -> [1, 2, 3, 4, 5, 6, 7, 8, 255, 0, 0, 0, 0, 0, 0, 0, 0, 247]
+//
 // Refer: https://github.com/facebook/mysql-5.6/wiki/MyRocks-record-format#memcomparable-format
 func EncodeBytes(b []byte, data []byte) []byte {
 	// Allocate more space to avoid unnecessary slice growing.


### PR DESCRIPTION
* Added `SetSnapshotTSGetter` support for `Snapshot` as an alternative to `SetSnapshotTS` which supports lazy-initializing the ts.
* Added `CheckConstraintForAlreadyLockedKeys` which is used to check if the keys that the trasnaction has already locked satisifies the PresumeNotexist constraint.