### PR TITLE
adjust parameter for pipelined memdb by failpoint

### DIFF
--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -204,8 +204,12 @@ func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]
 	return s.BatchGetWithTier(ctx, keys, BatchGetSnapshotTier)
 }
 
+// BatchGet tiers indicate the read tier of the batch get request.
+// BatchGet read keys in regions. The keys location and region error retry mechanism are shared.
 const (
+	// BatchGetSnapshotTier indicates the batch get reads from a snapshot.
 	BatchGetSnapshotTier = 1 << iota
+	// BatchGetBufferTier indicates the batch get reads from the pipelined flushed buffer, only read locks in the current txn.
 	BatchGetBufferTier
 )
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -210,6 +210,7 @@ const (
 	// BatchGetSnapshotTier indicates the batch get reads from a snapshot.
 	BatchGetSnapshotTier = 1 << iota
 	// BatchGetBufferTier indicates the batch get reads from the pipelined flushed buffer, only read locks in the current txn.
+	// this only works when the txn is created with a pipelined memdb, unless an error will be returned.
 	BatchGetBufferTier
 )
 


### PR DESCRIPTION
Add failpoint interface to adjusting the flush options for pipelined memdb.
