### PR TITLE
handle `mismatch peer id` region error

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1938,6 +1938,7 @@ func (s *RegionRequestSender) onRegionError(
 	if s.replicaSelector != nil {
 		if errLabel == "mismatch_peer_id" {
 			s.replicaSelector.invalidateRegion()
+			return false, nil
 		}
 		// Try the next replica.
 		return true, nil

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1645,6 +1645,10 @@ func regionErrorToLabel(e *errorpb.Error) string {
 		return "flashback_not_prepared"
 	} else if e.GetIsWitness() != nil {
 		return "peer_is_witness"
+	} else if strings.HasPrefix(e.Message, "mismatch peer id") {
+		// the `mismatch peer id` error does not has a specific error type, so we have to match the error message.
+		// TODO: add a specific error type for `mismatch peer id`.
+		return "mismatch_peer_id"
 	}
 	return "unknown"
 }
@@ -1663,7 +1667,8 @@ func (s *RegionRequestSender) onRegionError(
 	if req != nil {
 		isInternal = util.IsInternalRequest(req.GetRequestSource())
 	}
-	metrics.TiKVRegionErrorCounter.WithLabelValues(regionErrorToLabel(regionErr), strconv.FormatBool(isInternal)).Inc()
+	errLabel := regionErrorToLabel(regionErr)
+	metrics.TiKVRegionErrorCounter.WithLabelValues(errLabel, strconv.FormatBool(isInternal)).Inc()
 
 	if notLeader := regionErr.GetNotLeader(); notLeader != nil {
 		// Retry if error is `NotLeader`.
@@ -1931,10 +1936,8 @@ func (s *RegionRequestSender) onRegionError(
 	)
 
 	if s.replicaSelector != nil {
-		// the `mismatch peer id` error does not has a specific error type, so we have to match the error message.
-		// TODO: add a specific error type for `mismatch peer id`.
-		if strings.HasPrefix(regionErr.Message, "mismatch peer id") {
-			s.replicaSelector.region.invalidate(NoLeader)
+		if errLabel == "mismatch_peer_id" {
+			s.replicaSelector.invalidateRegion()
 		}
 		// Try the next replica.
 		return true, nil

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1931,6 +1931,11 @@ func (s *RegionRequestSender) onRegionError(
 	)
 
 	if s.replicaSelector != nil {
+		// the `mismatch peer id` error does not has a specific error type, so we have to match the error message.
+		// TODO: add a specific error type for `mismatch peer id`.
+		if strings.HasPrefix(regionErr.Message, "mismatch peer id") {
+			s.replicaSelector.region.invalidate(NoLeader)
+		}
 		// Try the next replica.
 		return true, nil
 	}

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1092,6 +1092,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 	s.GreaterOrEqual(retry, 1)
 	regionErr, err := resp.GetRegionError()
 	s.Nil(err)
+	s.Equal(regionErrorToLabel(regionErr), "mismatch_peer_id")
 	// return non-epoch-not-match region error and the upper layer can auto retry.
 	s.Nil(regionErr.GetEpochNotMatch())
 	// after region error returned, the region should be invalidated.

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1091,7 +1091,8 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 	s.GreaterOrEqual(retry, 1)
 	regionErr, err := resp.GetRegionError()
 	s.Nil(err)
+	// return epoch-not-match region error and the upper layer can auto retry.
 	s.NotNil(regionErr.GetEpochNotMatch())
-	// after region err returned, the region should be invalidated.
+	// after region error returned, the region should be invalidated.
 	s.False(region.isValid())
 }

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1082,6 +1082,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 	req.ReadReplicaScope = oracle.GlobalTxnScope
 	req.TxnScope = oracle.GlobalTxnScope
 	req.EnableStaleRead()
+	req.ReplicaReadType = kv.ReplicaReadFollower
 
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	bo := retry.NewBackoffer(ctx, -1)
@@ -1091,8 +1092,8 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 	s.GreaterOrEqual(retry, 1)
 	regionErr, err := resp.GetRegionError()
 	s.Nil(err)
-	// return epoch-not-match region error and the upper layer can auto retry.
-	s.NotNil(regionErr.GetEpochNotMatch())
+	// return non-epoch-not-match region error and the upper layer can auto retry.
+	s.Nil(regionErr.GetEpochNotMatch())
 	// after region error returned, the region should be invalidated.
 	s.False(region.isValid())
 }

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1064,7 +1064,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 			return nil, errors.New("timeout")
 		default:
 		}
-		// Return serverIsBusy when accesses the leader with busy threshold.
+		// Return `mismatch peer id` when accesses the leader.
 		if addr == s.cluster.GetStore(s.storeIDs[0]).Address {
 			return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{
 				Message: "mismatch peer id 1 != 2",


### PR DESCRIPTION
As pingcap/tidb#45297 reports, TiKV may report `mismatch peer id` error, currently the client-go doesn't handle such error, this PR checks this error and invalidate the region cache when receiving this error.

