### PR TITLE
check errors in scan request

### DIFF
--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -539,6 +539,9 @@ func (c *Client) Scan(ctx context.Context, startKey, endKey []byte, limit int, o
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawScanResponse)
 		for _, pair := range cmdResp.Kvs {
+			if pair.Error != nil {
+				return nil, nil, errors.New(pair.Error.String())
+			}
 			keys = append(keys, pair.Key)
 			values = append(values, convertNilToEmptySlice(pair.Value))
 		}
@@ -588,6 +591,9 @@ func (c *Client) ReverseScan(ctx context.Context, startKey, endKey []byte, limit
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawScanResponse)
 		for _, pair := range cmdResp.Kvs {
+			if pair.Error != nil {
+				return nil, nil, errors.New(pair.Error.String())
+			}
 			keys = append(keys, pair.Key)
 			values = append(values, convertNilToEmptySlice(pair.Value))
 		}


### PR DESCRIPTION
Problem can be reproduced on request to storage v2 without rawkv.WithAPIVersion(kvrpcpb.APIVersion_V2) in client.
in this case client returns list of empty bytes slices instead of error