### PR TITLE
cop: add kv read wall time to print result

### DIFF
--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -653,6 +653,13 @@ func (td *TimeDetail) String() string {
 		buf.WriteString("total_wait_time: ")
 		buf.WriteString(FormatDuration(td.WaitTime))
 	}
+	if td.KvReadWallTime > 0 {
+		if buf.Len() > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString("total_kv_read_wall_time: ")
+		buf.WriteString(FormatDuration(td.KvReadWallTime))
+	}
 	if td.TotalRPCWallTime > 0 {
 		if buf.Len() > 0 {
 			buf.WriteString(", ")
@@ -661,6 +668,16 @@ func (td *TimeDetail) String() string {
 		buf.WriteString(FormatDuration(td.TotalRPCWallTime))
 	}
 	return buf.String()
+}
+
+func (td *TimeDetail) Merge(detail *TimeDetail) {
+	if detail != nil {
+		td.ProcessTime += detail.ProcessTime
+		td.SuspendTime += detail.SuspendTime
+		td.WaitTime += detail.WaitTime
+		td.KvReadWallTime += detail.KvReadWallTime
+		td.TotalRPCWallTime += detail.TotalRPCWallTime
+	}
 }
 
 // MergeFromTimeDetail merges time detail from pb into itself.

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -670,6 +670,7 @@ func (td *TimeDetail) String() string {
 	return buf.String()
 }
 
+// Merge merges the time detail into itself.
 func (td *TimeDetail) Merge(detail *TimeDetail) {
 	if detail != nil {
 		td.ProcessTime += detail.ProcessTime


### PR DESCRIPTION
The kv read wall time which is the time consumed in tikv executors is not printted in the result. 
It is helpful to check time consumed in the tikv next operations, for example processing column with larger values.