### PR TITLE
rawkv: Fix context leak in rawkv.BatchPut

### DIFF
--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -899,12 +899,16 @@ func (c *Client) sendBatchPut(bo *retry.Backoffer, keys, values [][]byte, ttls [
 
 	for i := 0; i < len(batches); i++ {
 		if e := <-ch; e != nil {
-			cancel()
 			// catch the first error
 			if err == nil {
 				err = errors.WithStack(e)
+				cancel()
 			}
 		}
+	}
+
+	if err == nil {
+		cancel()
 	}
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Ping Yu <yuping@pingcap.com>

Close #696 

### Change
- invoke `cancel()` to release `ctx` in `bo` when there is no error.

### Test
Run this same program for reproducing in #696, the memory usage is stable and low for hour.
<img width="445" alt="image" src="https://user-images.githubusercontent.com/1907938/217409351-afce41ad-5218-452b-8cfe-31583de696d8.png">

