### PR TITLE
introduce a random jitter to region cache ttl

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -131,7 +131,7 @@ func SetRegionCacheTTLWithJitter(base int64, jitter int64) {
 	regionCacheTTLJitterSec = jitter
 }
 
-// nextTTL returns a random TTL in range [ts+base, ts+base+jitter).
+// nextTTL returns a random TTL in range [ts+base, ts+base+jitter). The input ts should be an epoch timestamp in seconds.
 func nextTTL(ts int64) int64 {
 	jitter := int64(0)
 	if regionCacheTTLJitterSec > 0 {

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1253,7 +1253,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestStaleReadFallback() {
 		return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{Value: value}}, nil
 	}}
 
-	region := s.cache.getRegionByIDFromCache(regionLoc.Region.GetID())
+	region, _ := s.cache.searchCachedRegionByID(regionLoc.Region.GetID())
 	s.True(region.isValid())
 
 	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")}, kv.ReplicaReadLeader, nil)
@@ -1485,7 +1485,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderReg
 		}}}, nil
 	}}
 
-	region := s.cache.getRegionByIDFromCache(regionLoc.Region.GetID())
+	region, _ := s.cache.searchCachedRegionByID(regionLoc.Region.GetID())
 	s.True(region.isValid())
 
 	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")}, kv.ReplicaReadLeader, nil)

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -557,9 +557,7 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 	s.Nil(err)
 	s.NotNil(regionLoc)
 
-	s.cache.mu.RLock()
-	region := s.cache.getRegionByIDFromCache(s.regionID)
-	s.cache.mu.RUnlock()
+	region, _ := s.cache.searchCachedRegionByID(s.regionID)
 	defer func() {
 		var (
 			valid       bool
@@ -662,10 +660,9 @@ func followerDown(s *testRegionCacheStaleReadSuite) {
 }
 
 func followerDownAndUp(s *testRegionCacheStaleReadSuite) {
-	s.cache.mu.RLock()
-	cachedRegion := s.cache.getRegionByIDFromCache(s.regionID)
-	s.cache.mu.RUnlock()
+	cachedRegion, expired := s.cache.searchCachedRegionByID(s.regionID)
 	_, follower := s.getFollower()
+	s.False(expired)
 	s.NotNil(cachedRegion)
 	s.NotNil(follower)
 	regionStore := cachedRegion.getStore()
@@ -751,10 +748,9 @@ func leaderDown(s *testRegionCacheStaleReadSuite) {
 }
 
 func leaderDownAndUp(s *testRegionCacheStaleReadSuite) {
-	s.cache.mu.RLock()
-	cachedRegion := s.cache.getRegionByIDFromCache(s.regionID)
-	s.cache.mu.RUnlock()
+	cachedRegion, expired := s.cache.searchCachedRegionByID(s.regionID)
 	_, leader := s.getLeader()
+	s.False(expired)
 	s.NotNil(cachedRegion)
 	s.NotNil(leader)
 	regionStore := cachedRegion.getStore()

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -616,7 +616,7 @@ func (s *testRegionRequestToSingleStoreSuite) TestGetRegionByIDFromCache() {
 	v2 := region.Region.confVer + 1
 	r2 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: region.Region.ver, ConfVer: v2}, StartKey: []byte{1}}
 	st := &Store{storeID: s.store}
-	s.cache.insertRegionToCache(&Region{meta: &r2, store: unsafe.Pointer(st), lastAccess: time.Now().Unix()}, true, true)
+	s.cache.insertRegionToCache(&Region{meta: &r2, store: unsafe.Pointer(st), ttl: nextTTLWithoutJitter(time.Now().Unix())}, true, true)
 	region, err = s.cache.LocateRegionByID(s.bo, s.region)
 	s.Nil(err)
 	s.NotNil(region)
@@ -626,7 +626,7 @@ func (s *testRegionRequestToSingleStoreSuite) TestGetRegionByIDFromCache() {
 	v3 := region.Region.confVer + 1
 	r3 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: v3, ConfVer: region.Region.confVer}, StartKey: []byte{2}}
 	st = &Store{storeID: s.store}
-	s.cache.insertRegionToCache(&Region{meta: &r3, store: unsafe.Pointer(st), lastAccess: time.Now().Unix()}, true, true)
+	s.cache.insertRegionToCache(&Region{meta: &r3, store: unsafe.Pointer(st), ttl: nextTTLWithoutJitter(time.Now().Unix())}, true, true)
 	region, err = s.cache.LocateRegionByID(s.bo, s.region)
 	s.Nil(err)
 	s.NotNil(region)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -58,6 +58,7 @@ var (
 	TiKVLoadSafepointCounter                 *prometheus.CounterVec
 	TiKVSecondaryLockCleanupFailureCounter   *prometheus.CounterVec
 	TiKVRegionCacheCounter                   *prometheus.CounterVec
+	TiKVLoadRegionCounter                    *prometheus.CounterVec
 	TiKVLoadRegionCacheHistogram             *prometheus.HistogramVec
 	TiKVLocalLatchWaitTimeHistogram          prometheus.Histogram
 	TiKVStatusDuration                       *prometheus.HistogramVec
@@ -128,6 +129,7 @@ const (
 	LblInternal        = "internal"
 	LblGeneral         = "general"
 	LblDirection       = "direction"
+	LblReason          = "reason"
 )
 
 func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
@@ -293,6 +295,14 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Help:        "Counter of region cache.",
 			ConstLabels: constLabels,
 		}, []string{LblType, LblResult})
+
+	TiKVLoadRegionCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "load_region_total",
+		Help:        "Counter of loading region.",
+		ConstLabels: constLabels,
+	}, []string{LblType, LblReason})
 
 	TiKVLoadRegionCacheHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -763,6 +773,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVLoadSafepointCounter)
 	prometheus.MustRegister(TiKVSecondaryLockCleanupFailureCounter)
 	prometheus.MustRegister(TiKVRegionCacheCounter)
+	prometheus.MustRegister(TiKVLoadRegionCounter)
 	prometheus.MustRegister(TiKVLoadRegionCacheHistogram)
 	prometheus.MustRegister(TiKVLocalLatchWaitTimeHistogram)
 	prometheus.MustRegister(TiKVStatusDuration)

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -194,9 +194,15 @@ func NewRegionRequestRuntimeStats() RegionRequestRuntimeStats {
 	return locate.NewRegionRequestRuntimeStats()
 }
 
-// SetRegionCacheTTLSec sets regionCacheTTLSec to t.
+// SetRegionCacheTTLSec sets the base value of region cache TTL.
+// Deprecated: use SetRegionCacheTTLWithJitter instead.
 func SetRegionCacheTTLSec(t int64) {
 	locate.SetRegionCacheTTLSec(t)
+}
+
+// SetRegionCacheTTLWithJitter sets region cache TTL with jitter. The real TTL is in range of [base, base+jitter).
+func SetRegionCacheTTLWithJitter(base int64, jitter int64) {
+	locate.SetRegionCacheTTLWithJitter(base, jitter)
 }
 
 // SetStoreLivenessTimeout sets storeLivenessTimeout to t.


### PR DESCRIPTION
Ref https://github.com/tikv/client-go/pull/1122#discussion_r1469009792 and #1104 .

This PR tries to address https://github.com/tikv/client-go/pull/1122#discussion_r1469009792 by introducing a random jitter to region cache TTL.

To observe the reason of region reloading, the methods for searching cached regions are refactored.