### PR TITLE
do not update atime when region has down peers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
-
+          install-mode: "goinstall"


### PR DESCRIPTION
With this PR, the cached region won't live longger than RegionCacheTTL, or in other words, a region with down peers will be reloaded every RegionCacheTTL.

ref: https://github.com/tikv/client-go/issues/1104
related issues:
- https://github.com/pingcap/tidb/issues/35418
- https://github.com/tikv/client-go/issues/879

## integreation tests

**tiflash crash then up** (https://github.com/tikv/client-go/pull/1029)

![2024-01-17_000435](https://github.com/tikv/client-go/assets/6850317/f7a5d1c2-835f-4ddb-b2a1-7a4c04cc32ae)

**tikv down and reschedule regions** (https://github.com/tikv/client-go/issues/879)

WIP
