### PR TITLE
Only fallback to leader read with data-is-not-ready error

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -93,8 +93,8 @@ var (
 	ErrRegionFlashbackInProgress = errors.New("region is in the flashback progress")
 	// ErrRegionFlashbackNotPrepared is the error when a region is not prepared for the flashback first.
 	ErrRegionFlashbackNotPrepared = errors.New("region is not prepared for the flashback")
-	// ErrUnknown is the unknow error.
-	ErrUnknown = errors.New("unknow")
+	// ErrUnknown is the unknown error.
+	ErrUnknown = errors.New("unknown")
 	// ErrResultUndetermined is the error when execution result is unknown.
 	ErrResultUndetermined = errors.New("execution result undetermined")
 )

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -533,10 +533,12 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaSelector() {
 	for i := 0; i < regionStore.accessStoreNum(tiKVOnly)-1; i++ {
 		rpcCtx, err := replicaSelector.next(s.bo)
 		s.Nil(err)
-		// Should swith to the next follower.
+		// Should switch to the next follower.
 		s.NotEqual(lastIdx, state3.lastIdx)
 		// Shouldn't access the leader if followers aren't exhausted.
-		s.NotEqual(regionStore.workTiKVIdx, state3.lastIdx)
+		if regionStore.workTiKVIdx == state3.lastIdx {
+			s.NotEqual(regionStore.workTiKVIdx, state3.lastIdx)
+		}
 		s.Equal(replicaSelector.targetIdx, state3.lastIdx)
 		assertRPCCtxEqual(rpcCtx, replicaSelector.replicas[replicaSelector.targetIdx], nil)
 		lastIdx = state3.lastIdx


### PR DESCRIPTION
Inject server-is-busy error for stale read and leader read, so direct fallback to leader won't success.

![fail](https://github.com/tikv/client-go/assets/9587680/7a2bf43e-8fdd-416d-be79-956b84167be2)

This patch will continue trying other replicas(the duration is high because of backoff).

![success](https://github.com/tikv/client-go/assets/9587680/df93ff60-62c1-401a-ae00-c7325f8e7c8e)

