### PR TITLE
pd http: support api to get store min resolved ts 

### DIFF
--- a/integration_tests/pd_api_test.go
+++ b/integration_tests/pd_api_test.go
@@ -66,11 +66,10 @@ type apiTestSuite struct {
 
 func (s *apiTestSuite) SetupTest() {
 	addrs := strings.Split(*pdAddrs, ",")
-	// Set PD HTTP client.
 	pdClient, err := pd.NewClient(addrs, pd.SecurityOption{})
 	s.Require().Nil(err)
-
 	rpcClient := tikv.NewRPCClient()
+	// Set PD HTTP client.
 	store, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0, tikv.WithPDHTTPClient(nil, addrs))
 	s.store = store
 	storeID := uint64(1)

--- a/integration_tests/pd_api_test.go
+++ b/integration_tests/pd_api_test.go
@@ -52,9 +52,9 @@ import (
 	pd "github.com/tikv/pd/client"
 )
 
-func TestPDApi(t *testing.T) {
+func TestPDAPI(t *testing.T) {
 	if !*withTiKV {
-		t.Skip("skipping TestPDApi because with-tikv is not enabled")
+		t.Skip("skipping TestPDAPI because with-tikv is not enabled")
 	}
 	suite.Run(t, new(apiTestSuite))
 }
@@ -106,7 +106,8 @@ func (c *storeSafeTsMockClient) CloseAddr(addr string) error {
 func (s *apiTestSuite) TestGetStoreMinResolvedTS() {
 	util.EnableFailpoints()
 	// Try to get the minimum resolved timestamp of the store from PD.
-	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(100)`))
+	require := s.Require()
+	require.Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(100)`))
 	mockClient := storeSafeTsMockClient{
 		Client: s.store.GetTiKVClient(),
 	}
@@ -119,12 +120,12 @@ func (s *apiTestSuite) TestGetStoreMinResolvedTS() {
 		}
 		retryCount++
 	}
-	s.Require().Equal(atomic.LoadInt32(&mockClient.requestCount), int32(0))
-	s.Require().Equal(uint64(100), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
-	s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
+	require.Equal(atomic.LoadInt32(&mockClient.requestCount), int32(0))
+	require.Equal(uint64(100), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
+	require.Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
 
 	// Try to get the minimum resolved timestamp of the store from TiKV.
-	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(0)`))
+	require.Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(0)`))
 	defer func() {
 		s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
 	}()
@@ -136,8 +137,8 @@ func (s *apiTestSuite) TestGetStoreMinResolvedTS() {
 		}
 		retryCount++
 	}
-	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(1))
-	s.Require().Equal(uint64(150), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
+	require.GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(1))
+	require.Equal(uint64(150), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
 }
 
 func (s *apiTestSuite) TearDownTest() {

--- a/integration_tests/pd_api_test.go
+++ b/integration_tests/pd_api_test.go
@@ -1,0 +1,148 @@
+// Copyright 2023 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: The code in this file is based on code from the
+// TiDB project, licensed under the Apache License v 2.0
+//
+// https://github.com/pingcap/tidb/tree/cc5e161ac06827589c4966674597c137cc9e809c/store/tikv/tests/prewrite_test.go
+//
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/suite"
+	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/util"
+	pd "github.com/tikv/pd/client"
+)
+
+func TestPDApi(t *testing.T) {
+	if !*withTiKV {
+		t.Skip("skipping TestPDApi because with-tikv is not enabled")
+	}
+	suite.Run(t, new(apiTestSuite))
+}
+
+type apiTestSuite struct {
+	suite.Suite
+	store *tikv.KVStore
+}
+
+func (s *apiTestSuite) SetupTest() {
+	addrs := strings.Split(*pdAddrs, ",")
+	// Set PD HTTP client.
+	pdClient, err := pd.NewClient(addrs, pd.SecurityOption{})
+	s.Require().Nil(err)
+
+	rpcClient := tikv.NewRPCClient()
+	store, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0, tikv.WithPDHTTPClient(nil, addrs))
+	s.store = store
+	storeID := uint64(1)
+	s.store.GetRegionCache().SetRegionCacheStore(storeID, s.storeAddr(storeID), s.storeAddr(storeID), tikvrpc.TiKV, 1, nil)
+}
+
+func (s *apiTestSuite) storeAddr(id uint64) string {
+	return fmt.Sprintf("store%d", id)
+}
+
+type storeSafeTsMockClient struct {
+	tikv.Client
+	requestCount int32
+}
+
+func (c *storeSafeTsMockClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	if req.Type != tikvrpc.CmdStoreSafeTS {
+		return c.Client.SendRequest(ctx, addr, req, timeout)
+	}
+	atomic.AddInt32(&c.requestCount, 1)
+	resp := &tikvrpc.Response{}
+	resp.Resp = &kvrpcpb.StoreSafeTSResponse{SafeTs: 150}
+	return resp, nil
+}
+
+func (c *storeSafeTsMockClient) Close() error {
+	return c.Client.Close()
+}
+
+func (c *storeSafeTsMockClient) CloseAddr(addr string) error {
+	return c.Client.CloseAddr(addr)
+}
+
+func (s *apiTestSuite) TestGetStoreMinResolvedTS() {
+	util.EnableFailpoints()
+	// Try to get the minimum resolved timestamp of the store from PD.
+	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(100)`))
+	mockClient := storeSafeTsMockClient{
+		Client: s.store.GetTiKVClient(),
+	}
+	s.store.SetTiKVClient(&mockClient)
+	var retryCount int
+	for s.store.GetMinSafeTS(oracle.GlobalTxnScope) != 100 {
+		time.Sleep(2 * time.Second)
+		if retryCount > 5 {
+			break
+		}
+		retryCount++
+	}
+	s.Require().Equal(atomic.LoadInt32(&mockClient.requestCount), int32(0))
+	s.Require().Equal(uint64(100), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
+	s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
+
+	// Try to get the minimum resolved timestamp of the store from TiKV.
+	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(0)`))
+	defer func() {
+		s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
+	}()
+	retryCount = 0
+	for s.store.GetMinSafeTS(oracle.GlobalTxnScope) != 150 {
+		time.Sleep(2 * time.Second)
+		if retryCount > 5 {
+			break
+		}
+		retryCount++
+	}
+	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(1))
+	s.Require().Equal(uint64(150), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
+}
+
+func (s *apiTestSuite) TearDownTest() {
+	if s.store != nil {
+		s.Require().Nil(s.store.Close())
+	}
+}

--- a/integration_tests/raw/api_test.go
+++ b/integration_tests/raw/api_test.go
@@ -19,9 +19,9 @@ import (
 	pd "github.com/tikv/pd/client"
 )
 
-func TestApi(t *testing.T) {
+func TestAPI(t *testing.T) {
 	if !*withTiKV {
-		t.Skip("skipping TestApi because with-tikv is not enabled")
+		t.Skip("skipping TestAPI because with-tikv is not enabled")
 	}
 	suite.Run(t, new(apiTestSuite))
 }

--- a/integration_tests/raw/api_test.go
+++ b/integration_tests/raw/api_test.go
@@ -8,19 +8,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/stretchr/testify/suite"
 	"github.com/tidwall/gjson"
-	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/rawkv"
 	"github.com/tikv/client-go/v2/tikv"
-	"github.com/tikv/client-go/v2/tikvrpc"
-	"github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 )
 
@@ -36,9 +31,7 @@ type apiTestSuite struct {
 	client       *rawkv.Client
 	clientForCas *rawkv.Client
 	pdClient     pd.Client
-	pdHttpClient *util.PDHTTPClient
 	apiVersion   kvrpcpb.APIVersion
-	store        *tikv.KVStore
 }
 
 func getConfig(url string) (string, error) {
@@ -101,20 +94,6 @@ func (s *apiTestSuite) SetupTest() {
 
 	client := s.newRawKVClient(pdClient, addrs)
 	s.client = client
-
-	// Set PD HTTP client.
-	var pdAddresses []string
-	for _, addr := range addrs {
-		pdAddresses = append(pdAddresses, addr)
-	}
-	s.pdHttpClient = util.NewPDHTTPClient(nil, pdAddresses)
-
-	rpcClient := tikv.NewRPCClient()
-	defer rpcClient.Close()
-	store, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0, tikv.WithPDHttpClient(nil, addrs))
-	s.store = store
-	storeID := uint64(1)
-	s.store.GetRegionCache().SetRegionCacheStore(storeID, s.storeAddr(storeID), s.storeAddr(storeID), tikvrpc.TiKV, 1, nil)
 
 	clientForCas := s.newRawKVClient(pdClient, addrs)
 	clientForCas.SetAtomicForCAS(true)
@@ -536,70 +515,6 @@ func (s *apiTestSuite) TestEmptyValue() {
 	s.Equal([]byte{}, oldVal)
 }
 
-func (s *apiTestSuite) storeAddr(id uint64) string {
-	return fmt.Sprintf("store%d", id)
-}
-
-type storeSafeTsMockClient struct {
-	tikv.Client
-	requestCount int32
-}
-
-func (c *storeSafeTsMockClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
-	if req.Type != tikvrpc.CmdStoreSafeTS {
-		return c.Client.SendRequest(ctx, addr, req, timeout)
-	}
-	atomic.AddInt32(&c.requestCount, 1)
-	resp := &tikvrpc.Response{}
-	resp.Resp = &kvrpcpb.StoreSafeTSResponse{SafeTs: 150}
-	return resp, nil
-}
-
-func (c *storeSafeTsMockClient) Close() error {
-	return c.Client.Close()
-}
-
-func (c *storeSafeTsMockClient) CloseAddr(addr string) error {
-	return c.Client.CloseAddr(addr)
-}
-
-func (s *apiTestSuite) TestGetStoreMinResolvedTS() {
-	util.EnableFailpoints()
-	// Try to get the minimum resolved timestamp of the store from PD.
-	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(100)`))
-	mockClient := storeSafeTsMockClient{
-		Client: s.store.GetTiKVClient(),
-	}
-	s.store.SetTiKVClient(&mockClient)
-	var retryCount int
-	for s.store.GetMinSafeTS(oracle.GlobalTxnScope) != 100 {
-		time.Sleep(2 * time.Second)
-		if retryCount > 5 {
-			break
-		}
-		retryCount++
-	}
-	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(0))
-	s.Require().Equal(uint64(100), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
-	s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
-
-	// Try to get the minimum resolved timestamp of the store from TiKV.
-	s.Require().Nil(failpoint.Enable("tikvclient/InjectMinResolvedTS", `return(0)`))
-	defer func() {
-		s.Require().Nil(failpoint.Disable("tikvclient/InjectMinResolvedTS"))
-	}()
-	retryCount = 0
-	for s.store.GetMinSafeTS(oracle.GlobalTxnScope) != 150 {
-		time.Sleep(2 * time.Second)
-		if retryCount > 5 {
-			break
-		}
-		retryCount++
-	}
-	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(2))
-	s.Require().Equal(uint64(150), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
-}
-
 func (s *apiTestSuite) TearDownTest() {
 	if s.client != nil {
 		s.Require().Nil(s.client.Close())
@@ -609,11 +524,5 @@ func (s *apiTestSuite) TearDownTest() {
 	}
 	if s.pdClient != nil {
 		s.pdClient.Close()
-	}
-	if s.store != nil {
-		s.Require().Nil(s.store.Close())
-	}
-	if s.pdHttpClient != nil {
-		s.pdHttpClient.Close()
 	}
 }

--- a/integration_tests/ticlient_test.go
+++ b/integration_tests/ticlient_test.go
@@ -69,8 +69,9 @@ func (s *testTiclientSuite) TearDownSuite() {
 	// Clean all data, or it may pollute other data.
 	txn := s.beginTxn()
 	scanner, err := txn.Iter(encodeKey(s.prefix, ""), nil)
-	s.Require().Nil(err)
-	s.Require().NotNil(scanner)
+	require := s.Require()
+	require.Nil(err)
+	require.NotNil(scanner)
 	for scanner.Valid() {
 		k := scanner.Key()
 		err = txn.Delete(k)
@@ -78,9 +79,9 @@ func (s *testTiclientSuite) TearDownSuite() {
 		scanner.Next()
 	}
 	err = txn.Commit(context.Background())
-	s.Require().Nil(err)
+	require.Nil(err)
 	err = s.store.Close()
-	s.Require().Nil(err)
+	require.Nil(err)
 }
 
 func (s *testTiclientSuite) beginTxn() *tikv.KVTxn {

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/log"
+	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"go.uber.org/zap"
 )
@@ -115,7 +115,7 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 		// TODO: using a more accurate size rather than using the whole response size as the read bytes.
 		readBytes = uint64(r.Size())
 	default:
-		log.Debug("[kv resource] unknown response type to collect the info", zap.Any("type", reflect.TypeOf(r)))
+		logutil.BgLogger().Debug("[kv resource] unknown response type to collect the info", zap.Any("type", reflect.TypeOf(r)))
 		return &ResponseInfo{}
 	}
 	// Try to get read bytes from the `detailsV2`.

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -67,7 +67,7 @@ type Future interface {
 const (
 	physicalShiftBits = 18
 	logicalBits       = (1 << physicalShiftBits) - 1
-	// GlobalTxnScope is the default transaction scope for a Oracle service.
+	// GlobalTxnScope is the default transaction scope for an Oracle service.
 	GlobalTxnScope = "global"
 )
 

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -194,8 +194,8 @@ func WithPool(gp Pool) Option {
 	}
 }
 
-// WithPDTLSConfig set the pd addrs and tls for pdHttpClient.
-func WithPDTLSConfig(tlsConf *tls.Config, pdaddrs []string) Option {
+// WithPDHttpClient set the pd addrs and tls for pdHttpClient.
+func WithPDHttpClient(tlsConf *tls.Config, pdaddrs []string) Option {
 	return func(o *KVStore) {
 		o.pdHttpClient = util.NewPDHTTPClient(tlsConf, pdaddrs)
 	}

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -601,6 +601,9 @@ func (s *KVStore) updateSafeTS(ctx context.Context) {
 			// Try to get the minimum resolved timestamp of the store from PD.
 			if s.pdHttpClient != nil {
 				safeTS, err = s.pdHttpClient.GetStoreMinResolvedTS(ctx, storeID)
+				if err != nil {
+					logutil.BgLogger().Debug("get resolved TS from PD failed", zap.Error(err), zap.Uint64("store-id", storeID))
+				}
 			}
 			// If getting the minimum resolved timestamp from PD failed or returned 0, try to get it from TiKV.
 			if safeTS == 0 || err != nil {

--- a/tikv/test_util.go
+++ b/tikv/test_util.go
@@ -65,7 +65,7 @@ func (c *CodecClient) SendRequest(ctx context.Context, addr string, req *tikvrpc
 }
 
 // NewTestTiKVStore creates a test store with Option
-func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, txnLocalLatches uint) (*KVStore, error) {
+func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, txnLocalLatches uint, opt ...Option) (*KVStore, error) {
 	codec := apicodec.NewCodecV1(apicodec.ModeTxn)
 	client = &CodecClient{
 		Client: client,
@@ -84,7 +84,7 @@ func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Clien
 	// Make sure the uuid is unique.
 	uid := uuid.New().String()
 	spkv := NewMockSafePointKV()
-	tikvStore, err := NewKVStore(uid, pdCli, spkv, client)
+	tikvStore, err := NewKVStore(uid, pdCli, spkv, client, opt...)
 
 	if txnLocalLatches > 0 {
 		tikvStore.EnableTxnLocalLatches(txnLocalLatches)

--- a/util/pd.go
+++ b/util/pd.go
@@ -39,8 +39,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/log"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
@@ -49,6 +47,9 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 )
 
 // pd request retry time when connection fail

--- a/util/pd.go
+++ b/util/pd.go
@@ -53,13 +53,13 @@ import (
 )
 
 const (
-	// pd request retry time when connection fail
+	// pd request retry time when connection fail.
 	pdRequestRetryTime = 10
 
 	storeMinResolvedTSPrefix = "pd/api/v1/min-resolved-ts"
 )
 
-// PDHTTPClient is an HTTP client of pd
+// PDHTTPClient is an HTTP client of pd.
 type PDHTTPClient struct {
 	addrs []string
 	cli   *http.Client
@@ -86,7 +86,7 @@ func NewPDHTTPClient(
 	}
 }
 
-// GetStoreMinResolvedTS get store-level min-resolved-ts from pd
+// GetStoreMinResolvedTS get store-level min-resolved-ts from pd.
 func (p *PDHTTPClient) GetStoreMinResolvedTS(ctx context.Context, storeID uint64) (uint64, error) {
 	var err error
 	for _, addr := range p.addrs {
@@ -112,7 +112,7 @@ func (p *PDHTTPClient) GetStoreMinResolvedTS(ctx context.Context, storeID uint64
 			return 0, errors.Trace(message)
 		}
 		if val, e := EvalFailpoint("InjectMinResolvedTS"); e == nil {
-			// Need to make sure successfully get from real pd
+			// Need to make sure successfully get from real pd.
 			if d.MinResolvedTS != 0 {
 				// Should be val.(uint64) but failpoint doesn't support that.
 				if tmp, ok := val.(int); ok {
@@ -207,5 +207,5 @@ func httpClient(tlsConf *tls.Config) *http.Client {
 
 func (p *PDHTTPClient) Close() {
 	p.cli.CloseIdleConnections()
-	log.Info("close pd http client")
+	log.Info("closed pd http client")
 }

--- a/util/pd.go
+++ b/util/pd.go
@@ -207,4 +207,5 @@ func httpClient(tlsConf *tls.Config) *http.Client {
 
 func (p *PDHTTPClient) Close() {
 	p.cli.CloseIdleConnections()
+	log.Info("close pd http client")
 }

--- a/util/pd.go
+++ b/util/pd.go
@@ -107,9 +107,9 @@ func (p *PDHTTPClient) GetStoreMinResolvedTS(ctx context.Context, storeID uint64
 			return 0, errors.Trace(err)
 		}
 		if !d.IsRealTime {
-			message := "store min resolved ts not enabled"
-			log.Error(message, zap.String("addr", addr))
-			return 0, errors.Trace(errors.New(message))
+			message := fmt.Errorf("store min resolved ts not enabled, addr: %s", addr)
+			log.Error(message.Error())
+			return 0, errors.Trace(message)
 		}
 		if val, e := EvalFailpoint("InjectMinResolvedTS"); e == nil {
 			// Need to make sure successfully get from real pd
@@ -123,6 +123,7 @@ func (p *PDHTTPClient) GetStoreMinResolvedTS(ctx context.Context, storeID uint64
 
 		return d.MinResolvedTS, nil
 	}
+
 	return 0, errors.Trace(err)
 }
 

--- a/util/pd.go
+++ b/util/pd.go
@@ -59,7 +59,7 @@ const (
 	storeMinResolvedTSPrefix = "pd/api/v1/min-resolved-ts"
 )
 
-// PDHTTPClient manage get/update config from pd.
+// PDHTTPClient is an HTTP client of pd
 type PDHTTPClient struct {
 	addrs []string
 	cli   *http.Client

--- a/util/pd.go
+++ b/util/pd.go
@@ -39,7 +39,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"net/url"
@@ -50,6 +49,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"go.uber.org/zap"
 )
 
 // pd request retry time when connection fail

--- a/util/pd.go
+++ b/util/pd.go
@@ -1,0 +1,203 @@
+// Copyright 2023 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: The code in this file is based on code from the
+// TiDB project, licensed under the Apache License v 2.0
+//
+// https://github.com/pingcap/tidb/tree/cc5e161ac06827589c4966674597c137cc9e809c/store/tikv/util/execdetails.go
+//
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// pd request retry time when connection fail
+const (
+	pdRequestRetryTime = 10
+
+	storeMinResolvedTSPrefix = "pd/api/v1/min-resolved-ts"
+)
+
+// PdController manage get/update config from pd.
+type PdController struct {
+	addrs []string
+	cli   *http.Client
+}
+
+func NewPdController(
+	tlsConf *tls.Config,
+	pdAddrs []string,
+) *PdController {
+	for i, addr := range pdAddrs {
+		if !strings.HasPrefix(addr, "http") {
+			if tlsConf != nil {
+				addr = "https://" + addr
+			} else {
+				addr = "http://" + addr
+			}
+			pdAddrs[i] = addr
+		}
+	}
+
+	return &PdController{
+		addrs: pdAddrs,
+		cli:   httpClient(tlsConf),
+	}
+}
+
+// GetStoreMinResolvedTS get store-level min-resolved-ts from pd
+func (p *PdController) GetStoreMinResolvedTS(ctx context.Context, storeID uint64) (uint64, error) {
+	var err error
+	for _, addr := range p.addrs {
+		query := fmt.Sprintf("%s/store_id=%d", storeMinResolvedTSPrefix, storeID)
+		v, e := pdRequest(ctx, addr, query, p.cli, http.MethodGet, nil)
+		if e != nil {
+			log.Warn("failed to get min resolved ts", zap.String("addr", addr), zap.Error(e))
+			err = e
+			continue
+		}
+		log.Info("store min resolved ts", zap.String("resp", string(v)))
+		d := struct {
+			IsRealTime    bool   `json:"is_real_time,omitempty"`
+			MinResolvedTS uint64 `json:"min_resolved_ts"`
+		}{}
+		err = json.Unmarshal(v, &d)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		if !d.IsRealTime {
+			message := "store min resolved ts not enabled"
+			log.Error(message, zap.String("addr", addr))
+			return 0, errors.Trace(errors.New(message))
+		}
+		return d.MinResolvedTS, nil
+	}
+	return 0, errors.Trace(err)
+}
+
+// pdRequest is a func to send an HTTP to pd and return the result bytes.
+func pdRequest(
+	ctx context.Context,
+	addr string, prefix string,
+	cli *http.Client, method string, body io.Reader) ([]byte, error) {
+	_, respBody, err := pdRequestWithCode(ctx, addr, prefix, cli, method, body)
+	return respBody, err
+}
+
+func pdRequestWithCode(
+	ctx context.Context,
+	addr string, prefix string,
+	cli *http.Client, method string, body io.Reader) (int, []byte, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return 0, nil, errors.Trace(err)
+	}
+	reqURL := fmt.Sprintf("%s/%s", u, prefix)
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return 0, nil, errors.Trace(err)
+	}
+	var resp *http.Response
+	count := 0
+	for {
+		resp, err = cli.Do(req)
+		count++
+
+		if _, e := EvalFailpoint("InjectClosed"); e == nil {
+			resp = nil
+			err = &url.Error{
+				Op:  "read",
+				Err: os.NewSyscallError("connect", syscall.ECONNREFUSED),
+			}
+			return 0, nil, errors.Trace(err)
+		}
+
+		if count > pdRequestRetryTime || (resp != nil && resp.StatusCode < 500) ||
+			err != nil {
+			break
+		}
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(pdRequestRetryInterval())
+	}
+	if err != nil {
+		return 0, nil, errors.Trace(err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		res, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, nil, errors.Errorf("[%d] %s %s", resp.StatusCode, res, reqURL)
+	}
+
+	r, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, errors.Trace(err)
+	}
+	return resp.StatusCode, r, nil
+}
+
+func pdRequestRetryInterval() time.Duration {
+	if _, e := EvalFailpoint("FastRetry"); e == nil {
+		return 0
+	}
+	println("pd request retry interval 1s")
+
+	return time.Second
+}
+
+// httpClient returns an HTTP(s) client.
+func httpClient(tlsConf *tls.Config) *http.Client {
+	// defaultTimeout for non-context requests.
+	const defaultTimeout = 30 * time.Second
+	cli := &http.Client{Timeout: defaultTimeout}
+	if tlsConf != nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConf
+		cli.Transport = transport
+	}
+	return cli
+}

--- a/util/pd_test.go
+++ b/util/pd_test.go
@@ -37,11 +37,12 @@ package util
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/failpoint"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pingcap/failpoint"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPDRequestRetry(t *testing.T) {

--- a/util/pd_test.go
+++ b/util/pd_test.go
@@ -1,0 +1,97 @@
+// Copyright 2023 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: The code in this file is based on code from the
+// TiDB project, licensed under the Apache License v 2.0
+//
+// https://github.com/pingcap/tidb/tree/cc5e161ac06827589c4966674597c137cc9e809c/store/tikv/util/rate_limit_test.go
+//
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"github.com/pingcap/failpoint"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPDRequestRetry(t *testing.T) {
+	EnableFailpoints()
+	ctx := context.Background()
+	require := require.New(t)
+
+	require.Nil(failpoint.Enable("tikvclient/FastRetry", `return()`))
+	defer func() {
+		require.Nil(failpoint.Disable("tikvclient/FastRetry"))
+	}()
+
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		if count <= pdRequestRetryTime-1 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	cli := http.DefaultClient
+	taddr := ts.URL
+	_, reqErr := pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	require.Nil(reqErr)
+	ts.Close()
+
+	count = 0
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		if count <= pdRequestRetryTime+1 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	taddr = ts.URL
+	_, reqErr = pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	require.Error(reqErr)
+	ts.Close()
+
+	require.Nil(failpoint.Enable("tikvclient/InjectClosed", fmt.Sprintf("return(%d)", 0)))
+	defer func() {
+		require.Nil(failpoint.Disable("tikvclient/InjectClosed"))
+	}()
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	taddr = ts.URL
+	_, reqErr = pdRequest(ctx, taddr, "", cli, http.MethodGet, nil)
+	require.Error(reqErr)
+	ts.Close()
+}

--- a/util/pd_test.go
+++ b/util/pd_test.go
@@ -49,7 +49,6 @@ func TestPDRequestRetry(t *testing.T) {
 	EnableFailpoints()
 	ctx := context.Background()
 	require := require.New(t)
-
 	require.Nil(failpoint.Enable("tikvclient/FastRetry", `return()`))
 	defer func() {
 		require.Nil(failpoint.Disable("tikvclient/FastRetry"))


### PR DESCRIPTION
Close #795
after https://github.com/tikv/pd/pull/6413 merged, We can replace resolved-ts's current implementation in client-go
- support api mechanism to pd
- support api to get store min resolved ts 