### PR TITLE
Match error message correctly

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1657,7 +1657,8 @@ func regionErrorToLabel(e *errorpb.Error) string {
 		return "flashback_not_prepared"
 	} else if e.GetIsWitness() != nil {
 		return "peer_is_witness"
-	} else if strings.HasPrefix(e.Message, "mismatch peer id") {
+	} else if strings.Contains(e.Message, "mismatch peer id") {
+		// the error message is like "[components/raftstore/src/store/util.rs:428]: mismatch peer id ? != ?"
 		// the `mismatch peer id` error does not has a specific error type, so we have to match the error message.
 		// TODO: add a specific error type for `mismatch peer id`.
 		return "mismatch_peer_id"

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1067,7 +1067,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 		// Return `mismatch peer id` when accesses the leader.
 		if addr == s.cluster.GetStore(s.storeIDs[0]).Address {
 			return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{
-				Message: "mismatch peer id 1 != 2",
+				Message: `"[components/raftstore/src/store/util.rs:428]: mismatch peer id 1 != 2"`,
 			}}}, nil
 		}
 		return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{


### PR DESCRIPTION
See the comment, the error message contains the code path, so it's not able to match it by prefix.