### PR TITLE
ci: update go version

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.20.x"
+        go-version: "1.21.0"
 
     - name: Checkout Client-Go
       uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.0
 
       - name: Test
         run: go test ./...
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.0
 
       - name: Test
         run: go test ./... -race
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.0
 
       - name: Fetch PD
         uses: shrink/actions-docker-extract@v1
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.0
 
       - name: Fetch PD
         uses: shrink/actions-docker-extract@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.2
+        go-version: 1.21.0
 
     - name: Test
       run: go test ./...
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.2
+        go-version: 1.21.0
 
     - name: Test with race
       run: go test -race ./...
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.2
+          go-version: 1.21.0
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3

--- a/internal/client/main_test.go
+++ b/internal/client/main_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("google.golang.org/grpc.(*ClientConn).WaitForStateChange"),
 		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/internal/retry.newBackoffFn.func1"),
+		goleak.IgnoreTopFunction("github.com/tikv/client-go/v2/internal/retry.(*Config).createBackoffFn.newBackoffFn.func2"),
 	}
 	goleak.VerifyTestMain(m, opts...)
 }


### PR DESCRIPTION
tidb use go1.21 after https://github.com/pingcap/tidb/pull/45923