### PR TITLE
doc(tikv/test_probe.go) fix case typo in comment.

### DIFF
--- a/tikv/test_probe.go
+++ b/tikv/test_probe.go
@@ -46,7 +46,7 @@ import (
 	pd "github.com/tikv/pd/client"
 )
 
-// StoreProbe wraps KVSTore and exposes internal states for testing purpose.
+// StoreProbe wraps KVStore and exposes internal states for testing purpose.
 type StoreProbe struct {
 	*KVStore
 }


### PR DESCRIPTION
Modify the name in the comment from "KVSTore" to "KVStore" match the type name.