### PR TITLE
metric: seperate source for txn cmd

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -119,6 +119,9 @@ const (
 	LblToStore         = "to_store"
 	LblStaleRead       = "stale_read"
 	LblSource          = "source"
+	LblScope           = "scope"
+	LblInternal        = "internal"
+	LblGeneral         = "general"
 )
 
 func initMetrics(namespace, subsystem string) {
@@ -129,7 +132,7 @@ func initMetrics(namespace, subsystem string) {
 			Name:      "txn_cmd_duration_seconds",
 			Help:      "Bucketed histogram of processing time of txn cmds.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
-		}, []string{LblType})
+		}, []string{LblType, LblScope})
 
 	TiKVBackoffHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -38,11 +38,16 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Shortcuts for performance improvement.
 var (
-	TxnCmdHistogramWithCommit   prometheus.Observer
-	TxnCmdHistogramWithRollback prometheus.Observer
-	TxnCmdHistogramWithBatchGet prometheus.Observer
-	TxnCmdHistogramWithGet      prometheus.Observer
-	TxnCmdHistogramWithLockKeys prometheus.Observer
+	TxnCmdHistogramWithCommitInternal   prometheus.Observer
+	TxnCmdHistogramWithCommitGeneral    prometheus.Observer
+	TxnCmdHistogramWithRollbackInternal prometheus.Observer
+	TxnCmdHistogramWithRollbackGeneral  prometheus.Observer
+	TxnCmdHistogramWithBatchGetInternal prometheus.Observer
+	TxnCmdHistogramWithBatchGetGeneral  prometheus.Observer
+	TxnCmdHistogramWithGetInternal      prometheus.Observer
+	TxnCmdHistogramWithGetGeneral       prometheus.Observer
+	TxnCmdHistogramWithLockKeysInternal prometheus.Observer
+	TxnCmdHistogramWithLockKeysGeneral  prometheus.Observer
 
 	RawkvCmdHistogramWithGet           prometheus.Observer
 	RawkvCmdHistogramWithBatchGet      prometheus.Observer
@@ -144,11 +149,16 @@ var (
 )
 
 func initShortcuts() {
-	TxnCmdHistogramWithCommit = TiKVTxnCmdHistogram.WithLabelValues(LblCommit)
-	TxnCmdHistogramWithRollback = TiKVTxnCmdHistogram.WithLabelValues(LblRollback)
-	TxnCmdHistogramWithBatchGet = TiKVTxnCmdHistogram.WithLabelValues(LblBatchGet)
-	TxnCmdHistogramWithGet = TiKVTxnCmdHistogram.WithLabelValues(LblGet)
-	TxnCmdHistogramWithLockKeys = TiKVTxnCmdHistogram.WithLabelValues(LblLockKeys)
+	TxnCmdHistogramWithCommitInternal = TiKVTxnCmdHistogram.WithLabelValues(LblCommit, LblInternal)
+	TxnCmdHistogramWithCommitGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblCommit, LblGeneral)
+	TxnCmdHistogramWithRollbackInternal = TiKVTxnCmdHistogram.WithLabelValues(LblRollback, LblInternal)
+	TxnCmdHistogramWithRollbackGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblRollback, LblGeneral)
+	TxnCmdHistogramWithBatchGetInternal = TiKVTxnCmdHistogram.WithLabelValues(LblBatchGet, LblInternal)
+	TxnCmdHistogramWithBatchGetGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblBatchGet, LblGeneral)
+	TxnCmdHistogramWithGetInternal = TiKVTxnCmdHistogram.WithLabelValues(LblGet, LblInternal)
+	TxnCmdHistogramWithGetGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblGet, LblGeneral)
+	TxnCmdHistogramWithLockKeysInternal = TiKVTxnCmdHistogram.WithLabelValues(LblLockKeys, LblInternal)
+	TxnCmdHistogramWithLockKeysGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblLockKeys, LblGeneral)
 
 	RawkvCmdHistogramWithGet = TiKVRawkvCmdHistogram.WithLabelValues("get")
 	RawkvCmdHistogramWithBatchGet = TiKVRawkvCmdHistogram.WithLabelValues("batch_get")

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -428,7 +428,13 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	}
 
 	start := time.Now()
-	defer func() { metrics.TxnCmdHistogramWithCommit.Observe(time.Since(start).Seconds()) }()
+	defer func() {
+		if txn.isInternal() {
+			metrics.TxnCmdHistogramWithCommitInternal.Observe(time.Since(start).Seconds())
+		} else {
+			metrics.TxnCmdHistogramWithCommitGeneral.Observe(time.Since(start).Seconds())
+		}
+	}()
 
 	// sessionID is used for log.
 	var sessionID uint64
@@ -555,7 +561,11 @@ func (txn *KVTxn) Rollback() error {
 	}
 	txn.close()
 	logutil.BgLogger().Debug("[kv] rollback txn", zap.Uint64("txnStartTS", txn.StartTS()))
-	metrics.TxnCmdHistogramWithRollback.Observe(time.Since(start).Seconds())
+	if txn.isInternal() {
+		metrics.TxnCmdHistogramWithRollbackInternal.Observe(time.Since(start).Seconds())
+	} else {
+		metrics.TxnCmdHistogramWithRollbackGeneral.Observe(time.Since(start).Seconds())
+	}
 	return nil
 }
 
@@ -586,6 +596,10 @@ func (txn *KVTxn) collectLockedKeys() [][]byte {
 		}
 	}
 	return keys
+}
+
+func (txn *KVTxn) isInternal() bool {
+	return util.IsRequestSourceInternal(txn.RequestSource)
 }
 
 // TxnInfo is used to keep track the info of a committed transaction (mainly for diagnosis and testing)
@@ -876,7 +890,11 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	defer func() {
-		metrics.TxnCmdHistogramWithLockKeys.Observe(time.Since(startTime).Seconds())
+		if txn.isInternal() {
+			metrics.TxnCmdHistogramWithLockKeysInternal.Observe(time.Since(startTime).Seconds())
+		} else {
+			metrics.TxnCmdHistogramWithLockKeysGeneral.Observe(time.Since(startTime).Seconds())
+		}
 		if err == nil {
 			if lockCtx.PessimisticLockWaited != nil {
 				if atomic.LoadInt32(lockCtx.PessimisticLockWaited) > 0 {

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -190,6 +190,7 @@ func (s *KVSnapshot) SetSnapshotTS(ts uint64) {
 	s.resolvedLocks = util.TSSet{}
 }
 
+// IsInternal returns if the KvSnapshot is used by internal executions.
 func (s *KVSnapshot) IsInternal() bool {
 	return util.IsRequestSourceInternal(s.RequestSource)
 }

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -60,6 +60,15 @@ func WithInternalSourceType(ctx context.Context, source string) context.Context 
 	})
 }
 
+// IsRequestSourceInternal checks whether the input request source type is internal type.
+func IsRequestSourceInternal(reqSrc *RequestSource) bool {
+	isInternal := false
+	if reqSrc != nil && IsInternalRequest(reqSrc.GetRequestSource()) {
+		isInternal = true
+	}
+	return isInternal
+}
+
 // GetRequestSource gets the request_source field of the request.
 func (r *RequestSource) GetRequestSource() string {
 	// if r.RequestSourceType is not set, it's mostly possible that r.RequestSourceInternal is not set


### PR DESCRIPTION
ref: https://github.com/pingcap/tidb/issues/41203

Add source scope for the `TiKVTxnCmdHistogram` metric.

Before
![image](https://user-images.githubusercontent.com/3692139/221743048-df8929d2-9c11-4717-ae9c-1f2d5a4c3046.png)


After
![image](https://user-images.githubusercontent.com/3692139/221743117-bcfcbbc7-7e7b-4205-8f4e-3413618309b5.png)
