### PR TITLE
refine timedetail string

### DIFF
--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -668,8 +668,10 @@ func (td *TimeDetail) String() string {
 		buf.WriteString("tikv_wall_time: ")
 		buf.WriteString(FormatDuration(td.TotalRPCWallTime))
 	}
-	buf.WriteString("}")
-	return buf.String()
+	if buf.Len() == 0 {
+		return ""
+	}
+	return "time_detail: {" + buf.String() + "}"
 }
 
 // Merge merges the time detail into itself.

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -635,7 +635,6 @@ func (td *TimeDetail) String() string {
 		return ""
 	}
 	buf := bytes.NewBuffer(make([]byte, 0, 16))
-	buf.WriteString("time_detail: {")
 	if td.ProcessTime > 0 {
 		buf.WriteString("total_process_time: ")
 		buf.WriteString(FormatDuration(td.ProcessTime))

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -92,4 +92,12 @@ func TestCompatibleParseGCTime(t *testing.T) {
 func TestTimeDetail(t *testing.T) {
 	detail := &TimeDetail{KvReadWallTime: time.Millisecond * 2, TotalRPCWallTime: time.Millisecond * 3}
 	assert.Equal(t, "time_detail: {total_kv_read_wall_time: 2ms, tikv_wall_time: 3ms}", detail.String())
+	detail = &TimeDetail{
+		ProcessTime:      time.Millisecond * 2,
+		SuspendTime:      time.Millisecond * 3,
+		WaitTime:         time.Millisecond * 4,
+		KvReadWallTime:   time.Millisecond * 5,
+		TotalRPCWallTime: time.Millisecond * 6,
+	}
+	assert.Equal(t, "time_detail: {total_process_time: 2ms, total_suspend_time: 3ms, total_wait_time: 4ms, total_kv_read_wall_time: 5ms, tikv_wall_time: 6ms}", detail.String())
 }

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -88,3 +88,8 @@ func TestCompatibleParseGCTime(t *testing.T) {
 		assert.NotNil(err)
 	}
 }
+
+func TestTimeDetail(t *testing.T) {
+	detail := &TimeDetail{KvReadWallTime: time.Millisecond * 2, TotalRPCWallTime: time.Millisecond * 3}
+	assert.Equal(t, "time_detail: {total_kv_read_wall_time: 2ms, tikv_wall_time: 3ms}", detail.String())
+}


### PR DESCRIPTION
Before this PR, following is unexpected:

```go
time_detail: {, tikv_wall_time: 500ms}
```