### PR TITLE
*: try follower when stale read request timeout

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -2094,14 +2094,14 @@ func (s *RegionRequestSender) onRegionError(
 			s.replicaSelector.onDeadlineExceeded()
 			return true, nil
 		}
+		if s.replicaSelector != nil {
+			return s.replicaSelector.onServerIsBusy(bo, ctx, req, serverIsBusy)
+		}
 		logutil.Logger(bo.GetCtx()).Warn(
 			"tikv reports `ServerIsBusy` retry later",
 			zap.String("reason", regionErr.GetServerIsBusy().GetReason()),
 			zap.Stringer("ctx", ctx),
 		)
-		if s.replicaSelector != nil {
-			return s.replicaSelector.onServerIsBusy(bo, ctx, req, serverIsBusy)
-		}
 		if ctx != nil && ctx.Store != nil && ctx.Store.storeType.IsTiFlashRelatedType() {
 			err = bo.Backoff(retry.BoTiFlashServerBusy, errors.Errorf("server is busy, ctx: %v", ctx))
 		} else {

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -738,11 +738,11 @@ func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector
 				zap.Bool("leader-invalid", leaderInvalid),
 				zap.Any("labels", state.option.labels))
 		}
-		// If leader tried and received deadline exceeded error, try follower.
 		if leaderInvalid || leader.deadlineErrUsingConfTimeout {
 			// In stale-read, the request will fallback to leader after the local follower failure.
 			// If the leader is also unavailable, we can fallback to the follower and use replica-read flag again,
 			// The remote follower not tried yet, and the local follower can retry without stale-read flag.
+			// If leader tried and received deadline exceeded error, try follower.
 			if state.isStaleRead {
 				selector.state = &tryFollower{
 					leaderIdx: state.leaderIdx,

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1517,6 +1517,7 @@ func (s *RegionRequestSender) logSendReqError(bo *retry.Backoffer, msg string, r
 		zap.Int("retry-times", retryTimes),
 		zap.Int("total-backoff-ms", bo.GetTotalSleep()),
 		zap.Int("total-backoff-times", bo.GetTotalBackoffTimes()),
+		zap.Uint64("max-exec-timeout-ms", req.Context.MaxExecutionDurationMs),
 		zap.String("total-region-errors", totalErrorStr.String()))
 }
 

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -738,11 +738,8 @@ func (state *accessFollower) next(bo *retry.Backoffer, selector *replicaSelector
 				zap.Bool("leader-invalid", leaderInvalid),
 				zap.Any("labels", state.option.labels))
 		}
-		// If leader tried and received deadline exceeded error, return nil to upper layer to retry with default timeout.
-		if leader.deadlineErrUsingConfTimeout {
-			return nil, nil
-		}
-		if leaderInvalid {
+		// If leader tried and received deadline exceeded error, try follower.
+		if leaderInvalid || leader.deadlineErrUsingConfTimeout {
 			// In stale-read, the request will fallback to leader after the local follower failure.
 			// If the leader is also unavailable, we can fallback to the follower and use replica-read flag again,
 			// The remote follower not tried yet, and the local follower can retry without stale-read flag.

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -2094,14 +2094,14 @@ func (s *RegionRequestSender) onRegionError(
 			s.replicaSelector.onDeadlineExceeded()
 			return true, nil
 		}
-		if s.replicaSelector != nil {
-			return s.replicaSelector.onServerIsBusy(bo, ctx, req, serverIsBusy)
-		}
 		logutil.Logger(bo.GetCtx()).Warn(
 			"tikv reports `ServerIsBusy` retry later",
 			zap.String("reason", regionErr.GetServerIsBusy().GetReason()),
 			zap.Stringer("ctx", ctx),
 		)
+		if s.replicaSelector != nil {
+			return s.replicaSelector.onServerIsBusy(bo, ctx, req, serverIsBusy)
+		}
 		if ctx != nil && ctx.Store != nil && ctx.Store.storeType.IsTiFlashRelatedType() {
 			err = bo.Backoff(retry.BoTiFlashServerBusy, errors.Errorf("server is busy, ctx: %v", ctx))
 		} else {

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1255,14 +1255,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestSendReqFirstTimeout() {
 			s.Nil(err)
 			s.True(IsFakeRegionError(regionErr))
 			s.Equal(1, len(s.regionRequestSender.Stats))
-			if staleRead {
-				rpcNum := s.regionRequestSender.Stats[tikvrpc.CmdGet].Count
-				s.True(rpcNum == 1 || rpcNum == 2) // 1 rpc or 2 rpc
-			} else {
-				s.Equal(int64(3), s.regionRequestSender.Stats[tikvrpc.CmdGet].Count) // 3 rpc
-				s.Equal(3, len(reqTargetAddrs))                                      // each rpc to a different store.
-			}
-			s.Equal(0, bo.GetTotalBackoffTimes()) // no backoff since fast retry.
+			s.Equal(int64(3), s.regionRequestSender.Stats[tikvrpc.CmdGet].Count) // 3 rpc
+			s.Equal(3, len(reqTargetAddrs))                                      // each rpc to a different store.
+			s.Equal(0, bo.GetTotalBackoffTimes())                                // no backoff since fast retry.
 			// warn: must rest MaxExecutionDurationMs before retry.
 			resetStats()
 			if staleRead {


### PR DESCRIPTION
close #970

Do the same test in #970 

**Before this PR**

The following are related metrics, some of metrics here are not as expected:

- Too much failed query in TiDB `192.168.78.2`, which cause by execution timeout.

<img width="1425" alt="image" src="https://github.com/tikv/client-go/assets/26020263/8c6267c0-a68d-4188-b40d-4f7d67566c7e">

<img width="1431" alt="image" src="https://github.com/tikv/client-go/assets/26020263/9cc645e8-8569-4f4c-a6b6-bd65caa6ca94">

<img width="1429" alt="image" src="https://github.com/tikv/client-go/assets/26020263/f5e22871-8956-4f30-a076-17b7abeeb3e5">

<img width="2872" alt="image" src="https://github.com/tikv/client-go/assets/26020263/abf97f28-3268-48d2-b57f-f0a5844cb59e">


**This PR**

- TiDB `192.168.78.2` doesn't have any failed query which execution timeout now, and doesn't have backoff too.
- TIDB `192.168.78.2` has a low QPS because each of the stale-read queries will timeout (100ms) first and then retry to succeed, and it only has 15 connections executing requests.

<img width="1435" alt="image" src="https://github.com/tikv/client-go/assets/26020263/ee4cc88d-8dd8-4784-a360-6d9e3a60ddd4">

<img width="1435" alt="image" src="https://github.com/tikv/client-go/assets/26020263/2382f448-0b70-42e7-96e8-985a5ad51549">

<img width="1430" alt="image" src="https://github.com/tikv/client-go/assets/26020263/048d2ce9-e996-4147-9f6f-d2d0b4e3577a">


<img width="2875" alt="image" src="https://github.com/tikv/client-go/assets/26020263/1f8423b5-5c18-4f4c-b819-04372a1bf5c4">

<img width="1435" alt="image" src="https://github.com/tikv/client-go/assets/26020263/3130f565-12e5-4af0-ac13-fccc7cc9ddc7">


