### PR TITLE
min-safe-ts: fix MinSafeTS might be set to MaxUint64 permanently

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -500,6 +500,9 @@ func (s *KVStore) GetTiKVClient() (client Client) {
 // GetMinSafeTS return the minimal safeTS of the storage with given txnScope.
 func (s *KVStore) GetMinSafeTS(txnScope string) uint64 {
 	if val, ok := s.minSafeTS.Load(txnScope); ok {
+		if val.(uint64) == uint64(math.MaxUint64) {
+			return 0
+		}
 		return val.(uint64)
 	}
 	return 0
@@ -850,3 +853,15 @@ type SchemaVer = transaction.SchemaVer
 // MaxTxnTimeUse is the max time a Txn may use (in ms) from its begin to commit.
 // We use it to abort the transaction to guarantee GC worker will not influence it.
 const MaxTxnTimeUse = transaction.MaxTxnTimeUse
+
+// SetMinSafeTS set the minimal safeTS of the storage with given txnScope.
+// Note: it is only used for test.
+func (s *KVStore) SetMinSafeTS(txnScope string, safeTS uint64) {
+	s.minSafeTS.Store(txnScope, safeTS)
+}
+
+// SetStoreSafeTS set the safeTS of the store with given storeID.
+// Note: it is only used for test.
+func (s *KVStore) SetStoreSafeTS(storeID, safeTS uint64) {
+	s.safeTSMap.Store(storeID, safeTS)
+}

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -692,10 +692,7 @@ func (s *KVStore) updateGlobalTxnScopeTSFromPD(ctx context.Context) bool {
 			preClusterMinSafeTS := s.GetMinSafeTS(oracle.GlobalTxnScope)
 			// If preClusterMinSafeTS is maxUint64, it means that the min safe ts has not been initialized.
 			// related to https://github.com/tikv/client-go/issues/991
-			if preClusterMinSafeTS == math.MaxUint64 {
-				preClusterMinSafeTS = 0
-			}
-			if preClusterMinSafeTS > clusterMinSafeTS {
+			if preClusterMinSafeTS != math.MaxUint64 && preClusterMinSafeTS > clusterMinSafeTS {
 				skipSafeTSUpdateCounter.Inc()
 				preSafeTSTime := oracle.GetTimeFromTS(preClusterMinSafeTS)
 				clusterMinSafeTSGap.Set(time.Since(preSafeTSTime).Seconds())


### PR DESCRIPTION
close #991 

The core question is the getter 
- we introduce `PD API` to not execute `go func which for KV request`, resulting in not updating `safeTSMap`. 		 
    - `updateMinSafeTS` relies on  `safeTSMap` which makes sense(because actually, we can call `updateMinSafeTS` to `kvReuqestUpdater`[to indicate func base]).
- And we need to update `minsafeTS` to make sure when API fails we can fall back to the original way which is by kv request.
- But the core problem is:  **`updateMinSafeTS` will return `maxUnit64` when the first kv request returns 0 and then although `PD API` returns correctly[maybe kv is not initialized], TS can not change `maxUnit64`.**
   - to resolve this question, we need to regard `maxUnit64` as 0 which means there is an initial state.
