### PR TITLE
txn: set group name in twoPhaseCommitter

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -454,14 +454,15 @@ func (c *PlainMutations) AppendMutation(mutation PlainMutation) {
 // newTwoPhaseCommitter creates a twoPhaseCommitter.
 func newTwoPhaseCommitter(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, error) {
 	return &twoPhaseCommitter{
-		store:         txn.store,
-		txn:           txn,
-		startTS:       txn.StartTS(),
-		sessionID:     sessionID,
-		regionTxnSize: map[uint64]int{},
-		isPessimistic: txn.IsPessimistic(),
-		binlog:        txn.binlog,
-		diskFullOpt:   kvrpcpb.DiskFullOpt_NotAllowedOnFull,
+		store:             txn.store,
+		txn:               txn,
+		startTS:           txn.StartTS(),
+		sessionID:         sessionID,
+		regionTxnSize:     map[uint64]int{},
+		isPessimistic:     txn.IsPessimistic(),
+		binlog:            txn.binlog,
+		diskFullOpt:       kvrpcpb.DiskFullOpt_NotAllowedOnFull,
+		resourceGroupName: txn.resourceGroupName,
 	}, nil
 }
 


### PR DESCRIPTION
We need to also support track PessimisticLock request by resource group. The correspending changes at tidb side is https://github.com/glorv/tidb/commit/99b36924e7a8d4b836052de1648be02e0b374054.