### PR TITLE
fix: check kill signal against 0

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -218,7 +218,12 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 	}
 
 	if b.vars != nil && b.vars.Killed != nil {
-		if atomic.LoadUint32(b.vars.Killed) == 1 {
+		killed := atomic.LoadUint32(b.vars.Killed)
+		if killed != 0 {
+			logutil.BgLogger().Info(
+				"backoff stops because a killed signal is received",
+				zap.Uint32("signal", killed),
+			)
 			return errors.WithStack(tikverr.ErrQueryInterrupted)
 		}
 	}

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -217,15 +217,9 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 		atomic.AddInt64(&detail.BackoffCount, 1)
 	}
 
-	if b.vars != nil && b.vars.Killed != nil {
-		killed := atomic.LoadUint32(b.vars.Killed)
-		if killed != 0 {
-			logutil.BgLogger().Info(
-				"backoff stops because a killed signal is received",
-				zap.Uint32("signal", killed),
-			)
-			return errors.WithStack(tikverr.ErrQueryInterrupted)
-		}
+	err2 := b.CheckKilled()
+	if err2 != nil {
+		return err2
 	}
 
 	var startTs interface{}
@@ -386,4 +380,18 @@ func (b *Backoffer) longestSleepCfg() (*Config, int) {
 		}
 	}
 	return nil, 0
+}
+
+func (b *Backoffer) CheckKilled() error {
+	if b.vars != nil && b.vars.Killed != nil {
+		killed := atomic.LoadUint32(b.vars.Killed)
+		if killed != 0 {
+			logutil.BgLogger().Info(
+				"backoff stops because a killed signal is received",
+				zap.Uint32("signal", killed),
+			)
+			return errors.WithStack(tikverr.ErrQueryInterrupted)
+		}
+	}
+	return nil
 }

--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -2502,3 +2502,13 @@ func (s *testCommitterSuite) TestExtractKeyExistsErr() {
 	s.True(txn.GetMemBuffer().TryLock())
 	txn.GetMemBuffer().Unlock()
 }
+
+func (s *testCommitterSuite) TestKillSignal() {
+	txn := s.begin()
+	err := txn.Set([]byte("key"), []byte("value"))
+	s.Nil(err)
+	var killed uint32 = 2
+	txn.SetVars(kv.NewVariables(&killed))
+	err = txn.Commit(context.Background())
+	s.ErrorContains(err, "query interrupted")
+}

--- a/internal/client/retry/backoff.go
+++ b/internal/client/retry/backoff.go
@@ -218,7 +218,12 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 	}
 
 	if b.vars != nil && b.vars.Killed != nil {
-		if atomic.LoadUint32(b.vars.Killed) == 1 {
+		killed := atomic.LoadUint32(b.vars.Killed)
+		if killed != 0 {
+			logutil.BgLogger().Info(
+				"backoff stops because a killed signal is received",
+				zap.Uint32("signal", killed),
+			)
 			return errors.WithStack(tikverr.ErrQueryInterrupted)
 		}
 	}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1477,16 +1477,8 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		// recheck whether the session/query is killed during the Next()
-		boVars := bo.GetVars()
-		if boVars != nil && boVars.Killed != nil {
-			killed := atomic.LoadUint32(boVars.Killed)
-			if killed != 0 {
-				logutil.BgLogger().Info(
-					"backoff stops because a killed signal is received",
-					zap.Uint32("signal", killed),
-				)
-				return nil, nil, retryTimes, errors.WithStack(tikverr.ErrQueryInterrupted)
-			}
+		if err2 := bo.CheckKilled(); err2 != nil {
+			return nil, nil, retryTimes, err2
 		}
 		if val, err := util.EvalFailpoint("mockRetrySendReqToRegion"); err == nil {
 			if val.(bool) {

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -44,6 +44,10 @@ type Variables struct {
 
 	// Pointer to SessionVars.Killed
 	// Killed is a flag to indicate that this query is killed.
+	// This is an enum value rather than a boolean. See sqlkiller.go
+	// in TiDB for its definition.
+	// When its value is 0, it's not killed
+	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
 }
 


### PR DESCRIPTION
Previously the kill signal was checked against `1`, however TiDB uses non-zero values to indicate a kill signal.