### PR TITLE
Distinguish identifier and name in task runner

### DIFF
--- a/integration_tests/range_task_test.go
+++ b/integration_tests/range_task_test.go
@@ -198,7 +198,6 @@ func (s *testRangeTaskSuite) testRangeTaskImpl(concurrency int) {
 
 	runner := rangetask.NewRangeTaskRunner(
 		"test-runner",
-		"test-runner",
 		s.store,
 		concurrency,
 		handler,
@@ -244,7 +243,6 @@ func (s *testRangeTaskSuite) testRangeTaskErrorImpl(concurrency int) {
 			}
 
 			runner := rangetask.NewRangeTaskRunner(
-				"test-error-runner",
 				"test-error-runner",
 				s.store,
 				concurrency,

--- a/integration_tests/range_task_test.go
+++ b/integration_tests/range_task_test.go
@@ -196,7 +196,13 @@ func (s *testRangeTaskSuite) testRangeTaskImpl(concurrency int) {
 		return stat, nil
 	}
 
-	runner := rangetask.NewRangeTaskRunner("test-runner", s.store, concurrency, handler)
+	runner := rangetask.NewRangeTaskRunner(
+		"test-runner",
+		"test-runner",
+		s.store,
+		concurrency,
+		handler,
+	)
 
 	for regionsPerTask := 1; regionsPerTask <= 5; regionsPerTask++ {
 		for i, r := range s.testRanges {
@@ -237,7 +243,13 @@ func (s *testRangeTaskSuite) testRangeTaskErrorImpl(concurrency int) {
 				return stat, nil
 			}
 
-			runner := rangetask.NewRangeTaskRunner("test-error-runner", s.store, concurrency, handler)
+			runner := rangetask.NewRangeTaskRunner(
+				"test-error-runner",
+				"test-error-runner",
+				s.store,
+				concurrency,
+				handler,
+			)
 			runner.SetRegionsPerTask(1)
 			err := runner.RunOnRange(context.Background(), r.StartKey, r.EndKey)
 			// RunOnRange returns no error only when all sub tasks are done successfully.

--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -90,7 +90,7 @@ func (s *KVStore) resolveLocks(ctx context.Context, safePoint uint64, concurrenc
 		return ResolveLocksForRange(ctx, lockResolver, safePoint, r.StartKey, r.EndKey, NewGcResolveLockMaxBackoffer, GCScanLockLimit)
 	}
 
-	runner := rangetask.NewRangeTaskRunner(
+	runner := rangetask.NewRangeTaskRunnerWithID(
 		"resolve-locks-runner",
 		fmt.Sprintf("resolve-locks-runner-%d", safePoint),
 		s,

--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -17,6 +17,7 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -89,7 +90,13 @@ func (s *KVStore) resolveLocks(ctx context.Context, safePoint uint64, concurrenc
 		return ResolveLocksForRange(ctx, lockResolver, safePoint, r.StartKey, r.EndKey, NewGcResolveLockMaxBackoffer, GCScanLockLimit)
 	}
 
-	runner := rangetask.NewRangeTaskRunner("resolve-locks-runner", s, concurrency, handler)
+	runner := rangetask.NewRangeTaskRunner(
+		"resolve-locks-runner",
+		fmt.Sprintf("resolve-locks-runner-%d", safePoint),
+		s,
+		concurrency,
+		handler,
+	)
 	// Run resolve lock on the whole TiKV cluster. Empty keys means the range is unbounded.
 	err := runner.RunOnRange(ctx, []byte(""), []byte(""))
 	if err != nil {

--- a/txnkv/rangetask/delete_range.go
+++ b/txnkv/rangetask/delete_range.go
@@ -103,7 +103,7 @@ func (t *DeleteRangeTask) getRunnerName() string {
 func (t *DeleteRangeTask) Execute(ctx context.Context) error {
 	runnerName := t.getRunnerName()
 
-	runner := NewRangeTaskRunner(runnerName, runnerName, t.store, t.concurrency, t.sendReqOnRange)
+	runner := NewRangeTaskRunner(runnerName, t.store, t.concurrency, t.sendReqOnRange)
 	err := runner.RunOnRange(ctx, t.startKey, t.endKey)
 	t.completedRegions = runner.CompletedRegions()
 

--- a/txnkv/rangetask/delete_range.go
+++ b/txnkv/rangetask/delete_range.go
@@ -103,7 +103,7 @@ func (t *DeleteRangeTask) getRunnerName() string {
 func (t *DeleteRangeTask) Execute(ctx context.Context) error {
 	runnerName := t.getRunnerName()
 
-	runner := NewRangeTaskRunner(runnerName, t.store, t.concurrency, t.sendReqOnRange)
+	runner := NewRangeTaskRunner(runnerName, runnerName, t.store, t.concurrency, t.sendReqOnRange)
 	err := runner.RunOnRange(ctx, t.startKey, t.endKey)
 	t.completedRegions = runner.CompletedRegions()
 

--- a/txnkv/rangetask/range_task.go
+++ b/txnkv/rangetask/range_task.go
@@ -93,6 +93,16 @@ type TaskHandler = func(ctx context.Context, r kv.KeyRange) (TaskStat, error)
 // will be canceled.
 func NewRangeTaskRunner(
 	name string,
+	store storage,
+	concurrency int,
+	handler TaskHandler,
+) *Runner {
+	return NewRangeTaskRunnerWithID(name, "", store, concurrency, handler)
+}
+
+// NewRangeTaskRunnerWithID creates a RangeTaskRunner with a specified identifier
+func NewRangeTaskRunnerWithID(
+	name string,
 	identifier string,
 	store storage,
 	concurrency int,

--- a/txnkv/rangetask/range_task.go
+++ b/txnkv/rangetask/range_task.go
@@ -61,7 +61,10 @@ const (
 // regions in the range. Because of merging and splitting, it's possible that multiple requests for disjoint ranges are
 // sent to the same region.
 type Runner struct {
-	name            string
+	// name is consistent across all runners of the same type, which is used for metrics
+	name string
+	// identifier can be a unique identifier for each runner, which is used for logging
+	identifier      string
 	store           storage
 	concurrency     int
 	handler         TaskHandler
@@ -90,12 +93,18 @@ type TaskHandler = func(ctx context.Context, r kv.KeyRange) (TaskStat, error)
 // will be canceled.
 func NewRangeTaskRunner(
 	name string,
+	identifier string,
 	store storage,
 	concurrency int,
 	handler TaskHandler,
 ) *Runner {
+	id := identifier
+	if len(id) == 0 {
+		id = name
+	}
 	return &Runner{
 		name:            name,
+		identifier:      id,
 		store:           store,
 		concurrency:     concurrency,
 		handler:         handler,
@@ -128,14 +137,14 @@ func (s *Runner) RunOnRange(ctx context.Context, startKey, endKey []byte) error 
 
 	if len(endKey) != 0 && bytes.Compare(startKey, endKey) >= 0 {
 		logutil.Logger(ctx).Info("empty range task executed. ignored",
-			zap.String("name", s.name),
+			zap.String("name", s.identifier),
 			zap.String("startKey", kv.StrKey(startKey)),
 			zap.String("endKey", kv.StrKey(endKey)))
 		return nil
 	}
 
 	logutil.Logger(ctx).Info("range task started",
-		zap.String("name", s.name),
+		zap.String("name", s.identifier),
 		zap.String("startKey", kv.StrKey(startKey)),
 		zap.String("endKey", kv.StrKey(endKey)),
 		zap.Int("concurrency", s.concurrency))
@@ -177,7 +186,7 @@ Loop:
 		select {
 		case <-statLogTicker.C:
 			logutil.Logger(ctx).Info("range task in progress",
-				zap.String("name", s.name),
+				zap.String("name", s.identifier),
 				zap.String("startKey", kv.StrKey(startKey)),
 				zap.String("endKey", kv.StrKey(endKey)),
 				zap.Int("concurrency", s.concurrency),
@@ -191,7 +200,7 @@ Loop:
 		rangeEndKey, err := s.store.GetRegionCache().BatchLoadRegionsFromKey(bo, key, s.regionsPerTask)
 		if err != nil {
 			logutil.Logger(ctx).Info("range task try to get range end key failure",
-				zap.String("name", s.name),
+				zap.String("name", s.identifier),
 				zap.String("startKey", kv.StrKey(startKey)),
 				zap.String("endKey", kv.StrKey(endKey)),
 				zap.String("loadRegionKey", kv.StrKey(key)),
@@ -232,7 +241,7 @@ Loop:
 	for _, w := range workers {
 		if w.err != nil {
 			logutil.Logger(ctx).Info("range task failed",
-				zap.String("name", s.name),
+				zap.String("name", s.identifier),
 				zap.String("startKey", kv.StrKey(startKey)),
 				zap.String("endKey", kv.StrKey(endKey)),
 				zap.Duration("cost time", time.Since(startTime)),
@@ -244,7 +253,7 @@ Loop:
 	}
 
 	logutil.Logger(ctx).Info("range task finished",
-		zap.String("name", s.name),
+		zap.String("name", s.identifier),
 		zap.String("startKey", kv.StrKey(startKey)),
 		zap.String("endKey", kv.StrKey(endKey)),
 		zap.Duration("cost time", time.Since(startTime)),
@@ -256,11 +265,12 @@ Loop:
 // createWorker creates a worker that can process tasks from the given channel.
 func (s *Runner) createWorker(taskCh chan *kv.KeyRange, wg *sync.WaitGroup) *rangeTaskWorker {
 	return &rangeTaskWorker{
-		name:    s.name,
-		store:   s.store,
-		handler: s.handler,
-		taskCh:  taskCh,
-		wg:      wg,
+		name:       s.name,
+		identifier: s.identifier,
+		store:      s.store,
+		handler:    s.handler,
+		taskCh:     taskCh,
+		wg:         wg,
 
 		completedRegions: &s.completedRegions,
 		failedRegions:    &s.failedRegions,
@@ -279,11 +289,14 @@ func (s *Runner) FailedRegions() int {
 
 // rangeTaskWorker is used by RangeTaskRunner to process tasks concurrently.
 type rangeTaskWorker struct {
-	name    string
-	store   storage
-	handler TaskHandler
-	taskCh  chan *kv.KeyRange
-	wg      *sync.WaitGroup
+	// name is consistent across all runners of the same type, which is used for metrics
+	name string
+	// identifier can be a unique identifier for each runner, which is used for logging
+	identifier string
+	store      storage
+	handler    TaskHandler
+	taskCh     chan *kv.KeyRange
+	wg         *sync.WaitGroup
 
 	err error
 
@@ -311,7 +324,7 @@ func (w *rangeTaskWorker) run(ctx context.Context, cancel context.CancelFunc) {
 
 		if err != nil {
 			logutil.Logger(ctx).Info("canceling range task because of error",
-				zap.String("name", w.name),
+				zap.String("name", w.identifier),
 				zap.String("startKey", kv.StrKey(r.StartKey)),
 				zap.String("endKey", kv.StrKey(r.EndKey)),
 				zap.Error(err))

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -435,7 +435,7 @@ func (c *twoPhaseCommitter) resolveFlushedLocks(bo *retry.Backoffer, start, end 
 		)
 		return
 	}
-	runner := rangetask.NewRangeTaskRunner(
+	runner := rangetask.NewRangeTaskRunnerWithID(
 		"pipelined-dml-commit",
 		fmt.Sprintf("pipelined-dml-commit-%d", c.startTS),
 		c.store,

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -451,7 +451,8 @@ func (c *twoPhaseCommitter) resolveFlushedLocks(bo *retry.Backoffer, start, end 
 			zap.Error(err),
 		)
 	} else {
-		logutil.BgLogger().Info("[pipelined dml] commit transaction secondaries done",
+		logutil.Logger(bo.GetCtx()).Info(
+			"[pipelined dml] commit transaction secondaries done",
 			zap.Uint64("resolved regions", resolved.Load()),
 			zap.Uint64("startTS", c.startTS),
 			zap.Uint64("commitTS", atomic.LoadUint64(&c.commitTS)),

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -436,6 +436,7 @@ func (c *twoPhaseCommitter) resolveFlushedLocks(bo *retry.Backoffer, start, end 
 		return
 	}
 	runner := rangetask.NewRangeTaskRunner(
+		"pipelined-dml-commit",
 		fmt.Sprintf("pipelined-dml-commit-%d", c.startTS),
 		c.store,
 		RESOLVE_CONCURRENCY,


### PR DESCRIPTION
`name` is used in both metrics and logs. We separate name and identifier to avoid messy metrics and pertain useful logs.