### PR TITLE
make ResourceControlInterceptor atomic

### DIFF
--- a/internal/client/client_interceptor.go
+++ b/internal/client/client_interceptor.go
@@ -29,7 +29,6 @@ import (
 
 func init() {
 	ResourceControlSwitch.Store(false)
-	ResourceControlInterceptor = nil
 }
 
 var _ Client = interceptedClient{}
@@ -77,7 +76,7 @@ var (
 	// ResourceControlSwitch is used to control whether to enable the resource control.
 	ResourceControlSwitch atomic.Value
 	// ResourceControlInterceptor is used to build the resource control interceptor.
-	ResourceControlInterceptor resourceControlClient.ResourceGroupKVInterceptor
+	ResourceControlInterceptor atomic.Pointer[resourceControlClient.ResourceGroupKVInterceptor]
 )
 
 // buildResourceControlInterceptor builds a resource control interceptor with
@@ -95,16 +94,20 @@ func buildResourceControlInterceptor(
 	if len(resourceGroupName) == 0 {
 		return nil
 	}
+
+	rcInterceptor := ResourceControlInterceptor.Load()
 	// No resource group interceptor is set.
-	if ResourceControlInterceptor == nil {
+	if rcInterceptor == nil {
 		return nil
 	}
+	resourceControlInterceptor := *rcInterceptor
+
 	// Make the request info.
 	reqInfo := resourcecontrol.MakeRequestInfo(req)
 	// Build the interceptor.
 	interceptFn := func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
 		return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
-			consumption, penalty, err := ResourceControlInterceptor.OnRequestWait(ctx, resourceGroupName, reqInfo)
+			consumption, penalty, err := resourceControlInterceptor.OnRequestWait(ctx, resourceGroupName, reqInfo)
 			if err != nil {
 				return nil, err
 			}
@@ -113,7 +116,7 @@ func buildResourceControlInterceptor(
 			resp, err := next(target, req)
 			if resp != nil {
 				respInfo := resourcecontrol.MakeResponseInfo(resp)
-				consumption, err = ResourceControlInterceptor.OnResponse(resourceGroupName, reqInfo, respInfo)
+				consumption, err = resourceControlInterceptor.OnResponse(resourceGroupName, reqInfo, respInfo)
 				if err != nil {
 					return nil, err
 				}

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -705,12 +705,12 @@ func DisableResourceControl() {
 
 // SetResourceControlInterceptor sets the interceptor for resource control.
 func SetResourceControlInterceptor(interceptor resourceControlClient.ResourceGroupKVInterceptor) {
-	client.ResourceControlInterceptor = interceptor
+	client.ResourceControlInterceptor.Store(&interceptor)
 }
 
 // UnsetResourceControlInterceptor un-sets the interceptor for resource control.
 func UnsetResourceControlInterceptor() {
-	client.ResourceControlInterceptor = nil
+	client.ResourceControlInterceptor.Store(nil)
 }
 
 // Variables defines the variables used by TiKV storage.


### PR DESCRIPTION
ref https://github.com/pingcap/tidb/issues/44818

https://github.com/pingcap/tidb/pull/44819 is another attempt to fix the race but the test still failed https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/26946/display/redirect.

while in theory, we can init the `ResourceControlInterceptor` once when the server is bootstrapped. But due to some implementation restriction, it's hard to do so in tidb and the current code can case data race though the data race is harmless. 

So this PR changes the type to atomic ptr for simplicity.