### PR TITLE
metrics: durations of region requests, counters of region request retries

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1318,13 +1318,13 @@ func (s *RegionRequestSender) SendReqCtx(
 		if err != nil {
 			metrics.TiKVRegionRequestHistogram.WithLabelValues(
 				req.Type.String(),
-				"fail",
+				metrics.LblErr,
 				req.InputRequestSource,
 			).Observe(time.Since(startTime).Seconds())
 		} else {
 			metrics.TiKVRegionRequestHistogram.WithLabelValues(
 				req.Type.String(),
-				"ok",
+				metrics.LblOK,
 				req.InputRequestSource,
 			).Observe(time.Since(startTime).Seconds())
 		}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -738,7 +738,7 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Name:        "region_request_duration_seconds",
 			Help:        "Bucketed histogram of region request duration",
 			ConstLabels: constLabels,
-			Buckets: prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 104s
+			Buckets:     prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 104s
 		}, []string{LblType, LblResult, LblSource},
 	)
 	TiKVRegionRequestRetryCounter = prometheus.NewCounterVec(

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -104,6 +104,8 @@ var (
 	TiKVStaleReadCounter                     *prometheus.CounterVec
 	TiKVStaleReadReqCounter                  *prometheus.CounterVec
 	TiKVStaleReadBytes                       *prometheus.CounterVec
+	TiKVRegionRequestHistogram               *prometheus.HistogramVec
+	TiKVRegionRequestRetryCounter            *prometheus.CounterVec
 )
 
 // Label constants.
@@ -128,6 +130,7 @@ const (
 	LblInternal        = "internal"
 	LblGeneral         = "general"
 	LblDirection       = "direction"
+	LblReason          = "reason"
 )
 
 func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
@@ -726,6 +729,23 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Help:      "Counter of stale read requests bytes",
 		}, []string{LblResult, LblDirection})
 
+	TiKVRegionRequestHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "region_request_duration_seconds",
+			Help:      "Bucketed histogram of region request duration",
+		}, []string{LblType, LblResult, LblSource},
+	)
+	TiKVRegionRequestRetryCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "region_request_retry_total",
+			Help:      "Counter of region request retry",
+		}, []string{LblType, LblSource, LblReason},
+	)
+
 	initShortcuts()
 }
 
@@ -809,6 +829,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVStaleReadCounter)
 	prometheus.MustRegister(TiKVStaleReadReqCounter)
 	prometheus.MustRegister(TiKVStaleReadBytes)
+	prometheus.MustRegister(TiKVRegionRequestHistogram)
+	prometheus.MustRegister(TiKVRegionRequestRetryCounter)
 }
 
 // readCounter reads the value of a prometheus.Counter.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -131,6 +131,8 @@ const (
 	LblGeneral         = "general"
 	LblDirection       = "direction"
 	LblReason          = "reason"
+	LblOK              = "ok"
+	LblErr             = "err"
 )
 
 func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
@@ -731,18 +733,21 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 
 	TiKVRegionRequestHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "region_request_duration_seconds",
-			Help:      "Bucketed histogram of region request duration",
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "region_request_duration_seconds",
+			Help:        "Bucketed histogram of region request duration",
+			ConstLabels: constLabels,
+			Buckets: prometheus.ExponentialBuckets(0.0001, 2, 20), // 0.1ms ~ 104s
 		}, []string{LblType, LblResult, LblSource},
 	)
 	TiKVRegionRequestRetryCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "region_request_retry_total",
-			Help:      "Counter of region request retry",
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "region_request_retry_total",
+			Help:        "Counter of region request retry",
+			ConstLabels: constLabels,
 		}, []string{LblType, LblSource, LblReason},
 	)
 

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -287,11 +287,11 @@ func (s *KVStore) runSafePointChecker() {
 		case spCachedTime := <-time.After(d):
 			cachedSafePoint, err := loadSafePoint(s.GetSafePointKV())
 			if err == nil {
-				metrics.TiKVLoadSafepointCounter.WithLabelValues("ok").Inc()
+				metrics.TiKVLoadSafepointCounter.WithLabelValues(metrics.LblOK).Inc()
 				s.UpdateSPCache(cachedSafePoint, spCachedTime)
 				d = gcSafePointUpdateInterval
 			} else {
-				metrics.TiKVLoadSafepointCounter.WithLabelValues("fail").Inc()
+				metrics.TiKVLoadSafepointCounter.WithLabelValues(metrics.LblErr).Inc()
 				logutil.BgLogger().Error("fail to load safepoint from pd", zap.Error(err))
 				d = gcSafePointQuickRepeatInterval
 			}


### PR DESCRIPTION
Part of #987 

Current kv request duration metrics are about the low-level request in sendRequest(), which doesn't count the retries, durations in region caches, etc.

Add 2 metrics that focus on the SendReqCtx level, which brings us more insight about retries.

One question is whether the combination of source x result x type is too large and risk the storage of Prometheus?

Preview
<img width="531" alt="image" src="https://github.com/tikv/client-go/assets/31720476/781d6bb1-d7d4-45ff-8962-a491883fe449">
<img width="801" alt="image" src="https://github.com/tikv/client-go/assets/31720476/39aca7cd-95a8-438c-a7cf-7944e13d793f">
