### PR TITLE
metrics: add txn ttl lifetime

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -75,6 +75,7 @@ var (
 	TiKVRangeTaskPushDuration                *prometheus.HistogramVec
 	TiKVTokenWaitDuration                    prometheus.Histogram
 	TiKVTxnHeartBeatHistogram                *prometheus.HistogramVec
+	TiKVTTLManagerHistogram                  prometheus.Histogram
 	TiKVPessimisticLockKeysDuration          prometheus.Histogram
 	TiKVTTLLifeTimeReachCounter              prometheus.Counter
 	TiKVNoAvailableConnectionCounter         prometheus.Counter
@@ -422,6 +423,15 @@ func initMetrics(namespace, subsystem string) {
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms ~ 524s
 		}, []string{LblType})
 
+	TiKVTTLManagerHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "txn_ttl_manager",
+			Help:      "Bucketed histogram of the txn ttl manager lifetime duration.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 20), // 1s ~ 524288s
+		})
+
 	TiKVPessimisticLockKeysDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -677,6 +687,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVRangeTaskPushDuration)
 	prometheus.MustRegister(TiKVTokenWaitDuration)
 	prometheus.MustRegister(TiKVTxnHeartBeatHistogram)
+	prometheus.MustRegister(TiKVTTLManagerHistogram)
 	prometheus.MustRegister(TiKVPessimisticLockKeysDuration)
 	prometheus.MustRegister(TiKVTTLLifeTimeReachCounter)
 	prometheus.MustRegister(TiKVNoAvailableConnectionCounter)

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1144,6 +1144,10 @@ func keepAlive(c *twoPhaseCommitter, closeCh chan struct{}, primaryKey []byte, l
 	// Ticker is set to 1/2 of the ManagedLockTTL.
 	ticker := time.NewTicker(time.Duration(atomic.LoadUint64(&ManagedLockTTL)) * time.Millisecond / 2)
 	defer ticker.Stop()
+	startKeepAlive := time.Now()
+	defer func() {
+		metrics.TiKVTTLManagerHistogram.Observe(time.Since(startKeepAlive).Seconds())
+	}()
 	keepFail := 0
 	for {
 		select {


### PR DESCRIPTION
There is only metric for txn heartbeat duration, add a metric for the txn ttl lifetime, which may easy for us to know how long the lock to hold by a transaction.