### PR TITLE
Change MinTLSVersion to TLSv1.2

### DIFF
--- a/config/security.go
+++ b/config/security.go
@@ -77,9 +77,8 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			return
 		}
 		tlsConfig = &tls.Config{
-			RootCAs:    certPool,
-			ClientCAs:  certPool,
-			MinVersion: tls.VersionTLS10,
+			RootCAs:   certPool,
+			ClientCAs: certPool,
 		}
 
 		if len(s.ClusterSSLCert) != 0 && len(s.ClusterSSLKey) != 0 {


### PR DESCRIPTION
ref https://github.com/pingcap/tidb/issues/36036

TLSv1.1 and older should not be used by default.

https://www.rfc-editor.org/rfc/rfc8996.html#name-do-not-use-tls-11
https://dev.mysql.com/worklog/task/?id=14519
https://dev.mysql.com/doc/refman/8.0/en/encrypted-connection-protocols-ciphers.html#encrypted-connection-supported-protocols
