### PR TITLE
Configurable low res tso update interval (#1154)

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -50,6 +50,7 @@ type Oracle interface {
 	GetTimestampAsync(ctx context.Context, opt *Option) Future
 	GetLowResolutionTimestamp(ctx context.Context, opt *Option) (uint64, error)
 	GetLowResolutionTimestampAsync(ctx context.Context, opt *Option) Future
+	SetLowResolutionTimestampUpdateInterval(time.Duration) error
 	GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (uint64, error)
 	IsExpired(lockTimestamp, TTL uint64, opt *Option) bool
 	UntilExpired(lockTimeStamp, TTL uint64, opt *Option) int64

--- a/oracle/oracles/export_test.go
+++ b/oracle/oracles/export_test.go
@@ -36,12 +36,12 @@ package oracles
 
 import (
 	"context"
-	pd "github.com/tikv/pd/client"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/tikv/client-go/v2/oracle"
+	pd "github.com/tikv/pd/client"
 )
 
 // SetOracleHookCurrentTime exports localOracle's time hook to test.
@@ -74,8 +74,8 @@ func StartTsUpdateLoop(o oracle.Oracle, ctx context.Context, wg *sync.WaitGroup)
 		panic("expected pdOracle")
 	}
 	pd.quit = make(chan struct{})
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		pd.updateTS(ctx)
 		wg.Done()
 	}()

--- a/oracle/oracles/local.go
+++ b/oracle/oracles/local.go
@@ -101,6 +101,10 @@ func (l *localOracle) GetLowResolutionTimestampAsync(ctx context.Context, opt *o
 	return l.GetTimestampAsync(ctx, opt)
 }
 
+func (l *localOracle) SetLowResolutionTimestampUpdateInterval(time.Duration) error {
+	return nil
+}
+
 // GetStaleTimestamp return physical
 func (l *localOracle) GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (ts uint64, err error) {
 	return oracle.GoTimeToTS(time.Now().Add(-time.Second * time.Duration(prevSecond))), nil

--- a/oracle/oracles/mock.go
+++ b/oracle/oracles/mock.go
@@ -122,6 +122,10 @@ func (o *MockOracle) GetLowResolutionTimestampAsync(ctx context.Context, opt *or
 	return o.GetTimestampAsync(ctx, opt)
 }
 
+func (o *MockOracle) SetLowResolutionTimestampUpdateInterval(time.Duration) error {
+	return nil
+}
+
 // IsExpired implements oracle.Oracle interface.
 func (o *MockOracle) IsExpired(lockTimestamp, TTL uint64, _ *oracle.Option) bool {
 	o.RLock()

--- a/oracle/oracles/pd_test.go
+++ b/oracle/oracles/pd_test.go
@@ -36,7 +36,10 @@ package oracles_test
 
 import (
 	"context"
+	pd "github.com/tikv/pd/client"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -71,6 +74,88 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 	_, err = o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, math.MaxUint64)
 	assert.NotNil(t, err)
 	assert.Regexp(t, ".*invalid prevSecond.*", err.Error())
+}
+
+// A mock for pd.Client that only returns global transaction scoped
+// timestamps at the same physical time with increasing logical time
+type MockPdClient struct {
+	pd.Client
+
+	logicalTimestamp atomic.Int64
+}
+
+func (c *MockPdClient) GetTS(ctx context.Context) (int64, int64, error) {
+	return 0, c.logicalTimestamp.Add(1), nil
+}
+
+func TestPdOracle_SetLowResolutionTimestampUpdateInterval(t *testing.T) {
+	pdClient := MockPdClient{}
+	o := oracles.NewPdOracleWithClient(&pdClient)
+	ctx := context.TODO()
+	wg := sync.WaitGroup{}
+
+	// Too low, should error
+	err := o.SetLowResolutionTimestampUpdateInterval(time.Millisecond)
+	assert.NotNil(t, err)
+
+	// Too high, should error
+	err = o.SetLowResolutionTimestampUpdateInterval(time.Minute)
+	assert.NotNil(t, err)
+
+	// Should succeed
+	err = o.SetLowResolutionTimestampUpdateInterval(50 * time.Millisecond)
+	assert.Nil(t, err)
+
+	// First call to o.GetTimestamp just seeds the timestamp
+	_, err = o.GetTimestamp(ctx, &oracle.Option{})
+	assert.Nil(t, err)
+
+	// Haven't started update loop yet so next call to GetTs should be 1
+	// while the low resolution timestamp stays at 0
+	lowRes, err := o.GetLowResolutionTimestamp(ctx, &oracle.Option{})
+	assert.Nil(t, err)
+	ts, err := o.GetTimestamp(ctx, &oracle.Option{})
+	assert.Greater(t, ts, lowRes)
+
+	waitForTimestampToChange := func(checkFrequency time.Duration) (time.Time, time.Time) {
+		currTs, err := o.GetLowResolutionTimestamp(ctx, &oracle.Option{})
+		assert.Nil(t, err)
+		start := time.Now()
+		assert.Eventually(t, func() bool {
+			nextTs, err := o.GetLowResolutionTimestamp(ctx, &oracle.Option{})
+			assert.Nil(t, err)
+			return nextTs > currTs
+		}, 5*time.Second, checkFrequency)
+		return start, time.Now()
+	}
+
+	// Time based unit tests are inherently flaky. To reduce that
+	// this just asserts a loose lower and upper bound that should
+	// not be affected by timing inconsistencies across platforms
+	checkBounds := func(updateInterval time.Duration) {
+		start, _ := waitForTimestampToChange(10 * time.Millisecond)
+		_, end := waitForTimestampToChange(10 * time.Millisecond)
+		elapsed := end.Sub(start)
+		assert.Greater(t, elapsed, updateInterval)
+		assert.LessOrEqual(t, elapsed, 3*updateInterval)
+	}
+
+	oracles.StartTsUpdateLoop(o, ctx, &wg)
+	// Check each update interval. Note that since these are in increasing
+	// order the time for the new interval to take effect is always less
+	// than the new interval. If we iterated in opposite order, then we'd have
+	// to first wait for the timestamp to change before checking bounds.
+	for _, updateInterval := range []time.Duration{
+		50 * time.Millisecond,
+		150 * time.Millisecond,
+		500 * time.Millisecond} {
+		err = o.SetLowResolutionTimestampUpdateInterval(updateInterval)
+		assert.Nil(t, err)
+		checkBounds(updateInterval)
+	}
+
+	o.Close()
+	wg.Wait()
 }
 
 func TestNonFutureStaleTSO(t *testing.T) {

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -191,6 +191,9 @@ func WithPool(gp Pool) Option {
 	}
 }
 
+// WithUpdateInterval sets the frequency with which to refresh read timestamps
+// from the PD client. Smaller updateInterval will lead to more HTTP calls to
+// PD and less staleness on reads, and vice versa.
 func WithUpdateInterval(updateInterval time.Duration) Option {
 	return func(o *KVStore) {
 		err := o.oracle.SetLowResolutionTimestampUpdateInterval(updateInterval)

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -99,8 +99,9 @@ func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, erro
 	return cli, nil
 }
 
-// update oracle's lastTS every 2000ms.
-var oracleUpdateInterval = 2000
+// Update oracle's lastTS every 2000ms by default. Can override at startup with an option to NewKVStore
+// or at runtime by calling SetLowResolutionTimestampUpdateInterval on the oracle
+var defaultOracleUpdateInterval = 2 * time.Second
 
 // KVStore contains methods to interact with a TiKV cluster.
 type KVStore struct {
@@ -190,6 +191,15 @@ func WithPool(gp Pool) Option {
 	}
 }
 
+func WithUpdateInterval(updateInterval time.Duration) Option {
+	return func(o *KVStore) {
+		err := o.oracle.SetLowResolutionTimestampUpdateInterval(updateInterval)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
 // WithPDHTTPClient sets the PD HTTP client with the given PD addresses and options.
 // Source is to mark where the HTTP client is created, which is used for metrics and logs.
 func WithPDHTTPClient(
@@ -223,7 +233,7 @@ func loadOption(store *KVStore, opt ...Option) {
 
 // NewKVStore creates a new TiKV store instance.
 func NewKVStore(uuid string, pdClient pd.Client, spkv SafePointKV, tikvclient Client, opt ...Option) (*KVStore, error) {
-	o, err := oracles.NewPdOracle(pdClient, time.Duration(oracleUpdateInterval)*time.Millisecond)
+	o, err := oracles.NewPdOracle(pdClient, defaultOracleUpdateInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/tikv/test_probe.go
+++ b/tikv/test_probe.go
@@ -37,6 +37,7 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/client-go/v2/config/retry"
@@ -240,5 +241,5 @@ func (c ConfigProbe) StorePreSplitSizeThreshold(v uint32) {
 
 // SetOracleUpdateInterval sets the interval of updating cached ts.
 func (c ConfigProbe) SetOracleUpdateInterval(v int) {
-	oracleUpdateInterval = v
+	defaultOracleUpdateInterval = time.Duration(v) * time.Millisecond
 }


### PR DESCRIPTION
Closes #1154 and is the first half of https://github.com/pingcap/tidb/issues/51081. 

Adds new function `SetLowResolutionTimestampUpdateInterval(time.Duration) error` to the Oracle interface and implements it in `pdOracle` to control how often timestamps are refreshed in the local cache. Default behavior remaining unchanged at 2s.