### PR TITLE
do not try leader if it's unreachable

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -616,7 +616,8 @@ func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector
 	if selector.targetIdx < 0 {
 		leader := selector.replicas[state.leaderIdx]
 		leaderEpochStale := leader.isEpochStale()
-		leaderInvalid := leaderEpochStale || state.IsLeaderExhausted(leader)
+		leaderUnreachable := leader.store.getLivenessState() != reachable
+		leaderInvalid := leaderEpochStale || leaderUnreachable || state.IsLeaderExhausted(leader)
 		if len(state.option.labels) > 0 {
 			logutil.BgLogger().Warn("unable to find stores with given labels",
 				zap.Uint64("region", selector.region.GetID()),


### PR DESCRIPTION
When isolate two AZs, tidb may still try unreachable leader replicas, which leads to long-tail queries.

![2023-08-17_173808](https://github.com/tikv/client-go/assets/6850317/ec179e07-b8c2-4b18-936d-f5ba901c54bf)
