### PR TITLE
request_source: set the request source at the last section

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -2337,9 +2337,10 @@ func (s *replicaSelector) replicaType(rpcCtx *RPCContext) string {
 
 func (s *replicaSelector) patchRequestSource(req *tikvrpc.Request, rpcCtx *RPCContext) {
 	var sb strings.Builder
-	sb.WriteString(req.InputRequestSource)
-	sb.WriteByte('-')
 	defer func() {
+		// TiKV does the limit control by the last part of the request source.
+		sb.WriteByte('_')
+		sb.WriteString(req.InputRequestSource)
 		req.RequestSource = sb.String()
 	}()
 

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1515,7 +1515,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestRetryRequestSource() {
 			rpcCtx, err := replicaSelector.buildRPCContext(bo)
 			s.Nil(err)
 			replicaSelector.patchRequestSource(req, rpcCtx)
-			s.Equal("test-"+firstReplica, req.RequestSource)
+			s.Equal(firstReplica+"_test", req.RequestSource)
 
 			// retry
 			setReadType(req, retryReplica)
@@ -1526,7 +1526,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestRetryRequestSource() {
 			s.Nil(err)
 			req.IsRetryRequest = true
 			replicaSelector.patchRequestSource(req, rpcCtx)
-			s.Equal("test-retry_"+firstReplica+"_"+retryReplica, req.RequestSource)
+			s.Equal("retry_"+firstReplica+"_"+retryReplica+"_test", req.RequestSource)
 		}
 	}
 }


### PR DESCRIPTION
As https://github.com/tikv/client-go/pull/953#issuecomment-1708749115 says, the format modified by #953 is not compatible with TiKV, this PR set the request source as the last section, so that TiKV can handle it correctly.