### PR TITLE
use leader read when `tryFollower` is fallback from `accessKnownLeader`

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -347,7 +347,7 @@ func (state *accessKnownLeader) next(bo *retry.Backoffer, selector *replicaSelec
 	// a request. So, before the new leader is elected, we should not send requests
 	// to the unreachable old leader to avoid unnecessary timeout.
 	if liveness != reachable || leader.isExhausted(maxReplicaAttempt) {
-		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx}
+		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
 		return nil, stateChanged{}
 	}
 	if selector.busyThreshold > 0 {
@@ -371,7 +371,7 @@ func (state *accessKnownLeader) onSendFailure(bo *retry.Backoffer, selector *rep
 		return
 	}
 	if liveness != reachable || selector.targetReplica().isExhausted(maxReplicaAttempt) {
-		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx}
+		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
 	}
 	if liveness != reachable {
 		selector.invalidateReplicaStore(selector.targetReplica(), cause)
@@ -379,7 +379,7 @@ func (state *accessKnownLeader) onSendFailure(bo *retry.Backoffer, selector *rep
 }
 
 func (state *accessKnownLeader) onNoLeader(selector *replicaSelector) {
-	selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromOnNotLeader: true}
+	selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
 }
 
 // tryFollower is the state where we cannot access the known leader
@@ -393,8 +393,8 @@ type tryFollower struct {
 	stateBase
 	leaderIdx AccessIndex
 	lastIdx   AccessIndex
-	// fromOnNotLeader indicates whether the state is changed from onNotLeader.
-	fromOnNotLeader bool
+	// fromKnownLeader indicates whether the state is changed from onNotLeader.
+	fromKnownLeader bool
 	labels          []*metapb.StoreLabel
 }
 
@@ -454,7 +454,7 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 	if err != nil || rpcCtx == nil {
 		return rpcCtx, err
 	}
-	if !state.fromOnNotLeader {
+	if !state.fromKnownLeader {
 		replicaRead := true
 		rpcCtx.contextPatcher.replicaRead = &replicaRead
 	}
@@ -464,7 +464,7 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 }
 
 func (state *tryFollower) onSendSuccess(selector *replicaSelector) {
-	if state.fromOnNotLeader {
+	if state.fromKnownLeader {
 		peer := selector.targetReplica().peer
 		if !selector.region.switchWorkLeaderToPeer(peer) {
 			logutil.BgLogger().Warn("the store must exist",

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -347,7 +347,7 @@ func (state *accessKnownLeader) next(bo *retry.Backoffer, selector *replicaSelec
 	// a request. So, before the new leader is elected, we should not send requests
 	// to the unreachable old leader to avoid unnecessary timeout.
 	if liveness != reachable || leader.isExhausted(maxReplicaAttempt) {
-		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
+		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromAccessKnownLeader: true}
 		return nil, stateChanged{}
 	}
 	if selector.busyThreshold > 0 {
@@ -371,7 +371,7 @@ func (state *accessKnownLeader) onSendFailure(bo *retry.Backoffer, selector *rep
 		return
 	}
 	if liveness != reachable || selector.targetReplica().isExhausted(maxReplicaAttempt) {
-		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
+		selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromAccessKnownLeader: true}
 	}
 	if liveness != reachable {
 		selector.invalidateReplicaStore(selector.targetReplica(), cause)
@@ -379,7 +379,7 @@ func (state *accessKnownLeader) onSendFailure(bo *retry.Backoffer, selector *rep
 }
 
 func (state *accessKnownLeader) onNoLeader(selector *replicaSelector) {
-	selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromKnownLeader: true}
+	selector.state = &tryFollower{leaderIdx: state.leaderIdx, lastIdx: state.leaderIdx, fromAccessKnownLeader: true}
 }
 
 // tryFollower is the state where we cannot access the known leader
@@ -393,9 +393,9 @@ type tryFollower struct {
 	stateBase
 	leaderIdx AccessIndex
 	lastIdx   AccessIndex
-	// fromKnownLeader indicates whether the state is changed from onNotLeader.
-	fromKnownLeader bool
-	labels          []*metapb.StoreLabel
+	// fromAccessKnownLeader indicates whether the state is changed from `accessKnownLeader`.
+	fromAccessKnownLeader bool
+	labels                []*metapb.StoreLabel
 }
 
 func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (*RPCContext, error) {
@@ -454,7 +454,7 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 	if err != nil || rpcCtx == nil {
 		return rpcCtx, err
 	}
-	if !state.fromKnownLeader {
+	if !state.fromAccessKnownLeader {
 		replicaRead := true
 		rpcCtx.contextPatcher.replicaRead = &replicaRead
 	}
@@ -464,7 +464,7 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 }
 
 func (state *tryFollower) onSendSuccess(selector *replicaSelector) {
-	if state.fromKnownLeader {
+	if state.fromAccessKnownLeader {
 		peer := selector.targetReplica().peer
 		if !selector.region.switchWorkLeaderToPeer(peer) {
 			logutil.BgLogger().Warn("the store must exist",


### PR DESCRIPTION
Recently, we made some changes to the selector states, the `tryFollower` is not only used as a fallback state of `accessKnownLeader`, this PR keeps the compatibility of `tryFollower`'s requests.

Before the changes we made:

`accessKnownLeader` -> `tryFollower` -> switch leader when success, and the flag `KVContext.ReplicaRead` is always false here.

Now there is another path lead to `tryFollower` state:

`accessFollower` -> `tryFollower`, in this case, `KVContext.ReplicaRead` is set to true in `tryFollower` state.

To make the behavior compatible with earlier versions, we need to set a flag for the `accessKnownLeader` -> `tryFollower` path, and that's `fromKnownLeader`. It's renamed from `fromOnNotLeader` for better semantic.

cc @crazycs520 
