### PR TITLE
mocktikv: impl mock pd service discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 )
 
 require (
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudfoundry/gosigar v1.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
+github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/internal/mockstore/mocktikv/mock.go
+++ b/internal/mockstore/mocktikv/mock.go
@@ -39,7 +39,7 @@ import (
 )
 
 // NewTiKVAndPDClient creates a TiKV client and PD client from options.
-func NewTiKVAndPDClient(path string, coprHandler CoprRPCHandler) (*RPCClient, *Cluster, pd.Client, error) {
+func NewTiKVAndPDClient(path string, pdAddrs []string, coprHandler CoprRPCHandler) (*RPCClient, *Cluster, pd.Client, error) {
 	mvccStore, err := NewMVCCLevelDB(path)
 	if err != nil {
 		return nil, nil, nil, err

--- a/testutils/mockstore.go
+++ b/testutils/mockstore.go
@@ -42,8 +42,8 @@ type MockClient = mocktikv.RPCClient
 type RPCSession = mocktikv.Session
 
 // NewMockTiKV creates a TiKV client and PD client from options.
-func NewMockTiKV(path string, coprHandler CoprRPCHandler) (*MockClient, *MockCluster, pd.Client, error) {
-	return mocktikv.NewTiKVAndPDClient(path, coprHandler)
+func NewMockTiKV(path string, pdAddrs []string, coprHandler CoprRPCHandler) (*MockClient, *MockCluster, pd.Client, error) {
+	return mocktikv.NewTiKVAndPDClient(path, pdAddrs, coprHandler)
 }
 
 // BootstrapWithSingleStore initializes a Cluster with 1 Region and 1 Store.

--- a/tikv/kv_test.go
+++ b/tikv/kv_test.go
@@ -46,7 +46,7 @@ type testKVSuite struct {
 }
 
 func (s *testKVSuite) SetupTest() {
-	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	client, cluster, pdClient, err := testutils.NewMockTiKV("", nil, nil)
 	s.Require().Nil(err)
 	testutils.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)


### PR DESCRIPTION
If pd http server is required for future tests of mocktikv, this needs to be implemented to provide the server address for the pd http client