### PR TITLE
log: print log if the assertion error is generated from client-go

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -38,6 +38,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	errors2 "errors"
 	"math"
 	"math/rand"
 	"strings"
@@ -512,7 +513,11 @@ func (c *twoPhaseCommitter) checkAssertionByPessimisticLockResults(ctx context.C
 	}
 
 	if assertionFailed != nil {
-		return c.checkSchemaOnAssertionFail(ctx, assertionFailed)
+		err := c.checkSchemaOnAssertionFail(ctx, assertionFailed)
+		if errors2.Is(err, assertionFailed) {
+			logutil.Logger(ctx).Error("assertion failed when checking by pessimistic lock results")
+		}
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
It helps us identify the source of the error when investigating issues.