### PR TITLE
[tidb-7.0] Add exitAggressiveLockingIfInapplicable function and call within mutex of lockKeys

### DIFF
--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -902,7 +902,7 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	startTime := time.Now()
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	
+
 	err = txn.exitAggressiveLockingIfInapplicable(ctx, keysInput)
 	if err != nil {
 		return err


### PR DESCRIPTION
Porting https://github.com/tikv/client-go/pull/749 to the version used by tidb 7.0
