### PR TITLE
lock_resolver: let resolve lock timeout properly

### DIFF
--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -693,6 +693,7 @@ func (lr *LockResolver) getTxnStatusFromLock(bo *retry.Backoffer, l *Lock, calle
 		// success before the primary region.
 		if err := bo.Backoff(retry.BoTxnNotFound, err); err != nil {
 			logutil.Logger(bo.GetCtx()).Warn("getTxnStatusFromLock backoff fail", zap.Error(err))
+			return TxnStatus{}, err
 		}
 	}
 }


### PR DESCRIPTION
fix https://github.com/pingcap/tidb/issues/44822 , after this PR tidb can pass the test.

![2023-06-20_120206](https://github.com/tikv/client-go/assets/6850317/fa2cebee-1d26-4fcc-ab6e-352865195faf)
