### PR TITLE
fix misleading annotation of LoadRegionsInKeyRange

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -990,7 +990,7 @@ func (c *RegionCache) ListRegionIDsInKeyRange(bo *retry.Backoffer, startKey, end
 	return regionIDs, nil
 }
 
-// LoadRegionsInKeyRange lists regions in [start_key,end_key].
+// LoadRegionsInKeyRange lists regions in [start_key,end_key).
 func (c *RegionCache) LoadRegionsInKeyRange(bo *retry.Backoffer, startKey, endKey []byte) (regions []*Region, err error) {
 	var batchRegions []*Region
 	for {


### PR DESCRIPTION
The annotation of LoadRegionsInKeyRange seems to be misleading.
I think it is better to fix it. 
It once wasts time of me when i am troubleshooting a tidb bug.  

As issue #924 describe.