### PR TITLE
bugfix: fix invalid nil pointer when trying to record Store.SlownessStat.

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1679,7 +1679,7 @@ func (s *RegionRequestSender) sendReqToRegion(
 	if !injectFailOnSend {
 		start := time.Now()
 		resp, err = s.client.SendRequest(ctx, sendToAddr, req, timeout)
-		// Record timecost of external requests on related Store when ReplicaReadMode == PreferLeader.
+		// Record timecost of external requests on related Store when `ReplicaReadMode == "PreferLeader"`.
 		if rpcCtx.Store != nil && req.ReplicaReadType == kv.ReplicaReadPreferLeader && !util.IsInternalRequest(req.RequestSource) {
 			rpcCtx.Store.recordSlowScoreStat(time.Since(start))
 		}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1680,7 +1680,7 @@ func (s *RegionRequestSender) sendReqToRegion(
 		start := time.Now()
 		resp, err = s.client.SendRequest(ctx, sendToAddr, req, timeout)
 		// Record timecost of external requests on related Store when ReplicaReadMode == PreferLeader.
-		if req.ReplicaReadType == kv.ReplicaReadPreferLeader && !util.IsInternalRequest(req.RequestSource) && rpcCtx.Store != nil {
+		if rpcCtx.Store != nil && req.ReplicaReadType == kv.ReplicaReadPreferLeader && !util.IsInternalRequest(req.RequestSource) {
 			rpcCtx.Store.recordSlowScoreStat(time.Since(start))
 		}
 		if s.Stats != nil {

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1680,7 +1680,7 @@ func (s *RegionRequestSender) sendReqToRegion(
 		start := time.Now()
 		resp, err = s.client.SendRequest(ctx, sendToAddr, req, timeout)
 		// Record timecost of external requests on related Store when ReplicaReadMode == PreferLeader.
-		if req.ReplicaReadType == kv.ReplicaReadPreferLeader && !util.IsInternalRequest(req.RequestSource) {
+		if req.ReplicaReadType == kv.ReplicaReadPreferLeader && !util.IsInternalRequest(req.RequestSource) && rpcCtx.Store != nil {
 			rpcCtx.Store.recordSlowScoreStat(time.Since(start))
 		}
 		if s.Stats != nil {


### PR DESCRIPTION
## Description
This pr is a bugfix pr, used to fix the `panic` issue when trying to record Store.SlownessStat if `rpcCtx.Store == nil`.

Related issue: https://github.com/pingcap/tidb/issues/47531