### PR TITLE
rawkv: Fix context leak in BatchDelete

### DIFF
--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -750,9 +750,9 @@ func (c *Client) sendBatchReq(bo *retry.Backoffer, keys [][]byte, options *rawOp
 		singleResp, ok := <-ches
 		if ok {
 			if singleResp.Error != nil {
-				cancel()
 				if firstError == nil {
 					firstError = errors.WithStack(singleResp.Error)
+					cancel()
 				}
 			} else if cmdType == tikvrpc.CmdRawBatchGet {
 				cmdResp := singleResp.Resp.(*kvrpcpb.RawBatchGetResponse)
@@ -761,6 +761,9 @@ func (c *Client) sendBatchReq(bo *retry.Backoffer, keys [][]byte, options *rawOp
 		}
 	}
 
+	if firstError == nil {
+		cancel()
+	}
 	return resp, firstError
 }
 


### PR DESCRIPTION
Close #696 (https://github.com/tikv/client-go/issues/696#issuecomment-1430868197)

### Change
- invoke `cancel()` to release ctx in `bo` when there is no error.

### Test
Run this same program for reproducing in https://github.com/tikv/client-go/issues/696#issuecomment-1430868197, the memory usage is stable and low for tens of minutes.
<img width="570" alt="image" src="https://user-images.githubusercontent.com/1907938/218959576-740c6d1f-c320-4907-ab6b-23a5ac8c8708.png">
