### PR TITLE
region_cache: filter out unresolved stores when GetTiFlashStores

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2191,7 +2191,8 @@ func (c *RegionCache) PDClient() pd.Client {
 	return c.pdClient
 }
 
-// GetTiFlashStores returns the information of all tiflash nodes.
+// GetTiFlashStores returns the information of all tiflash nodes. Like `GetAllStores`, the method only returns resolved
+// stores so that users won't be bothered by tombstones. (related issue: https://github.com/pingcap/tidb/issues/46602)
 func (c *RegionCache) GetTiFlashStores(labelFilter LabelFilter) []*Store {
 	return c.filterStores(nil, func(s *Store) bool {
 		return s.storeType == tikvrpc.TiFlash && labelFilter(s.labels) && s.getResolveState() == resolved

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2194,7 +2194,7 @@ func (c *RegionCache) PDClient() pd.Client {
 // GetTiFlashStores returns the information of all tiflash nodes.
 func (c *RegionCache) GetTiFlashStores(labelFilter LabelFilter) []*Store {
 	return c.filterStores(nil, func(s *Store) bool {
-		return s.storeType == tikvrpc.TiFlash && labelFilter(s.labels)
+		return s.storeType == tikvrpc.TiFlash && labelFilter(s.labels) && s.getResolveState() == resolved
 	})
 }
 

--- a/internal/locate/store_cache.go
+++ b/internal/locate/store_cache.go
@@ -411,7 +411,7 @@ func (s *Store) reResolve(c storeCache) (bool, error) {
 	if store == nil || store.GetState() == metapb.StoreState_Tombstone {
 		// store has be removed in PD, we should invalidate all regions using those store.
 		logutil.BgLogger().Info("invalidate regions in removed store",
-			zap.Uint64("store", s.storeID), zap.String("add", s.addr))
+			zap.Uint64("store", s.storeID), zap.String("addr", s.addr))
 		atomic.AddUint32(&s.epoch, 1)
 		s.setResolveState(tombstone)
 		metrics.RegionCacheCounterWithInvalidateStoreRegionsOK.Inc()


### PR DESCRIPTION
Try to fix https://github.com/pingcap/tidb/issues/46602 .

`GetTiFlashStores` would return unresolved stores, which causes mpp probe keep checking tomebstone stores. `RegionCache` exports some methods for listing stores, like `GetAllStores`. There should/better be a contract that those methods do not return unresolved stores. Note that `GetTiFlashComputeStores` may still returns unresolved stores, however, the entire store list will be reloaded once invalidate method get called, that is, it's users' responsibility to reload tiflash compute stores. 