### PR TITLE
Replace stale-read traffic with local-remote traffic

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -37,18 +37,12 @@ package locate
 import (
 	"context"
 	"fmt"
-	"github.com/tikv/client-go/v2/oracle"
-	"github.com/tikv/client-go/v2/tikv"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -62,8 +56,12 @@ import (
 	"github.com/tikv/client-go/v2/internal/retry"
 	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/metrics"
+	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // shuttingDown is a flag to indicate tidb-server is exiting (Ctrl+C signal
@@ -1717,7 +1715,7 @@ func (s *staleReadMetricsCollector) onResp(resp *tikvrpc.Response, rpcCtx *RPCCo
 		return
 	}
 	for _, label := range rpcCtx.Store.labels {
-		if label.Key == tikv.DCLabelKey && label.Value == s.scope {
+		if label.Key == tikvrpc.DCLabelKey && label.Value == s.scope {
 			return
 		}
 	}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1727,7 +1727,7 @@ func (s *staleReadMetricsCollector) collect() {
 		return
 	}
 	in, out := metrics.StaleReadLocalInBytes, metrics.StaleReadLocalOutBytes
-	if !s.local {
+	if !s.local || !s.hit {
 		in, out = metrics.StaleReadRemoteInBytes, metrics.StaleReadRemoteOutBytes
 	}
 	in.Add(float64(s.in))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -96,7 +96,8 @@ var (
 	TiKVReadThroughput                       prometheus.Histogram
 	TiKVUnsafeDestroyRangeFailuresCounterVec *prometheus.CounterVec
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
-	TiKVStaleReadSizeSummary                 *prometheus.SummaryVec
+	TiKVStaleReadCounter                     *prometheus.CounterVec
+	TiKVStaleReadBytes                       *prometheus.CounterVec
 )
 
 // Label constants.
@@ -591,8 +592,16 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Counter of assertions used in prewrite requests",
 		}, []string{LblType})
 
-	TiKVStaleReadSizeSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	TiKVStaleReadCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stale_read_counter",
+			Help:      "Size of stale read.",
+		}, []string{LblResult})
+
+	TiKVStaleReadBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "stale_read_bytes",
@@ -669,7 +678,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVReadThroughput)
 	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
-	prometheus.MustRegister(TiKVStaleReadSizeSummary)
+	prometheus.MustRegister(TiKVStaleReadCounter)
+	prometheus.MustRegister(TiKVStaleReadBytes)
 }
 
 // readCounter reads the value of a prometheus.Counter.

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -136,10 +136,13 @@ var (
 	PrewriteAssertionUsageCounterNotExist prometheus.Counter
 	PrewriteAssertionUsageCounterUnknown  prometheus.Counter
 
-	StaleReadHitInTraffic   prometheus.Observer
-	StaleReadHitOutTraffic  prometheus.Observer
-	StaleReadMissInTraffic  prometheus.Observer
-	StaleReadMissOutTraffic prometheus.Observer
+	StaleReadHitCounter  prometheus.Counter
+	StaleReadMissCounter prometheus.Counter
+
+	StaleReadLocalInBytes   prometheus.Counter
+	StaleReadLocalOutBytes  prometheus.Counter
+	StaleReadRemoteInBytes  prometheus.Counter
+	StaleReadRemoteOutBytes prometheus.Counter
 )
 
 func initShortcuts() {
@@ -241,8 +244,11 @@ func initShortcuts() {
 	PrewriteAssertionUsageCounterNotExist = TiKVPrewriteAssertionUsageCounter.WithLabelValues("not-exist")
 	PrewriteAssertionUsageCounterUnknown = TiKVPrewriteAssertionUsageCounter.WithLabelValues("unknown")
 
-	StaleReadHitInTraffic = TiKVStaleReadSizeSummary.WithLabelValues("hit", "in")
-	StaleReadHitOutTraffic = TiKVStaleReadSizeSummary.WithLabelValues("hit", "out")
-	StaleReadMissInTraffic = TiKVStaleReadSizeSummary.WithLabelValues("miss", "in")
-	StaleReadMissOutTraffic = TiKVStaleReadSizeSummary.WithLabelValues("miss", "out")
+	StaleReadHitCounter = TiKVStaleReadCounter.WithLabelValues("hit")
+	StaleReadMissCounter = TiKVStaleReadCounter.WithLabelValues("miss")
+
+	StaleReadLocalInBytes = TiKVStaleReadBytes.WithLabelValues("local", "in")
+	StaleReadLocalOutBytes = TiKVStaleReadBytes.WithLabelValues("local", "out")
+	StaleReadRemoteInBytes = TiKVStaleReadBytes.WithLabelValues("remote", "in")
+	StaleReadRemoteOutBytes = TiKVStaleReadBytes.WithLabelValues("remote", "out")
 }

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -74,7 +74,7 @@ import (
 )
 
 // DCLabelKey indicates the key of label which represents the dc for Store.
-const DCLabelKey = "zone"
+const DCLabelKey = tikvrpc.DCLabelKey
 
 func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, error) {
 	cfg := config.GetGlobalConfig()

--- a/tikvrpc/endpoint.go
+++ b/tikvrpc/endpoint.go
@@ -87,3 +87,6 @@ func GetStoreTypeByMeta(store *metapb.Store) EndpointType {
 	}
 	return TiKV
 }
+
+// DCLabelKey indicates the key of label which represents the dc for Store.
+const DCLabelKey = "zone"


### PR DESCRIPTION
By recording stale-read-miss traffic, we can know the traffic of remote reading.

But in some cases, the replica selector just skip the unavailable local replica and do a **remote stale read**. Even such stale-read is successful, billed traffic may be produced and need to be specified.

This PR will record the traffic of stale-read requests by local and remote types when there is labels. In the example metrics, the local store is in restart progress, but the stale-read success rate is still high, and we can find the remote traffic with this PR.

![image](https://github.com/tikv/client-go/assets/9587680/e95f1348-447c-4cf9-a783-4479156c29d9)

