### PR TITLE
*: fix stale read ops metric

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -254,7 +254,7 @@ type replicaSelector struct {
 	region      *Region
 	regionStore *regionStore
 	replicas    []*replica
-	option      *storeSelectorOp
+	labels      []*metapb.StoreLabel
 	state       selectorState
 	// replicas[targetIdx] is the replica handling the request this time
 	targetIdx AccessIndex
@@ -670,7 +670,7 @@ func newReplicaSelector(regionCache *RegionCache, regionID RegionVerID, req *tik
 		cachedRegion,
 		regionStore,
 		replicas,
-		&option,
+		option.labels,
 		state,
 		-1,
 		-1,
@@ -1045,9 +1045,9 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		var isLocalTraffic bool
-		if staleReadCollector != nil && s.replicaSelector != nil && s.replicaSelector.option != nil {
+		if staleReadCollector != nil && s.replicaSelector != nil {
 			if target := s.replicaSelector.targetReplica(); target != nil {
-				isLocalTraffic = target.store.IsLabelsMatch(s.replicaSelector.option.labels)
+				isLocalTraffic = target.store.IsLabelsMatch(s.replicaSelector.labels)
 				staleReadCollector.onReq(req, isLocalTraffic)
 			}
 		}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -254,7 +254,7 @@ type replicaSelector struct {
 	region      *Region
 	regionStore *regionStore
 	replicas    []*replica
-	option      storeSelectorOp
+	option      *storeSelectorOp
 	state       selectorState
 	// replicas[targetIdx] is the replica handling the request this time
 	targetIdx AccessIndex
@@ -670,7 +670,7 @@ func newReplicaSelector(regionCache *RegionCache, regionID RegionVerID, req *tik
 		cachedRegion,
 		regionStore,
 		replicas,
-		option,
+		&option,
 		state,
 		-1,
 		-1,
@@ -1045,7 +1045,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		var isLocalTraffic bool
-		if staleReadCollector != nil && s.replicaSelector != nil {
+		if staleReadCollector != nil && s.replicaSelector != nil && s.replicaSelector.option != nil {
 			if target := s.replicaSelector.targetReplica(); target != nil {
 				isLocalTraffic = target.store.IsLabelsMatch(s.replicaSelector.option.labels)
 				staleReadCollector.onReq(req, isLocalTraffic)
@@ -1695,7 +1695,7 @@ func (s *staleReadMetricsCollector) onReq(req *tikvrpc.Request, isLocalTraffic b
 		// ignore non-read requests
 		return
 	}
-	size += +req.Context.Size()
+	size += req.Context.Size()
 	if isLocalTraffic {
 		metrics.StaleReadLocalOutBytes.Add(float64(size))
 		metrics.StaleReadReqLocalCounter.Add(1)

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1696,11 +1696,9 @@ func (s *staleReadMetricsCollector) onReq(req *tikvrpc.Request, isLocalTraffic b
 	if isLocalTraffic {
 		metrics.StaleReadLocalOutBytes.Add(float64(reqSize))
 		metrics.StaleReadHitCounter.Add(1)
-		metrics.TiKVStaleReadByteSummary.WithLabelValues(req.Type.String(), "local", "out").Observe(float64(reqSize))
 	} else {
 		metrics.StaleReadRemoteOutBytes.Add(float64(reqSize))
 		metrics.StaleReadMissCounter.Add(1)
-		metrics.TiKVStaleReadByteSummary.WithLabelValues(req.Type.String(), "remote", "out").Observe(float64(reqSize))
 	}
 }
 
@@ -1721,9 +1719,7 @@ func (s *staleReadMetricsCollector) onResp(resp *tikvrpc.Response, isLocalTraffi
 	}
 	if isLocalTraffic {
 		metrics.StaleReadLocalInBytes.Add(float64(size))
-		metrics.TiKVStaleReadByteSummary.WithLabelValues(s.tp.String(), "local", "in").Observe(float64(size))
 	} else {
 		metrics.StaleReadRemoteInBytes.Add(float64(size))
-		metrics.TiKVStaleReadByteSummary.WithLabelValues(s.tp.String(), "remote", "in").Observe(float64(size))
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -97,6 +97,7 @@ var (
 	TiKVUnsafeDestroyRangeFailuresCounterVec *prometheus.CounterVec
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
 	TiKVStaleReadSizeSummary                 *prometheus.SummaryVec
+	TiKVStaleReadByteSummary                 *prometheus.SummaryVec
 )
 
 // Label constants.
@@ -118,6 +119,7 @@ const (
 	LblStaleRead       = "stale_read"
 	LblSource          = "source"
 	LblDirection       = "direction"
+	LblCrossAz         = "cross_az"
 )
 
 func initMetrics(namespace, subsystem string) {
@@ -598,6 +600,13 @@ func initMetrics(namespace, subsystem string) {
 			Name:      "stale_read_bytes",
 			Help:      "Size of stale read.",
 		}, []string{LblResult, LblDirection})
+	TiKVStaleReadByteSummary = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "send_req_bytes",
+			Help:      "Size of stale read.",
+		}, []string{LblType, LblCrossAz, LblDirection})
 
 	initShortcuts()
 }
@@ -670,6 +679,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
 	prometheus.MustRegister(TiKVStaleReadSizeSummary)
+	prometheus.MustRegister(TiKVStaleReadByteSummary)
 }
 
 // readCounter reads the value of a prometheus.Counter.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -98,7 +98,6 @@ var (
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
 	TiKVStaleReadCounter                     *prometheus.CounterVec
 	TiKVStaleReadBytes                       *prometheus.CounterVec
-	TiKVStaleReadByteSummary                 *prometheus.SummaryVec
 )
 
 // Label constants.
@@ -604,18 +603,11 @@ func initMetrics(namespace, subsystem string) {
 
 	TiKVStaleReadBytes = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "stale_read_bytes",
 			Help:      "Size of stale read.",
 		}, []string{LblResult, LblDirection})
-
-	TiKVStaleReadByteSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "send_req_bytes",
-			Help:      "Size of stale read.",
-		}, []string{LblType, LblCrossAz, LblDirection})
 
 	initShortcuts()
 }
@@ -689,7 +681,6 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
 	prometheus.MustRegister(TiKVStaleReadCounter)
 	prometheus.MustRegister(TiKVStaleReadBytes)
-	prometheus.MustRegister(TiKVStaleReadByteSummary)
 }
 
 // readCounter reads the value of a prometheus.Counter.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -601,7 +601,7 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Counter of stale read hit/miss",
 		}, []string{LblResult})
 
-	TiKVStaleReadCounter = prometheus.NewCounterVec(
+	TiKVStaleReadReqCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -97,6 +97,7 @@ var (
 	TiKVUnsafeDestroyRangeFailuresCounterVec *prometheus.CounterVec
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
 	TiKVStaleReadCounter                     *prometheus.CounterVec
+	TiKVStaleReadReqCounter                  *prometheus.CounterVec
 	TiKVStaleReadBytes                       *prometheus.CounterVec
 )
 
@@ -597,15 +598,23 @@ func initMetrics(namespace, subsystem string) {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "stale_read_counter",
-			Help:      "Size of stale read.",
+			Help:      "Counter of stale read hit/miss",
 		}, []string{LblResult})
+
+	TiKVStaleReadCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stale_read_req_counter",
+			Help:      "Counter of stale read requests",
+		}, []string{LblType})
 
 	TiKVStaleReadBytes = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "stale_read_bytes",
-			Help:      "Size of stale read.",
+			Help:      "Counter of stale read requests bytes",
 		}, []string{LblResult, LblDirection})
 
 	initShortcuts()
@@ -679,6 +688,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
 	prometheus.MustRegister(TiKVStaleReadCounter)
+	prometheus.MustRegister(TiKVStaleReadReqCounter)
 	prometheus.MustRegister(TiKVStaleReadBytes)
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -119,7 +119,6 @@ const (
 	LblStaleRead       = "stale_read"
 	LblSource          = "source"
 	LblDirection       = "direction"
-	LblCrossAz         = "cross_az"
 )
 
 func initMetrics(namespace, subsystem string) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -96,7 +96,8 @@ var (
 	TiKVReadThroughput                       prometheus.Histogram
 	TiKVUnsafeDestroyRangeFailuresCounterVec *prometheus.CounterVec
 	TiKVPrewriteAssertionUsageCounter        *prometheus.CounterVec
-	TiKVStaleReadSizeSummary                 *prometheus.SummaryVec
+	TiKVStaleReadCounter                     *prometheus.CounterVec
+	TiKVStaleReadBytes                       *prometheus.CounterVec
 	TiKVStaleReadByteSummary                 *prometheus.SummaryVec
 )
 
@@ -593,13 +594,21 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Counter of assertions used in prewrite requests",
 		}, []string{LblType})
 
-	TiKVStaleReadSizeSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	TiKVStaleReadCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stale_read_counter",
+			Help:      "Size of stale read.",
+		}, []string{LblResult})
+
+	TiKVStaleReadBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "stale_read_bytes",
 			Help:      "Size of stale read.",
 		}, []string{LblResult, LblDirection})
+
 	TiKVStaleReadByteSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
@@ -678,7 +687,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVReadThroughput)
 	prometheus.MustRegister(TiKVUnsafeDestroyRangeFailuresCounterVec)
 	prometheus.MustRegister(TiKVPrewriteAssertionUsageCounter)
-	prometheus.MustRegister(TiKVStaleReadSizeSummary)
+	prometheus.MustRegister(TiKVStaleReadCounter)
+	prometheus.MustRegister(TiKVStaleReadBytes)
 	prometheus.MustRegister(TiKVStaleReadByteSummary)
 }
 

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -136,10 +136,13 @@ var (
 	PrewriteAssertionUsageCounterNotExist prometheus.Counter
 	PrewriteAssertionUsageCounterUnknown  prometheus.Counter
 
-	StaleReadHitInTraffic   prometheus.Observer
-	StaleReadHitOutTraffic  prometheus.Observer
-	StaleReadMissInTraffic  prometheus.Observer
-	StaleReadMissOutTraffic prometheus.Observer
+	StaleReadHitCounter  prometheus.Counter
+	StaleReadMissCounter prometheus.Counter
+
+	StaleReadLocalInBytes   prometheus.Counter
+	StaleReadLocalOutBytes  prometheus.Counter
+	StaleReadRemoteInBytes  prometheus.Counter
+	StaleReadRemoteOutBytes prometheus.Counter
 )
 
 func initShortcuts() {
@@ -241,8 +244,11 @@ func initShortcuts() {
 	PrewriteAssertionUsageCounterNotExist = TiKVPrewriteAssertionUsageCounter.WithLabelValues("not-exist")
 	PrewriteAssertionUsageCounterUnknown = TiKVPrewriteAssertionUsageCounter.WithLabelValues("unknown")
 
-	StaleReadHitInTraffic = TiKVStaleReadSizeSummary.WithLabelValues("hit", "in")
-	StaleReadHitOutTraffic = TiKVStaleReadSizeSummary.WithLabelValues("hit", "out")
-	StaleReadMissInTraffic = TiKVStaleReadSizeSummary.WithLabelValues("miss", "in")
-	StaleReadMissOutTraffic = TiKVStaleReadSizeSummary.WithLabelValues("miss", "out")
+	StaleReadHitCounter = TiKVStaleReadCounter.WithLabelValues("hit")
+	StaleReadMissCounter = TiKVStaleReadCounter.WithLabelValues("miss")
+
+	StaleReadLocalInBytes = TiKVStaleReadBytes.WithLabelValues("local", "in")
+	StaleReadLocalOutBytes = TiKVStaleReadBytes.WithLabelValues("local", "out")
+	StaleReadRemoteInBytes = TiKVStaleReadBytes.WithLabelValues("remote", "in")
+	StaleReadRemoteOutBytes = TiKVStaleReadBytes.WithLabelValues("remote", "out")
 }

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -139,6 +139,9 @@ var (
 	StaleReadHitCounter  prometheus.Counter
 	StaleReadMissCounter prometheus.Counter
 
+	StaleReadReqLocalCounter     prometheus.Counter
+	StaleReadReqCrossZoneCounter prometheus.Counter
+
 	StaleReadLocalInBytes   prometheus.Counter
 	StaleReadLocalOutBytes  prometheus.Counter
 	StaleReadRemoteInBytes  prometheus.Counter
@@ -247,8 +250,11 @@ func initShortcuts() {
 	StaleReadHitCounter = TiKVStaleReadCounter.WithLabelValues("hit")
 	StaleReadMissCounter = TiKVStaleReadCounter.WithLabelValues("miss")
 
+	StaleReadReqLocalCounter = TiKVStaleReadReqCounter.WithLabelValues("local")
+	StaleReadReqCrossZoneCounter = TiKVStaleReadReqCounter.WithLabelValues("cross-zone")
+
 	StaleReadLocalInBytes = TiKVStaleReadBytes.WithLabelValues("local", "in")
 	StaleReadLocalOutBytes = TiKVStaleReadBytes.WithLabelValues("local", "out")
-	StaleReadRemoteInBytes = TiKVStaleReadBytes.WithLabelValues("remote", "in")
-	StaleReadRemoteOutBytes = TiKVStaleReadBytes.WithLabelValues("remote", "out")
+	StaleReadRemoteInBytes = TiKVStaleReadBytes.WithLabelValues("cross-zone", "in")
+	StaleReadRemoteOutBytes = TiKVStaleReadBytes.WithLabelValues("cross-zone", "out")
 }


### PR DESCRIPTION
The stale read ops metric is not right for some time. I found this issue when test stale read with reload all tikv node.

This PR is base on https://github.com/tikv/client-go/pull/877


<img width="1448" alt="image" src="https://github.com/tikv/client-go/assets/26020263/01e12425-727a-4ee1-a8a9-2d98241d6be1">


after fixed in this PR, the `stale read ops`, `stale read req ops` and `stale read traffic` metrics is like following when reload all tikv:

<img width="1615" alt="image" src="https://github.com/tikv/client-go/assets/26020263/509bbf9b-5ed4-4845-a7d2-43711d3e69d2">


