### PR TITLE
*: refine panic log

### DIFF
--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -301,7 +301,7 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 		if r := recover(); r != nil {
 			metrics.TiKVPanicCounter.WithLabelValues(metrics.LabelBatchSendLoop).Inc()
 			logutil.BgLogger().Error("batchSendLoop",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack"))
 			logutil.BgLogger().Info("restart batchSendLoop")
 			go a.batchSendLoop(cfg)
@@ -436,7 +436,7 @@ func (s *batchCommandsStream) recv() (resp *tikvpb.BatchCommandsResponse, err er
 		if r := recover(); r != nil {
 			metrics.TiKVPanicCounter.WithLabelValues(metrics.LabelBatchRecvLoop).Inc()
 			logutil.BgLogger().Error("batchCommandsClient.recv panic",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack"))
 			err = errors.New("batch conn recv paniced")
 		}
@@ -604,7 +604,7 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient, tikvTransport
 		if r := recover(); r != nil {
 			metrics.TiKVPanicCounter.WithLabelValues(metrics.LabelBatchRecvLoop).Inc()
 			logutil.BgLogger().Error("batchRecvLoop",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack"))
 			logutil.BgLogger().Info("restart batchRecvLoop")
 			go c.batchRecvLoop(cfg, tikvTransportLayerLoad, streamClient)

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -587,7 +587,7 @@ func (c *RegionCache) checkAndResolve(needCheckStores []*Store, needCheck func(*
 		r := recover()
 		if r != nil {
 			logutil.BgLogger().Error("panic in the checkAndResolve goroutine",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack trace"))
 		}
 	}()
@@ -2993,7 +2993,7 @@ func (c *RegionCache) checkAndUpdateStoreSlowScores() {
 		r := recover()
 		if r != nil {
 			logutil.BgLogger().Error("panic in the checkAndUpdateStoreSlowScores goroutine",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack trace"))
 		}
 	}()

--- a/util/misc.go
+++ b/util/misc.go
@@ -89,7 +89,7 @@ func WithRecovery(exec func(), recoverFn func(r interface{})) {
 		}
 		if r != nil {
 			logutil.BgLogger().Error("panic in the recoverable goroutine",
-				zap.Reflect("r", r),
+				zap.Any("r", r),
 				zap.Stack("stack trace"))
 		}
 	}()


### PR DESCRIPTION
close #966

Following is a tiny test:

Before this PR:

```go
func TestLog(t *testing.T) {
	defer func() {
		if r := recover(); r != nil {
			logutil.BgLogger().Warn("recover panic", zap.Reflect("r", r))
		}
	}()
	s := []int{}
	s[0] = 1
}
```

You will get the following log:

```log
[2023/09/11 14:36:19.797 +08:00] [WARN] [client_test.go:729] ["recover panic"] [r={}]
```

This PR, use `zap.Any` instead of `zap.Reflect`, You will get the following log:

```log
[2023/09/11 14:36:49.106 +08:00] [WARN] [client_test.go:729] ["recover panic"] [r="runtime error: index out of range [0] with length 0"]
```
