### PR TITLE
tests: Fix timeout of TestResolveTxnFallbackFromAsyncCommit

### DIFF
--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -504,7 +504,7 @@ func (s *testAsyncCommitSuite) TestResolveTxnFallbackFromAsyncCommit() {
 		if fallback {
 			req.Req.(*kvrpcpb.PrewriteRequest).MaxCommitTs = 1
 		}
-		resp, err := s.store.SendReq(bo, req, loc.Region, 5000)
+		resp, err := s.store.SendReq(bo, req, loc.Region, 5*time.Second)
 		s.Nil(err)
 		s.NotNil(resp.Resp)
 	}


### PR DESCRIPTION
### Changes

- Change `5000`  to `5*time.Second`.