### PR TITLE
Revert "fix: check kill signal against 0 (#1102)"

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -2502,13 +2502,3 @@ func (s *testCommitterSuite) TestExtractKeyExistsErr() {
 	s.True(txn.GetMemBuffer().TryLock())
 	txn.GetMemBuffer().Unlock()
 }
-
-func (s *testCommitterSuite) TestKillSignal() {
-	txn := s.begin()
-	err := txn.Set([]byte("key"), []byte("value"))
-	s.Nil(err)
-	var killed uint32 = 2
-	txn.SetVars(kv.NewVariables(&killed))
-	err = txn.Commit(context.Background())
-	s.ErrorContains(err, "query interrupted")
-}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1498,8 +1498,9 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		// recheck whether the session/query is killed during the Next()
-		if err2 := bo.CheckKilled(); err2 != nil {
-			return nil, nil, retryTimes, err2
+		boVars := bo.GetVars()
+		if boVars != nil && boVars.Killed != nil && atomic.LoadUint32(boVars.Killed) == 1 {
+			return nil, nil, retryTimes, errors.WithStack(tikverr.ErrQueryInterrupted)
 		}
 		if val, err := util.EvalFailpoint("mockRetrySendReqToRegion"); err == nil {
 			if val.(bool) {

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -44,10 +44,6 @@ type Variables struct {
 
 	// Pointer to SessionVars.Killed
 	// Killed is a flag to indicate that this query is killed.
-	// This is an enum value rather than a boolean. See sqlkiller.go
-	// in TiDB for its definition.
-	// When its value is 0, it's not killed
-	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
 }
 


### PR DESCRIPTION
Temporarily revert #1102 to avoid test failures on TiDB repo.

This would be fixed by #1124 later.