### PR TITLE
log: group replica selector logging and split not leader errors

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -253,6 +253,10 @@ type replica struct {
 	deadlineErrUsingConfTimeout bool
 }
 
+func (r *replica) getEpoch() uint32 {
+	return atomic.LoadUint32(&r.epoch)
+}
+
 func (r *replica) isEpochStale() bool {
 	return r.epoch != atomic.LoadUint32(&r.store.epoch)
 }
@@ -324,7 +328,7 @@ func (s *replicaSelector) String() string {
 				replica.store.storeID,
 				replica.isEpochStale(),
 				replica.attempts,
-				replica.epoch,
+				replica.getEpoch(),
 				atomic.LoadUint32(&replica.store.epoch),
 				replica.store.getResolveState(),
 				replica.store.getLivenessState(),


### PR DESCRIPTION
1. Refactor and group the logging-related logic into `RegionRequestSender` and `replicaSelector`.
2. Split the `totalErros` into details for `NotLeader` error responses, 
from
```
[total-region-errors="not_leader-nil:3"]
```
```
[Prefix: target peer id]-not_leader-[Suffix: Leader information in the returned error and nil if no leader]
[total-region-errors="6-not_leader-nil:1, 4-not_leader-nil:1, 5-not_leader-nil:1"]
```  