### PR TITLE
pdclient: add timeout config for http client

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -201,8 +201,8 @@ func WithPDHTTPClient(tlsConf *tls.Config, pdaddrs []string) Option {
 	}
 }
 
-// WithPDHTTPClientTimeout set the PD HTTP client with the given address, TLS config and http client config.
-func WithPDHTTPClientTimeout(tlsConf *tls.Config, pdaddrs []string, httpCfg *util.HttpClientConfig) Option {
+// WithPDHTTPClientCfg set the PD HTTP client with the given address, TLS config and http client config.
+func WithPDHTTPClientCfg(tlsConf *tls.Config, pdaddrs []string, httpCfg *util.HttpClientConfig) Option {
 	return func(o *KVStore) {
 		o.pdHttpClient = util.NewPDHTTPClient(tlsConf, pdaddrs, httpCfg)
 	}

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -197,7 +197,14 @@ func WithPool(gp Pool) Option {
 // WithPDHTTPClient set the PD HTTP client with the given address and TLS config.
 func WithPDHTTPClient(tlsConf *tls.Config, pdaddrs []string) Option {
 	return func(o *KVStore) {
-		o.pdHttpClient = util.NewPDHTTPClient(tlsConf, pdaddrs)
+		o.pdHttpClient = util.NewPDHTTPClient(tlsConf, pdaddrs, nil)
+	}
+}
+
+// WithPDHTTPClientTimeout set the PD HTTP client with the given address, TLS config and http client config.
+func WithPDHTTPClientTimeout(tlsConf *tls.Config, pdaddrs []string, httpCfg *util.HttpClientConfig) Option {
+	return func(o *KVStore) {
+		o.pdHttpClient = util.NewPDHTTPClient(tlsConf, pdaddrs, httpCfg)
 	}
 }
 

--- a/util/pd.go
+++ b/util/pd.go
@@ -68,6 +68,7 @@ type PDHTTPClient struct {
 func NewPDHTTPClient(
 	tlsConf *tls.Config,
 	pdAddrs []string,
+	cfg *HttpClientConfig,
 ) *PDHTTPClient {
 	for i, addr := range pdAddrs {
 		if !strings.HasPrefix(addr, "http") {
@@ -82,7 +83,7 @@ func NewPDHTTPClient(
 
 	return &PDHTTPClient{
 		addrs: pdAddrs,
-		cli:   httpClient(tlsConf),
+		cli:   httpClient(tlsConf, cfg),
 	}
 }
 
@@ -192,10 +193,23 @@ func pdRequestRetryInterval() time.Duration {
 	return time.Second
 }
 
+// HttpClientConfig is the configuration of HttpClient.
+type HttpClientConfig struct {
+	timeout time.Duration
+}
+
+// NewHttpClientConfig returns a new HttpClientConfig.
+func NewHttpClientConfig(timeout time.Duration) *HttpClientConfig {
+	return &HttpClientConfig{timeout: timeout}
+}
+
 // httpClient returns an HTTP(s) client.
-func httpClient(tlsConf *tls.Config) *http.Client {
+func httpClient(tlsConf *tls.Config, cfg *HttpClientConfig) *http.Client {
 	// defaultTimeout for non-context requests.
-	const defaultTimeout = 30 * time.Second
+	var defaultTimeout = 30 * time.Second
+	if cfg != nil {
+		defaultTimeout = cfg.timeout
+	}
 	cli := &http.Client{Timeout: defaultTimeout}
 	if tlsConf != nil {
 		transport := http.DefaultTransport.(*http.Transport).Clone()


### PR DESCRIPTION
We have found that the default 30s timeout is too long for tidb UT (unit tests). Therefore, we need a way to reduce this timeout value.