### PR TITLE
refactor sliceIdentical function

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1140,7 +1140,25 @@ func (s *replicaSelector) getLabels() []*metapb.StoreLabel {
 // sliceIdentical checks whether two slices are referencing the same block of memory. Two `nil`s are also considered
 // the same.
 func sliceIdentical[T any](a, b []T) bool {
-	return len(a) == len(b) && unsafe.SliceData(a) == unsafe.SliceData(b)
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	if cap(a) == 0 && cap(b) == 0 {
+		// If cap is 0, SliceData returns a non-nil pointer to an unspecified memory address
+		// So we can't compare them.
+		return true
+	}
+
+	return unsafe.SliceData(a) == unsafe.SliceData(b)
 }
 
 func (s *replicaSelector) refreshRegionStore() {

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -202,7 +202,7 @@ func (s *testRegionRequestToThreeStoresSuite) TestSliceIdentical() {
 	b := a
 	s.True(sliceIdentical(a, b))
 	b = make([]int, 0)
-	s.False(sliceIdentical(a, b))
+	s.True(sliceIdentical(a, b))
 
 	a = append(a, 1, 2, 3)
 	b = a


### PR DESCRIPTION
Make `sliceIdentical` consider two slices with a cap of 0 to be the same.

Resolves #1272