### PR TITLE
enable replica-selector-v2 by default

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -94,6 +94,7 @@ type TiKVClient struct {
 	// 0 means auto adjust by feedback.
 	MaxConcurrencyRequestLimit int64 `toml:"max-concurrency-request-limit" json:"max-concurrency-request-limit"`
 	// EnableReplicaSelectorV2 indicate whether to use the new replica-selector-v2.
+	// TODO(crazycs520): remove this config after the new replica-selector-v2 is stable.
 	EnableReplicaSelectorV2 bool `toml:"enable-replica-selector-v2" json:"enable-replica-selector-v2"`
 }
 

--- a/config/client.go
+++ b/config/client.go
@@ -93,6 +93,8 @@ type TiKVClient struct {
 	// MaxConcurrencyRequestLimit is the max concurrency number of request to be sent the tikv
 	// 0 means auto adjust by feedback.
 	MaxConcurrencyRequestLimit int64 `toml:"max-concurrency-request-limit" json:"max-concurrency-request-limit"`
+	// EnableReplicaSelectorV2 indicate whether to use the new replica-selector-v2.
+	EnableReplicaSelectorV2 bool `toml:"enable-replica-selector-v2" json:"enable-replica-selector-v2"`
 }
 
 // AsyncCommit is the config for the async commit feature. The switch to enable it is a system variable.
@@ -164,6 +166,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		ResolveLockLiteThreshold:   16,
 		MaxConcurrencyRequestLimit: math.MaxInt64,
+		EnableReplicaSelectorV2:    true,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -82,26 +82,23 @@ type Config struct {
 	RegionsRefreshInterval uint64
 	// EnablePreload indicates whether to preload region info when initializing the client.
 	EnablePreload bool
-	// EnableReplicaSelectorV2 indicates whether to enable ReplicaSelectorV2.
-	EnableReplicaSelectorV2 bool
 }
 
 // DefaultConfig returns the default configuration.
 func DefaultConfig() Config {
 	return Config{
-		CommitterConcurrency:    128,
-		MaxTxnTTL:               60 * 60 * 1000, // 1hour
-		TiKVClient:              DefaultTiKVClient(),
-		PDClient:                DefaultPDClient(),
-		TxnLocalLatches:         DefaultTxnLocalLatches(),
-		StoresRefreshInterval:   DefStoresRefreshInterval,
-		OpenTracingEnable:       false,
-		Path:                    "",
-		EnableForwarding:        false,
-		TxnScope:                "",
-		EnableAsyncCommit:       false,
-		Enable1PC:               false,
-		EnableReplicaSelectorV2: true,
+		CommitterConcurrency:  128,
+		MaxTxnTTL:             60 * 60 * 1000, // 1hour
+		TiKVClient:            DefaultTiKVClient(),
+		PDClient:              DefaultPDClient(),
+		TxnLocalLatches:       DefaultTxnLocalLatches(),
+		StoresRefreshInterval: DefStoresRefreshInterval,
+		OpenTracingEnable:     false,
+		Path:                  "",
+		EnableForwarding:      false,
+		TxnScope:              "",
+		EnableAsyncCommit:     false,
+		Enable1PC:             false,
 	}
 }
 

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -50,7 +50,7 @@ type ReplicaSelector interface {
 func NewReplicaSelector(
 	regionCache *RegionCache, regionID RegionVerID, req *tikvrpc.Request, opts ...StoreSelectorOption,
 ) (ReplicaSelector, error) {
-	if config.GetGlobalConfig().EnableReplicaSelectorV2 {
+	if config.GetGlobalConfig().TiKVClient.EnableReplicaSelectorV2 {
 		return newReplicaSelectorV2(regionCache, regionID, req, opts...)
 	}
 	return newReplicaSelector(regionCache, regionID, req, opts...)

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -2604,13 +2604,13 @@ func (s *testReplicaSelectorSuite) changeRegionLeader(storeId uint64) {
 func (s *testReplicaSelectorSuite) runCaseAndCompare(ca1 replicaSelectorAccessPathCase) bool {
 	ca2 := ca1
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = false
+		conf.TiKVClient.EnableReplicaSelectorV2 = false
 	})
 	sender := ca1.run(s)
 	ca1.checkResult(s, "v1", sender)
 
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = true
+		conf.TiKVClient.EnableReplicaSelectorV2 = true
 	})
 	sender = ca2.run(s)
 	if ca2.expect == nil {
@@ -2623,7 +2623,7 @@ func (s *testReplicaSelectorSuite) runCaseAndCompare(ca1 replicaSelectorAccessPa
 
 func (s *testReplicaSelectorSuite) runCase(ca replicaSelectorAccessPathCase, v2 bool) bool {
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = v2
+		conf.TiKVClient.EnableReplicaSelectorV2 = v2
 	})
 	sender := ca.run(s)
 	version := "v1"
@@ -2638,7 +2638,7 @@ func (s *testReplicaSelectorSuite) runMultiCaseAndCompare(cas []replicaSelectorA
 	expects := make([]accessPathResult, 0, len(cas))
 	valid := true
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = false
+		conf.TiKVClient.EnableReplicaSelectorV2 = false
 	})
 	for _, ca1 := range cas {
 		sender := ca1.run(s)
@@ -2648,7 +2648,7 @@ func (s *testReplicaSelectorSuite) runMultiCaseAndCompare(cas []replicaSelectorA
 	}
 
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = true
+		conf.TiKVClient.EnableReplicaSelectorV2 = true
 	})
 	for i, ca2 := range cas {
 		sender := ca2.run(s)
@@ -3227,7 +3227,7 @@ func BenchmarkReplicaSelector(b *testing.B) {
 	}()
 
 	config.UpdateGlobal(func(conf *config.Config) {
-		conf.EnableReplicaSelectorV2 = true
+		conf.TiKVClient.EnableReplicaSelectorV2 = true
 	})
 	cnt := 0
 	allErrs := getAllRegionErrors(nil)


### PR DESCRIPTION
Add `TiKVClient .EnableReplicaSelectorV2` config and enable by default.

`TiKVClient.EnableReplicaSelectorV2` config should be removed after the new replica-selector-v2 is stable.

```toml
[tikv-client]
enable-replica-selector-v2 = true
```