### PR TITLE
resource_control: consider default as a normal group

### DIFF
--- a/internal/client/client_interceptor.go
+++ b/internal/client/client_interceptor.go
@@ -91,9 +91,8 @@ func buildResourceControlInterceptor(
 		return nil
 	}
 	resourceGroupName := req.GetResourceGroupName()
-	// When the group name is empty or "default", we don't need to
-	// perform the resource control.
-	if len(resourceGroupName) == 0 || resourceGroupName == "default" {
+	// When the group name is empty we don't need to perform the resource control.
+	if len(resourceGroupName) == 0 {
 		return nil
 	}
 	// No resource group interceptor is set.


### PR DESCRIPTION
Currently we support to config the default resource group, relative https://github.com/pingcap/tidb/pull/41606. after remove resource group, we can see the metrics:
![image](https://user-images.githubusercontent.com/6428910/225533647-0fc0053e-a7e2-45aa-a4ae-aa805f753853.png)
