### PR TITLE
add more log for diagnose

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2322,6 +2322,7 @@ const (
 	tombstone
 )
 
+// String implements fmt.Stringer interface.
 func (s resolveState) String() string {
 	switch s {
 	case unresolved:
@@ -2566,6 +2567,7 @@ const (
 	unknown
 )
 
+// String implements fmt.Stringer interface.
 func (s livenessState) String() string {
 	switch s {
 	case unreachable:

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2336,7 +2336,7 @@ func (s resolveState) String() string {
 	case tombstone:
 		return "tombstone"
 	default:
-		return fmt.Sprintf("unknown-%v", s)
+		return fmt.Sprintf("unknown-%v", uint64(s))
 	}
 }
 
@@ -2577,7 +2577,7 @@ func (s livenessState) String() string {
 	case unknown:
 		return "unknown"
 	default:
-		return fmt.Sprintf("unknown-%v", s)
+		return fmt.Sprintf("unknown-%v", uint32(s))
 	}
 }
 

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2322,6 +2322,23 @@ const (
 	tombstone
 )
 
+func (s resolveState) String() string {
+	switch s {
+	case unresolved:
+		return "unresolved"
+	case resolved:
+		return "resolved"
+	case needCheck:
+		return "needCheck"
+	case deleted:
+		return "deleted"
+	case tombstone:
+		return "tombstone"
+	default:
+		return fmt.Sprintf("unknown-%v", s)
+	}
+}
+
 // IsTiFlash returns true if the storeType is TiFlash
 func (s *Store) IsTiFlash() bool {
 	return s.storeType == tikvrpc.TiFlash
@@ -2456,6 +2473,12 @@ func (s *Store) changeResolveStateTo(from, to resolveState) bool {
 			return false
 		}
 		if atomic.CompareAndSwapUint64(&s.state, uint64(from), uint64(to)) {
+			logutil.BgLogger().Info("change store resolve state",
+				zap.Uint64("store", s.storeID),
+				zap.String("addr", s.addr),
+				zap.String("from", from.String()),
+				zap.String("to", to.String()),
+				zap.String("liveness-state", s.getLivenessState().String()))
 			return true
 		}
 	}
@@ -2542,6 +2565,19 @@ const (
 	unreachable
 	unknown
 )
+
+func (s livenessState) String() string {
+	switch s {
+	case unreachable:
+		return "unreachable"
+	case reachable:
+		return "reachable"
+	case unknown:
+		return "unknown"
+	default:
+		return fmt.Sprintf("unknown-%v", s)
+	}
+}
 
 func (s *Store) startHealthCheckLoopIfNeeded(c *RegionCache, liveness livenessState) {
 	// This mechanism doesn't support non-TiKV stores currently.

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1048,14 +1048,14 @@ func (s *RegionRequestSender) SendReqCtx(
 			cacheRegionIsValid := "unknown"
 			if s.replicaSelector.region != nil {
 				if s.replicaSelector.region.isValid() {
-					cacheRegionIsValid = "valid"
+					cacheRegionIsValid = "true"
 				} else {
-					cacheRegionIsValid = "invalid"
+					cacheRegionIsValid = "false"
 				}
 			}
 			logutil.Logger(bo.GetCtx()).Info("throwing pseudo region error due to no replica available",
 				zap.String("region", regionID.String()),
-				zap.String("region-valid", cacheRegionIsValid),
+				zap.String("region-is-valid", cacheRegionIsValid),
 				zap.Int("try-times", tryTimes),
 				zap.String("replica-read-type", req.ReplicaReadType.String()),
 				zap.Bool("stale-read", req.StaleRead),

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -35,6 +35,7 @@
 package locate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
@@ -1088,6 +1089,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		}()
 	}
 
+	totalErrors := make(map[string]int)
 	for {
 		if tryTimes > 0 {
 			req.IsRetryRequest = true
@@ -1116,23 +1118,7 @@ func (s *RegionRequestSender) SendReqCtx(
 
 			// TODO: Change the returned error to something like "region missing in cache",
 			// and handle this error like EpochNotMatch, which means to re-split the request and retry.
-			cacheRegionIsValid := "unknown"
-			if s.replicaSelector != nil && s.replicaSelector.region != nil {
-				if s.replicaSelector.region.isValid() {
-					cacheRegionIsValid = "true"
-				} else {
-					cacheRegionIsValid = "false"
-				}
-			}
-			logutil.Logger(bo.GetCtx()).Info("throwing pseudo region error due to no replica available",
-				zap.String("region", regionID.String()),
-				zap.String("region-is-valid", cacheRegionIsValid),
-				zap.Int("try-times", tryTimes),
-				zap.String("replica-read-type", req.ReplicaReadType.String()),
-				zap.Bool("stale-read", req.StaleRead),
-				zap.Int("total-backoff-ms", bo.GetTotalSleep()),
-				zap.Int("total-backoff-times", bo.GetTotalBackoffTimes()),
-			)
+			s.logSendReqError(bo, "throwing pseudo region error due to no replica available", regionID, tryTimes, req, totalErrors)
 			resp, err = tikvrpc.GenRegionErrorResp(req, &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}})
 			return resp, nil, err
 		}
@@ -1158,6 +1144,8 @@ func (s *RegionRequestSender) SendReqCtx(
 		var retry bool
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)
 		if err != nil {
+			msg := fmt.Sprintf("send request failed, err: %v", err.Error())
+			s.logSendReqError(bo, msg, regionID, tryTimes, req, totalErrors)
 			return nil, nil, err
 		}
 
@@ -1182,14 +1170,19 @@ func (s *RegionRequestSender) SendReqCtx(
 			return nil, nil, err
 		}
 		if regionErr != nil {
+			regionErrLabel := regionErrorToLabel(regionErr)
+			totalErrors[regionErrLabel]++
 			retry, err = s.onRegionError(bo, rpcCtx, req, regionErr)
 			if err != nil {
+				msg := fmt.Sprintf("send request on region error failed, err: %v", err.Error())
+				s.logSendReqError(bo, msg, regionID, tryTimes, req, totalErrors)
 				return nil, nil, err
 			}
 			if retry {
 				tryTimes++
 				continue
 			}
+			s.logSendReqError(bo, "send request meet region error without retry", regionID, tryTimes, req, totalErrors)
 		} else {
 			if s.replicaSelector != nil {
 				s.replicaSelector.onSendSuccess()
@@ -1200,6 +1193,75 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 		return resp, rpcCtx, nil
 	}
+}
+
+func (s *RegionRequestSender) logSendReqError(bo *retry.Backoffer, msg string, regionID RegionVerID, retryTimes int, req *tikvrpc.Request, totalErrors map[string]int) {
+	var replicaStatus []string
+	replicaSelectorState := "nil"
+	cacheRegionIsValid := "unknown"
+	if s.replicaSelector != nil {
+		switch s.replicaSelector.state.(type) {
+		case *accessKnownLeader:
+			replicaSelectorState = "accessKnownLeader"
+		case *accessFollower:
+			replicaSelectorState = "accessFollower"
+		case *accessByKnownProxy:
+			replicaSelectorState = "accessByKnownProxy"
+		case *tryFollower:
+			replicaSelectorState = "tryFollower"
+		case *tryNewProxy:
+			replicaSelectorState = "tryNewProxy"
+		case *invalidLeader:
+			replicaSelectorState = "invalidLeader"
+		case *invalidStore:
+			replicaSelectorState = "invalidStore"
+		case *stateBase:
+			replicaSelectorState = "stateBase"
+		case nil:
+			replicaSelectorState = "nil"
+		}
+		if s.replicaSelector.region != nil {
+			if s.replicaSelector.region.isValid() {
+				cacheRegionIsValid = "true"
+			} else {
+				cacheRegionIsValid = "false"
+			}
+		}
+		for _, replica := range s.replicaSelector.replicas {
+			replicaStatus = append(replicaStatus, fmt.Sprintf("peer: %v, store: %v, isEpochStale: %v, attempts: %v, replica-epoch: %v, store-epoch: %v, store-state: %v, store-liveness-state: %v",
+				replica.peer.GetId(),
+				replica.store.storeID,
+				replica.isEpochStale(),
+				replica.attempts,
+				replica.epoch,
+				atomic.LoadUint32(&replica.store.epoch),
+				replica.store.getResolveState(),
+				replica.store.getLivenessState(),
+			))
+		}
+	}
+	var totalErrorStr bytes.Buffer
+	for err, cnt := range totalErrors {
+		if totalErrorStr.Len() > 0 {
+			totalErrorStr.WriteString(", ")
+		}
+		totalErrorStr.WriteString(err)
+		totalErrorStr.WriteString(":")
+		totalErrorStr.WriteString(strconv.Itoa(cnt))
+	}
+	logutil.Logger(bo.GetCtx()).Info(msg,
+		zap.Uint64("req-ts", req.GetStartTS()),
+		zap.String("req-type", req.Type.String()),
+		zap.String("region", regionID.String()),
+		zap.String("region-is-valid", cacheRegionIsValid),
+		zap.Int("retry-times", retryTimes),
+		zap.String("replica-read-type", req.ReplicaReadType.String()),
+		zap.String("replica-selector-state", replicaSelectorState),
+		zap.Bool("stale-read", req.StaleRead),
+		zap.String("replica-status", strings.Join(replicaStatus, "; ")),
+		zap.Int("total-backoff-ms", bo.GetTotalSleep()),
+		zap.Int("total-backoff-times", bo.GetTotalBackoffTimes()),
+		zap.String("total-region-errors", totalErrorStr.String()))
 }
 
 // RPCCancellerCtxKey is context key attach rpc send cancelFunc collector to ctx.

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -575,8 +575,8 @@ func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector
 		if len(state.option.labels) > 0 {
 			logutil.BgLogger().Warn("unable to find stores with given labels",
 				zap.Uint64("region", selector.region.GetID()),
-				zap.Bool("leader-invalid", leaderInvalid))
-
+				zap.Bool("leader-invalid", leaderInvalid),
+				zap.Any("labels", state.option.labels))
 		}
 		if leaderInvalid {
 			metrics.TiKVReplicaSelectorFailureCounter.WithLabelValues("exhausted").Inc()

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1059,7 +1059,7 @@ func (s *RegionRequestSender) SendReqCtx(
 			// TODO: Change the returned error to something like "region missing in cache",
 			// and handle this error like EpochNotMatch, which means to re-split the request and retry.
 			cacheRegionIsValid := "unknown"
-			if s.replicaSelector.region != nil {
+			if s.replicaSelector != nil && s.replicaSelector.region != nil {
 				if s.replicaSelector.region.isValid() {
 					cacheRegionIsValid = "true"
 				} else {

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1045,8 +1045,17 @@ func (s *RegionRequestSender) SendReqCtx(
 
 			// TODO: Change the returned error to something like "region missing in cache",
 			// and handle this error like EpochNotMatch, which means to re-split the request and retry.
+			cacheRegionIsValid := "unknown"
+			if s.replicaSelector.region != nil {
+				if s.replicaSelector.region.isValid() {
+					cacheRegionIsValid = "valid"
+				} else {
+					cacheRegionIsValid = "invalid"
+				}
+			}
 			logutil.Logger(bo.GetCtx()).Info("throwing pseudo region error due to no replica available",
 				zap.String("region", regionID.String()),
+				zap.String("region-valid", cacheRegionIsValid),
 				zap.Int("try-times", tryTimes),
 				zap.String("replica-read-type", req.ReplicaReadType.String()),
 				zap.Bool("stale-read", req.StaleRead),

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -35,9 +35,11 @@
 package retry
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -150,6 +152,18 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 				errMsg += "\n" + err.Error()
 			}
 		}
+		var backoffDetail bytes.Buffer
+		totalTimes := 0
+		for name, times := range b.backoffTimes {
+			totalTimes += times
+			if backoffDetail.Len() > 0 {
+				backoffDetail.WriteString(", ")
+			}
+			backoffDetail.WriteString(name)
+			backoffDetail.WriteString(":")
+			backoffDetail.WriteString(strconv.Itoa(times))
+		}
+		errMsg += fmt.Sprintf("\ntotal-backoff-times: %v, backoff-detail: %v", totalTimes, backoffDetail.String())
 		returnedErr := err
 		if longestSleepCfg != nil {
 			errMsg += fmt.Sprintf("\nlongest sleep type: %s, time: %dms", longestSleepCfg.String(), longestSleepTime)

--- a/kv/store_vars.go
+++ b/kv/store_vars.go
@@ -69,6 +69,7 @@ func (r ReplicaReadType) IsFollowerRead() bool {
 	return r != ReplicaReadLeader
 }
 
+// String implements fmt.Stringer interface.
 func (r ReplicaReadType) String() string {
 	switch r {
 	case ReplicaReadLeader:

--- a/kv/store_vars.go
+++ b/kv/store_vars.go
@@ -81,6 +81,6 @@ func (r ReplicaReadType) String() string {
 	case ReplicaReadMixed:
 		return "mixed"
 	default:
-		return fmt.Sprintf("unknown-%v", r)
+		return fmt.Sprintf("unknown-%v", byte(r))
 	}
 }

--- a/kv/store_vars.go
+++ b/kv/store_vars.go
@@ -35,6 +35,8 @@
 package kv
 
 import (
+	"fmt"
+
 	"go.uber.org/atomic"
 )
 
@@ -79,6 +81,6 @@ func (r ReplicaReadType) String() string {
 	case ReplicaReadMixed:
 		return "mixed"
 	default:
-		return "unknown"
+		return fmt.Sprintf("unknown-%v", r)
 	}
 }

--- a/kv/store_vars.go
+++ b/kv/store_vars.go
@@ -68,3 +68,16 @@ const (
 func (r ReplicaReadType) IsFollowerRead() bool {
 	return r != ReplicaReadLeader
 }
+
+func (r ReplicaReadType) String() string {
+	switch r {
+	case ReplicaReadLeader:
+		return "leader"
+	case ReplicaReadFollower:
+		return "follower"
+	case ReplicaReadMixed:
+		return "mixed"
+	default:
+		return "unknown"
+	}
+}

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -1271,3 +1271,51 @@ func (req *Request) IsTxnWriteRequest() bool {
 
 // ResourceGroupTagger is used to fill the ResourceGroupTag in the kvrpcpb.Context.
 type ResourceGroupTagger func(req *Request)
+
+// GetStartTS returns the `start_ts` of the request.
+func (req *Request) GetStartTS() uint64 {
+	switch req.Type {
+	case CmdGet:
+		return req.Get().GetVersion()
+	case CmdScan:
+		return req.Scan().GetVersion()
+	case CmdPrewrite:
+		return req.Prewrite().GetStartVersion()
+	case CmdCommit:
+		return req.Commit().GetStartVersion()
+	case CmdCleanup:
+		return req.Cleanup().GetStartVersion()
+	case CmdBatchGet:
+		return req.BatchGet().GetVersion()
+	case CmdBatchRollback:
+		return req.BatchRollback().GetStartVersion()
+	case CmdScanLock:
+		return req.ScanLock().GetMaxVersion()
+	case CmdResolveLock:
+		return req.ResolveLock().GetStartVersion()
+	case CmdPessimisticLock:
+		return req.PessimisticLock().GetStartVersion()
+	case CmdPessimisticRollback:
+		return req.PessimisticRollback().GetStartVersion()
+	case CmdTxnHeartBeat:
+		return req.TxnHeartBeat().GetStartVersion()
+	case CmdCheckTxnStatus:
+		return req.CheckTxnStatus().GetLockTs()
+	case CmdCheckSecondaryLocks:
+		return req.CheckSecondaryLocks().GetStartVersion()
+	case CmdFlashbackToVersion:
+		return req.FlashbackToVersion().GetStartTs()
+	case CmdPrepareFlashbackToVersion:
+		req.PrepareFlashbackToVersion().GetStartTs()
+	case CmdCop:
+		return req.Cop().GetStartTs()
+	case CmdCopStream:
+		return req.Cop().GetStartTs()
+	case CmdBatchCop:
+		return req.BatchCop().GetStartTs()
+	case CmdMvccGetByStartTs:
+		return req.MvccGetByStartTs().GetStartTs()
+	default:
+	}
+	return 0
+}


### PR DESCRIPTION
cherry-pick: https://github.com/tikv/client-go/pull/915

Add more logs for diagnose.

Here some log example:

```log
[2023/07/31 14:00:20.505 +08:00] [WARN] [region_request.go:614] ["unable to find stores with given labels"] [region=17] [leader-invalid=false] [labels="[{\"key\":\"zone\",\"value\":\"z99\"}]"]
[2023/07/31 13:57:29.333 +08:00] [INFO] [region_cache.go:2483] ["change store resolve state"] [store=5] [addr=10.0.1.9:20161] [from=needCheck] [to=resolved] [liveness-state=unreachable]
[2023/07/31 13:59:34.977 +08:00] [WARN] [backoff.go:172] ["regionMiss backoffer.maxSleep 40000ms is exceeded, errors:\nepoch_not_match:<>  at 2023-07-31T13:59:33.472306+08:00\nepoch_not_match:<>  at 2023-07-31T13:59:33.973395+08:00\nepoch_not_match:<>  at 2023-07-31T13:59:34.476155+08:00\ntotal-backoff-times: 87, backoff-detail: regionMiss:87\nlongest sleep type: regionMiss, time: 40010ms"]
[2023/07/31 13:56:11.856 +08:00] [INFO] [region_request.go:1252] ["throwing pseudo region error due to no replica available"] [req-ts=443228608411205633] [req-type=Cop] [region="{ region id: 225, ver: 83, confVer: 11 }"] [region-is-valid=false] [retry-times=3] [replica-read-type=leader] [replica-selector-state=tryFollower] [stale-read=false] [replica-status="peer: 226, store: 5, isEpochStale: false, attempts: 1, replica-epoch: 1, store-epoch: 1, store-state: resolved, store-liveness-state: reachable; peer: 227, store: 4, isEpochStale: false, attempts: 1, replica-epoch: 1, store-epoch: 1, store-state: resolved, store-liveness-state: reachable; peer: 228, store: 16, isEpochStale: false, attempts: 1, replica-epoch: 1, store-epoch: 1, store-state: resolved, store-liveness-state: reachable"] [total-backoff-ms=11078] [total-backoff-times=38] [total-region-errors=not_leader:3]
```