### PR TITLE
add explicit request source type to label the external request like lightning/br

### DIFF
--- a/tikvrpc/interceptor/interceptor.go
+++ b/tikvrpc/interceptor/interceptor.go
@@ -205,6 +205,9 @@ var interceptorCtxKey = interceptorCtxKeyType{}
 
 // WithRPCInterceptor is a helper function used to bind RPCInterceptor with ctx.
 func WithRPCInterceptor(ctx context.Context, interceptor RPCInterceptor) context.Context {
+	if v := ctx.Value(interceptorCtxKey); v != nil {
+		interceptor = ChainRPCInterceptors(v.(RPCInterceptor), interceptor)
+	}
 	return context.WithValue(ctx, interceptorCtxKey, interceptor)
 }
 

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1451,7 +1451,7 @@ func (txn *KVTxn) SetRequestSourceType(tp string) {
 	txn.RequestSource.SetRequestSourceType(tp)
 }
 
-// SetExplicitRequestSoureType sets the explicit type of the request source.
-func (txn *KVTxn) SetExplicitRequestSoureType(tp string) {
+// SetExplicitRequestSourceType sets the explicit type of the request source.
+func (txn *KVTxn) SetExplicitRequestSourceType(tp string) {
 	txn.RequestSource.SetExplicitRequestSourceType(tp)
 }

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1450,3 +1450,8 @@ func (txn *KVTxn) SetRequestSourceInternal(internal bool) {
 func (txn *KVTxn) SetRequestSourceType(tp string) {
 	txn.RequestSource.SetRequestSourceType(tp)
 }
+
+// SetExplicitRequestSoureType sets the explicit type of the request source.
+func (txn *KVTxn) SetExplicitRequestSoureType(tp string) {
+	txn.RequestSource.SetExplicitRequestSourceType(tp)
+}

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -27,6 +27,18 @@ const (
 	InternalTxnMeta = InternalTxnOthers
 )
 
+// explict source types.
+const (
+	ExplicitTypeDefault    = ""
+	ExplicitTypeLightning  = "lightning"
+	ExplicitTypeBR         = "br"
+	ExplicitTypeDumpling   = "dumpling"
+	ExplicitTypeBackground = "background"
+)
+
+// ExplictTypeList is the list of all explict source types.
+var ExplictTypeList = []string{ExplicitTypeDefault, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
+
 const (
 	// InternalRequest is the scope of internal queries
 	InternalRequest = "internal"
@@ -40,9 +52,9 @@ const (
 type RequestSource struct {
 	RequestSourceInternal bool
 	RequestSourceType     string
-	// ExplicitRequestSoureType is set from the session variable, it may specified by the client or users. `explicit_request_source_type`. it's a complement of RequestSourceType.
+	// ExplicitRequestSourceType is set from the session variable, it may specified by the client or users. `explicit_request_source_type`. it's a complement of RequestSourceType.
 	// The value maybe "lightning", "br", "dumpling" etc.
-	ExplicitRequestSoureType string
+	ExplicitRequestSourceType string
 }
 
 // SetRequestSourceInternal sets the scope of the request source.
@@ -57,7 +69,7 @@ func (r *RequestSource) SetRequestSourceType(tp string) {
 
 // SetExplicitRequestSourceType sets the type of the request source.
 func (r *RequestSource) SetExplicitRequestSourceType(tp string) {
-	r.ExplicitRequestSoureType = tp
+	r.ExplicitRequestSourceType = tp
 }
 
 // WithInternalSourceType create context with internal source.
@@ -81,12 +93,12 @@ func IsRequestSourceInternal(reqSrc *RequestSource) bool {
 func (r *RequestSource) GetRequestSource() string {
 	// if r.RequestSourceType is not set, it's mostly possible that r.RequestSourceInternal is not set
 	// to avoid internal requests be marked as external(default value), return unknown source here.
-	if r == nil || r.RequestSourceType == "" {
+	if r == nil || (len(r.RequestSourceType) == 0 && len(r.ExplicitRequestSourceType) == 0) {
 		return SourceUnknown
 	}
 	appendType := func(list []string) []string {
-		if len(r.ExplicitRequestSoureType) > 0 {
-			list = append(list, r.ExplicitRequestSoureType)
+		if len(r.ExplicitRequestSourceType) > 0 {
+			list = append(list, r.ExplicitRequestSourceType)
 			return list
 		}
 		return list
@@ -94,8 +106,8 @@ func (r *RequestSource) GetRequestSource() string {
 	if r.RequestSourceInternal {
 		labels := []string{InternalRequest, r.RequestSourceType}
 		labels = appendType(labels)
-		if len(r.ExplicitRequestSoureType) > 0 {
-			labels = append(labels, r.ExplicitRequestSoureType)
+		if len(r.ExplicitRequestSourceType) > 0 {
+			labels = append(labels, r.ExplicitRequestSourceType)
 		}
 		return strings.Join(labels, "_")
 	}

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -27,7 +27,7 @@ const (
 	InternalTxnMeta = InternalTxnOthers
 )
 
-// explict source types.
+// explicit source types.
 const (
 	ExplicitTypeDefault    = ""
 	ExplicitTypeLightning  = "lightning"
@@ -36,8 +36,8 @@ const (
 	ExplicitTypeBackground = "background"
 )
 
-// ExplictTypeList is the list of all explict source types.
-var ExplictTypeList = []string{ExplicitTypeDefault, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
+// ExplicitTypeList is the list of all explicit source types.
+var ExplicitTypeList = []string{ExplicitTypeDefault, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
 
 const (
 	// InternalRequest is the scope of internal queries
@@ -96,23 +96,24 @@ func (r *RequestSource) GetRequestSource() string {
 	if r == nil || (len(r.RequestSourceType) == 0 && len(r.ExplicitRequestSourceType) == 0) {
 		return SourceUnknown
 	}
-	appendType := func(list []string) []string {
-		if len(r.ExplicitRequestSourceType) > 0 {
-			list = append(list, r.ExplicitRequestSourceType)
-			return list
+	clearEmpty := func(list []string) []string {
+		i := 0
+		for _, v := range list {
+			if len(v) != 0 {
+				list[i] = v
+				i++
+			}
 		}
-		return list
+		return list[:i]
 	}
 	if r.RequestSourceInternal {
-		labels := []string{InternalRequest, r.RequestSourceType}
-		labels = appendType(labels)
-		if len(r.ExplicitRequestSourceType) > 0 {
-			labels = append(labels, r.ExplicitRequestSourceType)
-		}
+		labels := []string{InternalRequest, r.RequestSourceType, r.ExplicitRequestSourceType}
+		labels = clearEmpty(labels)
+
 		return strings.Join(labels, "_")
 	}
-	labels := []string{ExternalRequest, r.RequestSourceType}
-	labels = appendType(labels)
+	labels := []string{ExternalRequest, r.RequestSourceType, r.ExplicitRequestSourceType}
+	labels = clearEmpty(labels)
 	return strings.Join(labels, "_")
 }
 

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -30,7 +30,7 @@ const (
 // explicit source types.
 const (
 	ExplicitTypeEmpty      = ""
-	ExplicitTypeDB         = "db"
+	ExplicitTypeDefault    = "default"
 	ExplicitTypeLightning  = "lightning"
 	ExplicitTypeBR         = "br"
 	ExplicitTypeDumpling   = "dumpling"
@@ -38,7 +38,7 @@ const (
 )
 
 // ExplicitTypeList is the list of all explicit source types.
-var ExplicitTypeList = []string{ExplicitTypeDB, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
+var ExplicitTypeList = []string{ExplicitTypeDefault, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
 
 const (
 	// InternalRequest is the scope of internal queries
@@ -109,7 +109,7 @@ func (r *RequestSource) GetRequestSource() string {
 	}
 	explicitSourceType := r.ExplicitRequestSourceType
 	if len(explicitSourceType) == 0 {
-		explicitSourceType = ExplicitTypeDB
+		explicitSourceType = ExplicitTypeDefault
 	}
 	if r.RequestSourceInternal {
 		labels := []string{InternalRequest, r.RequestSourceType, explicitSourceType}

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -29,7 +29,8 @@ const (
 
 // explicit source types.
 const (
-	ExplicitTypeDefault    = ""
+	ExplicitTypeEmpty      = ""
+	ExplicitTypeDB         = "db"
 	ExplicitTypeLightning  = "lightning"
 	ExplicitTypeBR         = "br"
 	ExplicitTypeDumpling   = "dumpling"
@@ -37,7 +38,7 @@ const (
 )
 
 // ExplicitTypeList is the list of all explicit source types.
-var ExplicitTypeList = []string{ExplicitTypeDefault, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
+var ExplicitTypeList = []string{ExplicitTypeDB, ExplicitTypeLightning, ExplicitTypeBR, ExplicitTypeDumpling, ExplicitTypeBackground}
 
 const (
 	// InternalRequest is the scope of internal queries
@@ -106,13 +107,17 @@ func (r *RequestSource) GetRequestSource() string {
 		}
 		return list[:i]
 	}
+	explicitSourceType := r.ExplicitRequestSourceType
+	if len(explicitSourceType) == 0 {
+		explicitSourceType = ExplicitTypeDB
+	}
 	if r.RequestSourceInternal {
-		labels := []string{InternalRequest, r.RequestSourceType, r.ExplicitRequestSourceType}
+		labels := []string{InternalRequest, r.RequestSourceType, explicitSourceType}
 		labels = clearEmpty(labels)
 
 		return strings.Join(labels, "_")
 	}
-	labels := []string{ExternalRequest, r.RequestSourceType, r.ExplicitRequestSourceType}
+	labels := []string{ExternalRequest, r.RequestSourceType, explicitSourceType}
 	labels = clearEmpty(labels)
 	return strings.Join(labels, "_")
 }

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -55,7 +55,7 @@ func TestGetRequestSource(t *testing.T) {
 
 	// Test empty ExplicitRequestSourceType
 	rs.RequestSourceType = "test"
-	expected = "external_test_db"
+	expected = "external_test_default"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// NOTE: The code in this file is based on code from the
-// TiDB project, licensed under the Apache License v 2.0
-//
-// https://github.com/pingcap/tidb/tree/cc5e161ac06827589c4966674597c137cc9e809c/store/tikv/util/execdetails.go
-//
-
-// Copyright 2023 PingCAP, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package util
 
 import (

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: The code in this file is based on code from the
+// TiDB project, licensed under the Apache License v 2.0
+//
+// https://github.com/pingcap/tidb/tree/cc5e161ac06827589c4966674597c137cc9e809c/store/tikv/util/execdetails.go
+//
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRequestSource(t *testing.T) {
+	rsi := true
+	rst := "test"
+	ers := "explicit_test"
+	rs := &RequestSource{
+		RequestSourceInternal:     rsi,
+		RequestSourceType:         rst,
+		ExplicitRequestSourceType: ers,
+	}
+
+	// Test internal request
+	expected := "internal_test_explicit_test"
+	actual := rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test external request
+	rs.RequestSourceInternal = false
+	expected = "external_test_explicit_test"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test nil pointer
+	rs = nil
+	expected = "unknown"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty RequestSourceType and ExplicitRequestSourceType
+	rs = &RequestSource{}
+	expected = "unknown"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty ExplicitRequestSourceType
+	rs.RequestSourceType = "test"
+	expected = "external_test"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty RequestSourceType
+	rs.RequestSourceType = ""
+	rs.ExplicitRequestSourceType = "explicit_test"
+	expected = "external_explicit_test"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+}

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -55,7 +55,7 @@ func TestGetRequestSource(t *testing.T) {
 
 	// Test empty ExplicitRequestSourceType
 	rs.RequestSourceType = "test"
-	expected = "external_test"
+	expected = "external_test_db"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -23,7 +23,7 @@ import (
 func TestGetRequestSource(t *testing.T) {
 	rsi := true
 	rst := "test"
-	ers := "explicit_test"
+	ers := "lightning"
 	rs := &RequestSource{
 		RequestSourceInternal:     rsi,
 		RequestSourceType:         rst,
@@ -31,25 +31,25 @@ func TestGetRequestSource(t *testing.T) {
 	}
 
 	// Test internal request
-	expected := "internal_test_explicit_test"
+	expected := "internal_test_lightning"
 	actual := rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 
 	// Test external request
 	rs.RequestSourceInternal = false
-	expected = "external_test_explicit_test"
+	expected = "external_test_lightning"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 
 	// Test nil pointer
 	rs = nil
-	expected = "unknown"
+	expected = "unknown_default"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 
 	// Test empty RequestSourceType and ExplicitRequestSourceType
 	rs = &RequestSource{}
-	expected = "unknown"
+	expected = "unknown_default"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 
@@ -61,8 +61,8 @@ func TestGetRequestSource(t *testing.T) {
 
 	// Test empty RequestSourceType
 	rs.RequestSourceType = ""
-	rs.ExplicitRequestSourceType = "explicit_test"
-	expected = "external_explicit_test"
+	rs.ExplicitRequestSourceType = "lightning"
+	expected = "external_unknown_lightning"
 	actual = rs.GetRequestSource()
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
if use
```
set @tidb_request_source_type='lightling'
select count(*) from t;
```
the request source field will like:
```
external_Select_lightning
``` 