### PR TITLE
*: fix batch-client wait too long and add some metrics

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -620,7 +620,7 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	// TiDB RPC server supports batch RPC, but batch connection will send heart beat, It's not necessary since
 	// request to TiDB is not high frequency.
-	if config.GetGlobalConfig().TiKVClient.MaxBatchSize > 0 && enableBatch {
+	if config.GetGlobalConfig().TiKVClient.MaxBatchSize > 0 && enableBatch && !connArray.batchConn.isBusy(start.UnixNano()) {
 		if batchReq := req.ToBatchCommandsRequest(); batchReq != nil {
 			defer trace.StartRegion(ctx, req.Type.String()).End()
 			return sendBatchRequest(ctx, addr, req.ForwardedHost, connArray.batchConn, batchReq, timeout)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -62,7 +62,7 @@ var (
 	TiKVLocalLatchWaitTimeHistogram          prometheus.Histogram
 	TiKVStatusDuration                       *prometheus.HistogramVec
 	TiKVStatusCounter                        *prometheus.CounterVec
-	TiKVBatchWaitDuration                    prometheus.Histogram
+	TiKVBatchWaitDuration                    *prometheus.HistogramVec
 	TiKVBatchSendLatency                     prometheus.Histogram
 	TiKVBatchWaitOverLoad                    prometheus.Counter
 	TiKVBatchPendingRequests                 *prometheus.HistogramVec
@@ -333,7 +333,7 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			ConstLabels: constLabels,
 		}, []string{LblResult})
 
-	TiKVBatchWaitDuration = prometheus.NewHistogram(
+	TiKVBatchWaitDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace:   namespace,
 			Subsystem:   subsystem,
@@ -341,7 +341,7 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Buckets:     prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
 			Help:        "batch wait duration",
 			ConstLabels: constLabels,
-		})
+		}, []string{LblType, LblStore})
 
 	TiKVBatchSendLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -338,7 +338,7 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Namespace:   namespace,
 			Subsystem:   subsystem,
 			Name:        "batch_wait_duration",
-			Buckets:     prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
+			Buckets:     prometheus.ExponentialBuckets(16, 2, 36), // 16ns ~ 549s
 			Help:        "batch wait duration",
 			ConstLabels: constLabels,
 		}, []string{LblType, LblStore})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -62,7 +62,8 @@ var (
 	TiKVLocalLatchWaitTimeHistogram          prometheus.Histogram
 	TiKVStatusDuration                       *prometheus.HistogramVec
 	TiKVStatusCounter                        *prometheus.CounterVec
-	TiKVBatchWaitDuration                    *prometheus.HistogramVec
+	TiKVBatchConnSendDuration                *prometheus.HistogramVec
+	TiKVBatchCmdDuration                     *prometheus.HistogramVec
 	TiKVBatchSendLatency                     prometheus.Histogram
 	TiKVBatchWaitOverLoad                    prometheus.Counter
 	TiKVBatchPendingRequests                 *prometheus.HistogramVec
@@ -333,13 +334,23 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			ConstLabels: constLabels,
 		}, []string{LblResult})
 
-	TiKVBatchWaitDuration = prometheus.NewHistogramVec(
+	TiKVBatchConnSendDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace:   namespace,
 			Subsystem:   subsystem,
-			Name:        "batch_wait_duration",
+			Name:        "batch_conn_send_seconds",
+			Buckets:     prometheus.ExponentialBuckets(0.0005, 2, 22), // 0.5ms ~ 1048s
+			Help:        "batch conn send duration",
+			ConstLabels: constLabels,
+		}, []string{LblStore})
+
+	TiKVBatchCmdDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "batch_cmd_duration",
 			Buckets:     prometheus.ExponentialBuckets(16, 2, 36), // 16ns ~ 549s
-			Help:        "batch wait duration",
+			Help:        "batch cmd duration, unit is nanosecond",
 			ConstLabels: constLabels,
 		}, []string{LblType, LblStore})
 
@@ -767,7 +778,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVLocalLatchWaitTimeHistogram)
 	prometheus.MustRegister(TiKVStatusDuration)
 	prometheus.MustRegister(TiKVStatusCounter)
-	prometheus.MustRegister(TiKVBatchWaitDuration)
+	prometheus.MustRegister(TiKVBatchConnSendDuration)
+	prometheus.MustRegister(TiKVBatchCmdDuration)
 	prometheus.MustRegister(TiKVBatchSendLatency)
 	prometheus.MustRegister(TiKVBatchRecvLatency)
 	prometheus.MustRegister(TiKVBatchWaitOverLoad)


### PR DESCRIPTION
close #974

Do same test in issue #974, the related metric in this PR is following:

The QPS is much more stable

<img width="849" alt="image" src="https://github.com/tikv/client-go/assets/26020263/f373cc48-29f7-4801-ac91-8dc83af136a6">

<img width="837" alt="image" src="https://github.com/tikv/client-go/assets/26020263/66b93472-ba71-4768-9808-2c853f2f06eb">

<img width="1927" alt="image" src="https://github.com/tikv/client-go/assets/26020263/13a71747-c1d7-482d-aa23-97c9b12667e3">

<img width="1452" alt="image" src="https://github.com/tikv/client-go/assets/26020263/4c9f143e-f006-4925-86cb-0710c543152d">

