### PR TITLE
retry short read reqs immediately on server busy

### DIFF
--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -1005,7 +1005,7 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash() {
 	r := ctxTiFlash.Meta
 	reqSend := NewRegionRequestSender(s.cache, nil)
 	regionErr := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{r}}}
-	reqSend.onRegionError(s.bo, ctxTiFlash, nil, regionErr)
+	reqSend.onRegionError(s.bo, ctxTiFlash, nil, regionErr, nil)
 
 	// check leader read should not go to tiflash
 	lctx, err = s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
@@ -1640,14 +1640,14 @@ func (s *testRegionCacheSuite) TestShouldNotRetryFlashback() {
 	s.NotNil(ctx)
 	s.NoError(err)
 	reqSend := NewRegionRequestSender(s.cache, nil)
-	shouldRetry, err := reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{FlashbackInProgress: &errorpb.FlashbackInProgress{}})
+	shouldRetry, err := reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{FlashbackInProgress: &errorpb.FlashbackInProgress{}}, nil)
 	s.Error(err)
 	s.False(shouldRetry)
-	shouldRetry, err = reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{FlashbackNotPrepared: &errorpb.FlashbackNotPrepared{}})
+	shouldRetry, err = reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{FlashbackNotPrepared: &errorpb.FlashbackNotPrepared{}}, nil)
 	s.Error(err)
 	s.False(shouldRetry)
 
-	shouldRetry, err = reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{BucketVersionNotMatch: &errorpb.BucketVersionNotMatch{Keys: [][]byte{[]byte("a")}, Version: 1}})
+	shouldRetry, err = reqSend.onRegionError(s.bo, ctx, nil, &errorpb.Error{BucketVersionNotMatch: &errorpb.BucketVersionNotMatch{Keys: [][]byte{[]byte("a")}, Version: 1}}, nil)
 	s.Nil(err)
 	s.False(shouldRetry)
 	ctx.Region.GetID()

--- a/internal/retry/config.go
+++ b/internal/retry/config.go
@@ -95,6 +95,11 @@ func NewConfig(name string, metric *prometheus.Observer, backoffFnCfg *BackoffFn
 	}
 }
 
+// Base returns the base time of the backoff function.
+func (c *Config) Base() int {
+	return c.fnCfg.base
+}
+
 func (c *Config) String() string {
 	return c.name
 }


### PR DESCRIPTION
If a read-only workload running with a short max-execution-time (eg. 500ms), injecting IO delay faults will cause the QPS amost drop to zero, because the queries will be interrupted during server-busy backoff and have no chance to try other available peers.

To address the issue, let the sender retry those requests immediately and do backoff lazily. Here is the test results of injecting IO delay (1s) on one tikv for 3 minutes.
![20230922-133941](https://github.com/tikv/client-go/assets/6850317/ee1bd7d8-adc6-4526-acf8-d9c2f15e24ac)
