### PR TITLE
fallback to follower when leader is busy

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -371,6 +371,7 @@ func (state *accessKnownLeader) onNoLeader(selector *replicaSelector) {
 // the leader will be updated to replicas[0] and give it another chance.
 type tryFollower struct {
 	stateBase
+	// if the leader is unavailable, but it still holds the leadership, fallbackFromLeader is true and replica read is enabled.
 	fallbackFromLeader bool
 	leaderIdx          AccessIndex
 	lastIdx            AccessIndex

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -407,7 +407,7 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 		replicaRead := true
 		rpcCtx.contextPatcher.replicaRead = &replicaRead
 	}
-	return rpcCtx, err
+	return rpcCtx, nil
 }
 
 func (state *tryFollower) onSendSuccess(selector *replicaSelector) {


### PR DESCRIPTION
Fallback to follower when leader is busy.

Inject data-is-not-ready for stale read and server-is-busy for leader, so fallback to leader will be stucked.

![fail](https://github.com/tikv/client-go/assets/9587680/17254804-2e6d-4eec-9137-e0c63f37d2cb)

With this patch, server-is-busy on leader will try followers.

![success](https://github.com/tikv/client-go/assets/9587680/9a6907c4-f10c-46ad-9c67-8eacb7c5f583)

