### PR TITLE
*: set default tls.MinVersion as tls.VersionTLS10

### DIFF
--- a/config/security.go
+++ b/config/security.go
@@ -102,5 +102,8 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			}
 		}
 	}
+	if tlsConfig.MinVersion == 0 {
+		tlsConfig.MinVersion = tls.VersionTLS10
+	}
 	return
 }

--- a/config/security.go
+++ b/config/security.go
@@ -103,7 +103,5 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			}
 		}
 	}
-	return &tls.Config{
-		MinVersion: tls.VersionTLS10,
-	}, nil
+	return
 }

--- a/config/security.go
+++ b/config/security.go
@@ -77,8 +77,9 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			return
 		}
 		tlsConfig = &tls.Config{
-			RootCAs:   certPool,
-			ClientCAs: certPool,
+			RootCAs:    certPool,
+			ClientCAs:  certPool,
+			MinVersion: tls.VersionTLS10,
 		}
 
 		if len(s.ClusterSSLCert) != 0 && len(s.ClusterSSLKey) != 0 {
@@ -102,8 +103,7 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			}
 		}
 	}
-	if tlsConfig.MinVersion == 0 {
-		tlsConfig.MinVersion = tls.VersionTLS10
-	}
-	return
+	return &tls.Config{
+		MinVersion: tls.VersionTLS10,
+	}, nil
 }


### PR DESCRIPTION
after upgrading the GRPC 1.60, it changed some behaviors.

<img width="1098" alt="image" src="https://github.com/tikv/client-go/assets/3427324/fe0d6d29-b8ba-45f0-a9fc-1ab6af1518b0">

so we have to set the tls.MinVersion