### PR TITLE
fix data race when collapsing ResolveLockRequest

### DIFF
--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -213,4 +213,5 @@ func (s *testPipelinedMemDBSuite) TestResolveLockRace() {
 		}()
 		s.store.SendReq(bo, req, loc.Region, 100*time.Millisecond)
 	}
+	time.Sleep(time.Second)
 }

--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -22,11 +22,13 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/pkg/store/mockstore/unistore"
 	"github.com/stretchr/testify/suite"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/testutils"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
 const (
@@ -181,4 +183,34 @@ func (s *testPipelinedMemDBSuite) TestPipelinedSkipFlushedLock() {
 	val, err := txn.Get(context.Background(), []byte("key1"))
 	s.Nil(err)
 	s.Equal([]byte("value1"), val)
+}
+
+func (s *testPipelinedMemDBSuite) TestResolveLockRace() {
+	// This test should use `go test -race` to run.
+	// because pipelined memdb depends on ResolveLockRequest to commit the txn, we need to guarantee the ResolveLock won't lead to data race.
+	s.Nil(failpoint.Enable("tikvclient/pipelinedCommitFail", `return`))
+	defer func() {
+		failpoint.Disable("tikvclient/pipelinedCommitFail")
+	}()
+	for i := 0; i < 100; i++ {
+		txn, err := s.store.Begin(tikv.WithPipelinedMemDB())
+		startTS := txn.StartTS()
+		s.Nil(err)
+		for j := 0; j < 100; j++ {
+			key := []byte(strconv.Itoa(j))
+			value := key
+			txn.Set(key, value)
+		}
+		txn.Commit(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
+		bo := tikv.NewNoopBackoff(ctx)
+		loc, err := s.store.GetRegionCache().LocateKey(bo, []byte("1"))
+		s.Nil(err)
+		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, &kvrpcpb.ResolveLockRequest{StartVersion: startTS})
+		go func() {
+			time.Sleep(time.Duration(i) * time.Microsecond)
+			cancel()
+		}()
+		s.store.SendReq(bo, req, loc.Region, 100*time.Millisecond)
+	}
 }

--- a/internal/client/client_collapse.go
+++ b/internal/client/client_collapse.go
@@ -98,6 +98,7 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 
 func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,
 	addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
+	// because the request may be used by other goroutines, copy the request to avoid data race.
 	copyReq := *req
 	rsC := sf.DoChan(key, func() (interface{}, error) {
 		return r.Client.SendRequest(context.Background(), addr, &copyReq, ReadTimeoutShort) // use resolveLock timeout.

--- a/internal/client/client_collapse.go
+++ b/internal/client/client_collapse.go
@@ -98,8 +98,9 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 
 func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,
 	addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
+	copyReq := *req
 	rsC := sf.DoChan(key, func() (interface{}, error) {
-		return r.Client.SendRequest(context.Background(), addr, req, ReadTimeoutShort) // use resolveLock timeout.
+		return r.Client.SendRequest(context.Background(), addr, &copyReq, ReadTimeoutShort) // use resolveLock timeout.
 	})
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -93,7 +93,9 @@ func (c *twoPhaseCommitter) buildPipelinedFlushRequest(batch batchMutations, gen
 			DiskFullOpt:            c.txn.diskFullOpt,
 			TxnSource:              c.txn.txnSource,
 			MaxExecutionDurationMs: uint64(client.MaxWriteExecutionTime.Milliseconds()),
-			RequestSource:          c.txn.GetRequestSource(),
+			// txn.GetRequestSource may cause data race because the upper layer may edit the source while the flush requests are built in background.
+			// So we use the fixed source from the upper layer to avoid the data race.
+			RequestSource: "external_pdml",
 			ResourceControlContext: &kvrpcpb.ResourceControlContext{
 				ResourceGroupName: c.resourceGroupName,
 			},


### PR DESCRIPTION
The `ResolveLock` requests may race because it's handled by another goroutine, this PR fix it by a shallow copy before sending it.

```text
WARNING: DATA RACE
Write at 0x00c0005270dc by goroutine 46:
  github.com/tikv/client-go/v2/internal/locate.(*RegionRequestSender).SendReqCtx()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/locate/region_request.go:1563 +0x1bb8
  github.com/tikv/client-go/v2/internal/locate.(*RegionRequestSender).SendReq()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/locate/region_request.go:247 +0x19c
  github.com/tikv/client-go/v2/tikv.(*KVStore).SendReq()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/tikv/kv.go:524 +0x170
  integration_tests_test.(*testPipelinedMemDBSuite).TestResolveLockRace()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/integration_tests/pipelined_memdb_test.go:214 +0x144
  runtime.call16()
      /Users/you06/.gvm/gos/go1.21.5/src/runtime/asm_arm64.s:478 +0x74
  reflect.Value.Call()
      /Users/you06/.gvm/gos/go1.21.5/src/reflect/value.go:380 +0x90
  github.com/stretchr/testify/suite.Run.func1()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:197 +0x534
  testing.tRunner()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1648 +0x40

Previous read at 0x00c0005270d8 by goroutine 75:
  github.com/tikv/client-go/v2/internal/apicodec.attachAPICtx()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/apicodec/codec.go:93 +0x54
  github.com/tikv/client-go/v2/internal/apicodec.(*codecV1).EncodeRequest()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/apicodec/codec_v1.go:39 +0x38
  github.com/tikv/client-go/v2/tikv.(*CodecClient).SendRequest()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/tikv/test_util.go:56 +0x68
  github.com/tikv/client-go/v2/internal/client.interceptedClient.SendRequest()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/client/client_interceptor.go:60 +0x244
  github.com/tikv/client-go/v2/internal/client.(*interceptedClient).SendRequest()
      <autogenerated>:1 +0x74
  github.com/tikv/client-go/v2/internal/client.reqCollapse.collapse.func1()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/client/client_collapse.go:103 +0x80
  golang.org/x/sync/singleflight.(*Group).doCall.func2()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/golang.org/x/sync@v0.6.0/singleflight/singleflight.go:198 +0x8c
  golang.org/x/sync/singleflight.(*Group).doCall()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/golang.org/x/sync@v0.6.0/singleflight/singleflight.go:200 +0xe0
  golang.org/x/sync/singleflight.(*Group).DoChan.func1()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/golang.org/x/sync@v0.6.0/singleflight/singleflight.go:138 +0x64

Goroutine 46 (running) created at:
  testing.(*T).Run()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1648 +0x5e8
  github.com/stretchr/testify/suite.runTests()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:242 +0x170
  github.com/stretchr/testify/suite.Run()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:215 +0x79c
  integration_tests_test.TestPipelinedMemDB()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/integration_tests/pipelined_memdb_test.go:40 +0x40
  testing.tRunner()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1648 +0x40

Goroutine 75 (running) created at:
  golang.org/x/sync/singleflight.(*Group).DoChan()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/golang.org/x/sync@v0.6.0/singleflight/singleflight.go:138 +0x4a0
  github.com/tikv/client-go/v2/internal/client.reqCollapse.collapse()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/client/client_collapse.go:102 +0x150
  github.com/tikv/client-go/v2/internal/client.reqCollapse.tryCollapseRequest()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/client/client_collapse.go:91 +0x184
  github.com/tikv/client-go/v2/internal/client.reqCollapse.SendRequest()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/client/client_collapse.go:71 +0x70
  github.com/tikv/client-go/v2/internal/client.(*reqCollapse).SendRequest()
      <autogenerated>:1 +0x74
  github.com/tikv/client-go/v2/internal/locate.(*RegionRequestSender).sendReqToRegion()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/locate/region_request.go:1781 +0xc20
  github.com/tikv/client-go/v2/internal/locate.(*RegionRequestSender).SendReqCtx()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/locate/region_request.go:1562 +0x1b9c
  github.com/tikv/client-go/v2/internal/locate.(*RegionRequestSender).SendReq()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/internal/locate/region_request.go:247 +0x19c
  github.com/tikv/client-go/v2/tikv.(*KVStore).SendReq()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/tikv/kv.go:524 +0x170
  integration_tests_test.(*testPipelinedMemDBSuite).TestResolveLockRace()
      /Users/you06/workspace/go/src/github.com/tikv/client-go/integration_tests/pipelined_memdb_test.go:214 +0x144
  runtime.call16()
      /Users/you06/.gvm/gos/go1.21.5/src/runtime/asm_arm64.s:478 +0x74
  reflect.Value.Call()
      /Users/you06/.gvm/gos/go1.21.5/src/reflect/value.go:380 +0x90
  github.com/stretchr/testify/suite.Run.func1()
      /Users/you06/.gvm/pkgsets/go1.21.5/global/pkg/mod/github.com/stretchr/testify@v1.8.4/suite/suite.go:197 +0x534
  testing.tRunner()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/you06/.gvm/gos/go1.21.5/src/testing/testing.go:1648 +0x40
```