### PR TITLE
Do not use clientSideSlowScore in other health-based replica selection mechanism and keep it only for prefer-leader

### DIFF
--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -2790,7 +2790,6 @@ func (s *testReplicaSelectorSuite) resetStoreState() {
 		store.loadStats.Store(nil)
 		store.healthStatus.clientSideSlowScore.resetSlowScore()
 		store.healthStatus.updateTiKVServerSideSlowScore(0, time.Now())
-		store.healthStatus.updateSlowFlag()
 		atomic.StoreUint32(&store.livenessState, uint32(reachable))
 		store.setResolveState(resolved)
 	}


### PR DESCRIPTION
As we've discussed, we'll keep prefer-leader (as well as the clientSideSlowScore) independent from our new health-based replica selection mechanism.
So clientSideSlowScore should only be used by prefer-leader, and prefer-leader should only use clientSideSlowScore.

DNM: Needs to be updated after merging #1215