### PR TITLE
Close connection when get gRPC error Code.Canceled

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -222,7 +222,9 @@ func (a *connArray) monitoredDial(ctx context.Context, connName, target string, 
 
 func (c *monitoredConn) Close() error {
 	if c.ClientConn != nil {
-		return c.ClientConn.Close()
+		err := c.ClientConn.Close()
+		logutil.BgLogger().Debug("close gRPC connection", zap.String("target", c.Name), zap.Error(err))
+		return err
 	}
 	return nil
 }

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1832,10 +1832,12 @@ func (s *RegionRequestSender) onSendFail(bo *retry.Backoffer, ctx *RPCContext, r
 		case <-bo.GetCtx().Done():
 			return errors.WithStack(err)
 		default:
-			// If we don't cancel, but the error code is Canceled, it must be from grpc remote.
-			// This may happen when tikv is killed and exiting.
-			// Backoff and retry in this case.
-			logutil.Logger(bo.GetCtx()).Warn("receive a grpc cancel signal from remote", zap.Error(err))
+			// If we don't cancel, but the error code is Canceled, it may be canceled by keepalive or gRPC remote.
+			// For the case of canceled by keepalive, we need to re-establish the connection, otherwise following requests will always fail.
+			// Canceled by gRPC remote may happen when tikv is killed and exiting.
+			// Close the connection, backoff, and retry.
+			logutil.Logger(bo.GetCtx()).Warn("receive a grpc cancel signal", zap.Error(err))
+			s.client.CloseAddr(ctx.Addr)
 		}
 	}
 


### PR DESCRIPTION
Close #1120, https://github.com/tidbcloud/cloud-storage-engine/issues/1264

Close connection when get gRPC error as `Code.Canceled`, as the error would be caused by keep alive timeout. Then the next retry will try to establish the connection again. Otherwise, as underlying gRPC client has been canceled, we will keep get the same error.
