### PR TITLE
Fix the issue that primary pessimistic lock may be left not cleared after GC

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1221,7 +1221,6 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		if _, err1 := util.EvalFailpoint("afterSendReqToRegion"); err1 == nil {
-			A
 			if hook := bo.GetCtx().Value("sendReqToRegionFinishHook"); hook != nil {
 				h := hook.(func(*tikvrpc.Request, *tikvrpc.Response, error))
 				h(req, resp, err)

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1221,6 +1221,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		if _, err1 := util.EvalFailpoint("afterSendReqToRegion"); err1 == nil {
+			A
 			if hook := bo.GetCtx().Value("sendReqToRegionFinishHook"); hook != nil {
 				h := hook.(func(*tikvrpc.Request, *tikvrpc.Response, error))
 				h(req, resp, err)

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -556,6 +556,7 @@ func (txn *KVTxn) Rollback() error {
 		txn.CancelAggressiveLocking(context.Background())
 	}
 
+	// `skipPessimisticRollback` may be true only when set by failpoint in tests.
 	skipPessimisticRollback := false
 	if val, err := util.EvalFailpoint("onRollback"); err == nil {
 		if s, ok := val.(string); ok {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -556,10 +556,26 @@ func (txn *KVTxn) Rollback() error {
 		txn.CancelAggressiveLocking(context.Background())
 	}
 
+	skipPessimisticRollback := false
+	if val, err := util.EvalFailpoint("onRollback"); err == nil {
+		if s, ok := val.(string); ok {
+			if s == "skipRollbackPessimisticLock" {
+				logutil.BgLogger().Info("[failpoint] injected skip pessimistic rollback on explicit rollback",
+					zap.Uint64("txnStartTS", txn.startTS))
+				skipPessimisticRollback = true
+			} else {
+				panic(fmt.Sprintf("unknown instruction %s for failpoint \"onRollback\"", s))
+			}
+		}
+	}
+
 	start := time.Now()
 	// Clean up pessimistic lock.
 	if txn.IsPessimistic() && txn.committer != nil {
-		err := txn.rollbackPessimisticLocks()
+		var err error
+		if !skipPessimisticRollback {
+			err = txn.rollbackPessimisticLocks()
+		}
 		txn.committer.ttlManager.close()
 		if err != nil {
 			logutil.BgLogger().Error(err.Error())

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -245,6 +245,12 @@ func (lr *LockResolver) BatchResolveLocks(bo *retry.Backoffer, locks []*Lock, lo
 		}
 		metrics.LockResolverCountWithExpired.Inc()
 
+		// Use currentTS = math.MaxUint64 means rollback the txn, no matter the lock is expired or not!
+		status, err := lr.getTxnStatus(bo, l.TxnID, l.Primary, 0, math.MaxUint64, true, false, l)
+		if err != nil {
+			return false, err
+		}
+
 		if l.LockType == kvrpcpb.Op_PessimisticLock {
 			// BatchResolveLocks forces resolving the locks ignoring whether whey are expired.
 			// For pessimistic locks, committing them makes no sense, but it won't affect transaction
@@ -257,12 +263,6 @@ func (lr *LockResolver) BatchResolveLocks(bo *retry.Backoffer, locks []*Lock, lo
 				return false, err
 			}
 			continue
-		}
-
-		// Use currentTS = math.MaxUint64 means rollback the txn, no matter the lock is expired or not!
-		status, err := lr.getTxnStatus(bo, l.TxnID, l.Primary, 0, math.MaxUint64, true, false, l)
-		if err != nil {
-			return false, err
 		}
 
 		// If the transaction uses async commit, CheckTxnStatus will reject rolling back the primary lock.


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/45134

The problem is that `BatchResolveLock` calls `resolvePessimsticLock` without calling `getTxnStatus`, but `resolvePessimsticLock` assumes `getTxnStatus` (in which `CheckTxnStatus` RPC is called) is done so it doesn't do anything to primary pessimistic lock. This may result in residue pessimistic locks in some rare cases.

This PR moves `resolvePessimsticLock` calling to after `getTxnStatus` to avoid the problem.