### PR TITLE
Do not skip TestBatchResolveLocks for unistore

### DIFF
--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1468,8 +1468,6 @@ func (s *testLockWithTiKVSuite) TestBatchResolveLocks() {
 	if *withTiKV {
 		recoverFunc := s.trySetTiKVConfig("pessimistic-txn.in-memory", false)
 		defer recoverFunc()
-	} else {
-		s.T().Skip("this test only works with tikv")
 	}
 
 	s.NoError(failpoint.Enable("tikvclient/beforeAsyncPessimisticRollback", `return("skip")`))


### PR DESCRIPTION
Ref: https://github.com/pingcap/tidb/issues/43243

As merging the PR https://github.com/tikv/client-go/pull/777 updates the TiDB referenced by intergration tests which then includes the change https://github.com/pingcap/tidb/pull/43397 , the test TestBatchResolveLocks  now can successfully run on unistore, whose implementation of ScanLock has been fixed.