### PR TITLE
resource_control: bypass some internal urgent request

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -51,7 +51,7 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 		}
 	}
 	if !req.IsTxnWriteRequest() && !req.IsRawWriteRequest() {
-		return &RequestInfo{writeBytes: -1, bypass: bypass}
+		return &RequestInfo{writeBytes: -1, storeID: req.Context.Peer.StoreId, bypass: bypass}
 	}
 
 	var writeBytes int64
@@ -80,7 +80,10 @@ func (req *RequestInfo) IsWrite() bool {
 // WriteBytes returns the actual write size of the request,
 // -1 will be returned if it's not a write request.
 func (req *RequestInfo) WriteBytes() uint64 {
-	return uint64(req.writeBytes)
+	if req.writeBytes > 0 {
+		return uint64(req.writeBytes)
+	}
+	return 0
 }
 
 func (req *RequestInfo) ReplicaNumber() int64 {

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -46,7 +46,7 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 	var bypass bool
 	requestSource := req.Context.GetRequestSource()
 	if len(requestSource) > 0 {
-		if strings.Contains(requestSource, util.InternalRequest+util.InternalTxnOthers) {
+		if strings.Contains(requestSource, util.InternalRequestPrefix+util.InternalTxnOthers) {
 			bypass = true
 		}
 	}

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -1,0 +1,40 @@
+package resourcecontrol
+
+import (
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/stretchr/testify/assert"
+	"github.com/tikv/client-go/v2/tikvrpc"
+)
+
+func TestMakeRequestInfo(t *testing.T) {
+	// Test a non-write request.
+	req := &tikvrpc.Request{Req: &kvrpcpb.BatchGetRequest{}, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}}}
+	info := MakeRequestInfo(req)
+	assert.False(t, info.IsWrite())
+	assert.Equal(t, uint64(0), info.WriteBytes())
+	assert.False(t, info.Bypass())
+	assert.Equal(t, uint64(1), info.StoreID())
+
+	// Test a prewrite request.
+	mutation := &kvrpcpb.Mutation{Key: []byte("foo"), Value: []byte("bar")}
+	prewriteReq := &kvrpcpb.PrewriteRequest{Mutations: []*kvrpcpb.Mutation{mutation}, PrimaryLock: []byte("baz")}
+	req = &tikvrpc.Request{Type: tikvrpc.CmdPrewrite, Req: prewriteReq, ReplicaNumber: 1, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 2}}}
+	requestSource := "xxx_internal_others"
+	req.Context.RequestSource = requestSource
+	info = MakeRequestInfo(req)
+	assert.True(t, info.IsWrite())
+	assert.Equal(t, uint64(9), info.WriteBytes())
+	assert.True(t, info.Bypass())
+	assert.Equal(t, uint64(2), info.StoreID())
+	// Test a commit request.
+	commitReq := &kvrpcpb.CommitRequest{Keys: [][]byte{[]byte("qux")}}
+	req = &tikvrpc.Request{Type: tikvrpc.CmdCommit, Req: commitReq, ReplicaNumber: 2, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 3}}}
+	info = MakeRequestInfo(req)
+	assert.True(t, info.IsWrite())
+	assert.Equal(t, uint64(3), info.WriteBytes())
+	assert.False(t, info.Bypass())
+	assert.Equal(t, uint64(3), info.StoreID())
+}

--- a/tikvrpc/interceptor/interceptor.go
+++ b/tikvrpc/interceptor/interceptor.go
@@ -205,6 +205,9 @@ var interceptorCtxKey = interceptorCtxKeyType{}
 
 // WithRPCInterceptor is a helper function used to bind RPCInterceptor with ctx.
 func WithRPCInterceptor(ctx context.Context, interceptor RPCInterceptor) context.Context {
+	if v := ctx.Value(interceptorCtxKey); v != nil {
+		interceptor = ChainRPCInterceptors(v.(RPCInterceptor), interceptor)
+	}
 	return context.WithValue(ctx, interceptorCtxKey, interceptor)
 }
 

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1450,3 +1450,8 @@ func (txn *KVTxn) SetRequestSourceInternal(internal bool) {
 func (txn *KVTxn) SetRequestSourceType(tp string) {
 	txn.RequestSource.SetRequestSourceType(tp)
 }
+
+// SetExplicitRequestSourceType sets the explicit type of the request source.
+func (txn *KVTxn) SetExplicitRequestSourceType(tp string) {
+	txn.RequestSource.SetExplicitRequestSourceType(tp)
+}

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -25,6 +25,8 @@ const (
 	InternalTxnGC = "gc"
 	// InternalTxnMeta is the type of the miscellaneous meta usage.
 	InternalTxnMeta = InternalTxnOthers
+	// InternalTxnDDL is the type of inner DDL sql.
+	InternalTxnDDL = "ddl"
 )
 
 const (

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -43,6 +43,8 @@ var ExplicitTypeList = []string{ExplicitTypeEmpty, ExplicitTypeDefault, Explicit
 const (
 	// InternalRequest is the scope of internal queries
 	InternalRequest = "internal"
+	// InternalRequestPrefix is the prefix of internal queries
+	InternalRequestPrefix = "internal_"
 	// ExternalRequest is the scope of external queries
 	ExternalRequest = "external"
 	// SourceUnknown keeps same with the default value(empty string)

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -25,8 +25,6 @@ const (
 	InternalTxnGC = "gc"
 	// InternalTxnMeta is the type of the miscellaneous meta usage.
 	InternalTxnMeta = InternalTxnOthers
-	// InternalTxnDDL is the type of inner DDL sql.
-	InternalTxnDDL = "ddl"
 )
 
 const (

--- a/util/request_source_test.go
+++ b/util/request_source_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRequestSource(t *testing.T) {
+	rsi := true
+	rst := "test"
+	ers := "lightning"
+	rs := &RequestSource{
+		RequestSourceInternal:     rsi,
+		RequestSourceType:         rst,
+		ExplicitRequestSourceType: ers,
+	}
+
+	// Test internal request
+	expected := "internal_test_lightning"
+	actual := rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test external request
+	rs.RequestSourceInternal = false
+	expected = "external_test_lightning"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test nil pointer
+	rs = nil
+	expected = "unknown_default"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty RequestSourceType and ExplicitRequestSourceType
+	rs = &RequestSource{}
+	expected = "unknown_default"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty ExplicitRequestSourceType
+	rs.RequestSourceType = "test"
+	expected = "external_test_default"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+
+	// Test empty RequestSourceType
+	rs.RequestSourceType = ""
+	rs.ExplicitRequestSourceType = "lightning"
+	expected = "external_unknown_lightning"
+	actual = rs.GetRequestSource()
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
## Background

In tidb, the source request will be tiny but urgent. we can consider skip it by resource control
```
const (
	// InternalTxnOthers is the type of requests that consume low resources.
	// This reduces the size of metrics.
	InternalTxnOthers = util.InternalTxnOthers
	// InternalTxnBootstrap is the type of TiDB bootstrap txns.
	InternalTxnBootstrap = InternalTxnOthers
	// InternalTxnMeta is the type of the miscellaneous meta usage.
	InternalTxnMeta = util.InternalTxnMeta ==> util.InternalTxnOthers
	// InternalTxnCacheTable is the type of cache table usage.
	InternalTxnCacheTable = InternalTxnOthers
	// InternalTxnBindInfo is the type of bind info txn.
	InternalTxnBindInfo = InternalTxnOthers
	// InternalTxnSysVar is the type of sys var txn.
	InternalTxnSysVar = InternalTxnOthers
	// InternalTxnTelemetry is the type of telemetry.
	InternalTxnTelemetry = InternalTxnOthers
	// InternalTxnPrivilege is the type of privilege txn.
	InternalTxnPrivilege = InternalTxnOthers
)
```
As the upper show, `bootstrap`, `cached table`, `bindinfo`, `sysvar`, `telemetry`, `privilege`, `meta` relative internal SQL  can be skipped first.
Search code with `kv.WithInternalSourceType(context.Background(), kv.InternalTxnBindInfo)` can see the origin of the SQL.

## Manual Test:

It's based on cse repo. I set the group with low RU:
```
  {
    "name": "1",
    "mode": 1,
    "r_u_settings": {
      "r_u": {
        "settings": {
          "fill_rate": 0
          "burst_limit": 1
        },
        "state": {
          "last_update": "2023-07-14T01:23:21.99892+08:00",
          "initialized": true
        }
      }
    },
    "priority": 0
  }
```

Before:

![image](https://github.com/tidbcloud/tidb-cse/assets/6428910/a7c5d6f2-cfd8-4563-8b9c-61809b293011)

After
![image](https://github.com/tidbcloud/tidb-cse/assets/6428910/69301751-1968-4402-b2fa-12a3171616d2)



