### PR TITLE
Add integration test for the issue that stale pessimistic lock request with force-locking enabled may cause data inconsistency after resolving lock

### DIFF
--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1354,6 +1354,7 @@ storeIter:
 		}
 	}
 
+	// Prevent goleak from complaining about its internal connections.
 	http.DefaultClient.CloseIdleConnections()
 
 	if len(recoverConfigs) > 0 {
@@ -1368,6 +1369,9 @@ storeIter:
 				t.Logf("failed to recover config for store at %s: %v", item.url, err)
 			}
 		}
+
+		// Prevent goleak from complaining about its internal connections.
+		http.DefaultClient.CloseIdleConnections()
 	}
 }
 

--- a/tikv/test_probe.go
+++ b/tikv/test_probe.go
@@ -109,6 +109,11 @@ func (s StoreProbe) SetSafeTS(storeID, safeTS uint64) {
 	s.setSafeTS(storeID, safeTS)
 }
 
+// GCResolveLockPhase performs the resolve-locks phase of GC, which scans all locks and resolves them.
+func (s StoreProbe) GCResolveLockPhase(ctx context.Context, safepoint uint64, concurrency int) error {
+	return s.resolveLocks(ctx, safepoint, concurrency)
+}
+
 // LockResolverProbe wraps a LockResolver and exposes internal stats for testing purpose.
 type LockResolverProbe struct {
 	*txnlock.LockResolverProbe

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/tikv/client-go/v2/internal/locate"
 	"github.com/tikv/client-go/v2/internal/retry"
 	"github.com/tikv/client-go/v2/internal/unionstore"
@@ -276,6 +277,12 @@ func (c CommitterProbe) CommitMutations(ctx context.Context) error {
 // MutationsOfKeys returns mutations match the keys.
 func (c CommitterProbe) MutationsOfKeys(keys [][]byte) CommitterMutations {
 	return c.mutationsOfKeys(keys)
+}
+
+// PessimisticLockMutations pessimistic locks mutations.
+func (c CommitterProbe) PessimisticLockMutations(ctx context.Context, lockCtx *kv.LockCtx, lockWaitMode kvrpcpb.PessimisticLockWakeUpMode, muts CommitterMutations) error {
+	bo := retry.NewBackofferWithVars(ctx, pessimisticLockMaxBackoff, kv.DefaultVars)
+	return c.pessimisticLockMutations(bo, lockCtx, lockWaitMode, muts)
 }
 
 // PessimisticRollbackMutations rolls mutations back.

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1060,6 +1060,9 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 
 	metrics.LockResolverCountWithResolveLocks.Inc()
 	resolveLite := lite || l.TxnSize < lr.resolveLockLiteThreshold
+	if val, err := util.EvalFailpoint("forceSetResolveLockLite"); err == nil {
+		resolveLite = val.(bool)
+	}
 	// The lock has been resolved by getTxnStatusFromLock.
 	if resolveLite && bytes.Equal(l.Key, l.Primary) {
 		return nil


### PR DESCRIPTION
Ref: https://github.com/tikv/tikv/issues/14551

This PR adds a integration test case to cover the issue stated in https://github.com/tikv/tikv/issues/14551

It's confirmed that the test will fail when running on older TiKV versions without [the fix](https://github.com/tikv/tikv/pull/14557)

```
    lock_test.go:1483:
                Error Trace:    /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1483
                                                        /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1510
                                                        /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1513
                Error:          Received unexpected error:
                                not exist
                                github.com/tikv/client-go/v2/error.init
                                        /home/tidb/misono/sync/client-go/error/error.go:53
                                runtime.doInit
                                        /usr/local/go/src/runtime/proc.go:6506
                                runtime.doInit
                                        /usr/local/go/src/runtime/proc.go:6483
                                runtime.doInit
                                        /usr/local/go/src/runtime/proc.go:6483
                                runtime.doInit
                                        /usr/local/go/src/runtime/proc.go:6483
                                runtime.doInit
                                        /usr/local/go/src/runtime/proc.go:6483
                                runtime.main
                                        /usr/local/go/src/runtime/proc.go:233
                                runtime.goexit
                                        /usr/local/go/src/runtime/asm_amd64.s:1598
                Test:           TestLockWithTiKV/TestStaleForcePessimisticLockNotCommitted
    lock_test.go:1484:
                Error Trace:    /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1484
                                                        /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1510
                                                        /home/tidb/misono/sync/client-go/integration_tests/lock_test.go:1513
                Error:          Not equal:
                                expected: []byte{0x76, 0x32}
                                actual  : []byte(nil)

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,4 +1,2 @@
                                -([]uint8) (len=2) {
                                - 00000000  76 32                                             |v2|
                                -}
                                +([]uint8) <nil>

                Test:           TestLockWithTiKV/TestStaleForcePessimisticLockNotCommitted
```