### PR TITLE
txnkv: relax value check on lock->put untouched kv

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -1819,7 +1819,7 @@ func (s *testCommitterSuite) TestSetLockedKeyValue() {
 				func(txn transaction.TxnProbe) { mustLockKey(txn, k2) },
 				func(txn transaction.TxnProbe) { s.Require().NoError(txn.Set(k2, v2)) },
 			},
-			checkByOpVals(kvrpcpb.Op_Lock, v2),
+			checkByOpVals(kvrpcpb.Op_Put, v1),
 			checkByOpVals(kvrpcpb.Op_Lock, v2),
 		},
 		{

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -562,7 +562,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 					if !flags.HasLocked() {
 						continue
 					}
-					if val, ok := txn.getValueByLockedKey(key); ok && bytes.Equal(val, value) && c.isPessimistic {
+					if val, ok := txn.getValueByLockedKey(key); ok && len(val) > 0 && c.isPessimistic {
 						// Change the LOCK into PUT if the value of this key has a cached value.
 						cachedValue = val
 						op = kvrpcpb.Op_Put


### PR DESCRIPTION
Let
- k be the locked key that might be converted to PUT
- v be the value from membuf
- v' be the value from lockedKV

When IsUnnecessaryKeyValue(k, v) is true, we require v = v' when doing lock->put optimization, however it's not true because v has a tail untouched flag. So this PR tries to relex the value check.

