### PR TITLE
txn: cache result of snapshot.Get

### DIFF
--- a/integration_tests/safepoint_test.go
+++ b/integration_tests/safepoint_test.go
@@ -112,6 +112,8 @@ func (s *testSafePointSuite) TestSafePoint() {
 
 	s.waitUntilErrorPlugIn(txn2.StartTS())
 
+	// clean cache for sending request to store.
+	txn2.GetSnapshot().CleanCache([][]byte{encodeKey(s.prefix, s08d("key", 0))})
 	_, geterr2 := txn2.Get(context.TODO(), encodeKey(s.prefix, s08d("key", 0)))
 	s.NotNil(geterr2)
 

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -145,8 +145,6 @@ func (s *testSnapshotSuite) TestBatchGet() {
 	}
 }
 
-type contextKey string
-
 func (s *testSnapshotSuite) TestSnapshotCache() {
 	txn := s.beginTxn()
 	s.Nil(txn.Set([]byte("x"), []byte("x")))
@@ -159,7 +157,7 @@ func (s *testSnapshotSuite) TestSnapshotCache() {
 	s.Nil(err)
 
 	s.Nil(failpoint.Enable("tikvclient/snapshot-get-cache-fail", `return(true)`))
-	ctx := context.WithValue(context.Background(), contextKey("TestSnapshotCache"), true)
+	ctx := context.WithValue(context.Background(), "TestSnapshotCache", true)
 	_, err = snapshot.Get(ctx, []byte("x"))
 	s.Nil(err)
 

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -148,20 +148,37 @@ func (s *testSnapshotSuite) TestBatchGet() {
 func (s *testSnapshotSuite) TestSnapshotCache() {
 	txn := s.beginTxn()
 	s.Nil(txn.Set([]byte("x"), []byte("x")))
-	s.Nil(txn.Delete([]byte("y"))) // store data is affected by othe)
+	s.Nil(txn.Delete([]byte("y"))) // delete should also be cached
+	s.Nil(txn.Set([]byte("a"), []byte("a")))
+	s.Nil(txn.Delete([]byte("b")))
 	s.Nil(txn.Commit(context.Background()))
 
 	txn = s.beginTxn()
 	snapshot := txn.GetSnapshot()
+	// generate cache by BatchGet
 	_, err := snapshot.BatchGet(context.Background(), [][]byte{[]byte("x"), []byte("y")})
 	s.Nil(err)
+	// generate cache by Get
+	_, err = snapshot.Get(context.Background(), []byte("a"))
+	s.Nil(err)
+	_, err = snapshot.Get(context.Background(), []byte("b"))
+	s.True(error.IsErrNotFound(err))
 
 	s.Nil(failpoint.Enable("tikvclient/snapshot-get-cache-fail", `return(true)`))
 	ctx := context.WithValue(context.Background(), "TestSnapshotCache", true)
-	_, err = snapshot.Get(ctx, []byte("x"))
-	s.Nil(err)
 
+	// check cache from BatchGet
+	value, err := snapshot.Get(ctx, []byte("x"))
+	s.Nil(err)
+	s.Equal([]byte("x"), value)
 	_, err = snapshot.Get(ctx, []byte("y"))
+	s.True(error.IsErrNotFound(err))
+
+	// check cache from Get
+	value, err = snapshot.Get(ctx, []byte("a"))
+	s.Nil(err)
+	s.Equal([]byte("a"), value)
+	_, err = snapshot.Get(ctx, []byte("b"))
 	s.True(error.IsErrNotFound(err))
 
 	s.Nil(failpoint.Disable("tikvclient/snapshot-get-cache-fail"))

--- a/integration_tests/store_test.go
+++ b/integration_tests/store_test.go
@@ -158,6 +158,8 @@ func (s *testStoreSuite) TestRequestPriority() {
 	s.Nil(err)
 
 	// A counter example.
+	// clean cache for sending request to store.
+	txn.GetSnapshot().CleanCache([][]byte{[]byte("key")})
 	client.priority = kvrpcpb.CommandPri_Low
 	txn.SetPriority(txnkv.PriorityNormal)
 	_, err = txn.Get(context.TODO(), []byte("key"))

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -1015,6 +1015,7 @@ func (s *KVSnapshot) UpdateSnapshotCache(keys [][]byte, m map[string][]byte) {
 	for _, key := range keys {
 		val := m[string(key)]
 		s.mu.cachedSize += len(key) + len(val)
+		s.mu.cachedSize -= len(s.mu.cached[string(key)])
 		s.mu.cached[string(key)] = val
 	}
 
@@ -1038,6 +1039,8 @@ func (s *KVSnapshot) CleanCache(keys [][]byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, key := range keys {
+		s.mu.cachedSize -= len(key)
+		s.mu.cachedSize -= len(s.mu.cached[string(key)])
 		delete(s.mu.cached, string(key))
 	}
 }

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -1007,8 +1007,8 @@ func (s *KVSnapshot) SnapCache() map[string][]byte {
 
 // UpdateSnapshotCache sets the values of cache, for further fast read with same keys.
 func (s *KVSnapshot) UpdateSnapshotCache(keys [][]byte, m map[string][]byte) {
-	// Update the cache.
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.mu.cached == nil {
 		s.mu.cached = make(map[string][]byte, min(len(keys), 8))
 	}
@@ -1031,7 +1031,6 @@ func (s *KVSnapshot) UpdateSnapshotCache(keys [][]byte, m map[string][]byte) {
 			}
 		}
 	}
-	s.mu.Unlock()
 }
 
 // CleanCache cleans the cache for given keys. Only for test.

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -648,7 +648,6 @@ func (s *KVSnapshot) Get(ctx context.Context, k []byte) ([]byte, error) {
 }
 
 func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]byte, error) {
-	s.mu.RLock()
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("tikvSnapshot.get", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
@@ -656,7 +655,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]
 	}
 
 	cli := NewClientHelper(s.store, &s.resolvedLocks, &s.committedLocks, true)
-
+	s.mu.RLock()
 	if s.mu.stats != nil {
 		cli.Stats = make(map[tikvrpc.CmdType]*locate.RPCRuntimeStats)
 		defer func() {


### PR DESCRIPTION
Now snapshot cache can only be generated by `snapshot.BatchGet` which doesn't optimize the case get the same key multi times in a txn.

This PR cache the result of `snapshot.Get` to optimize this case.

### Before this PR

![image](https://github.com/tikv/client-go/assets/9587680/f5b94e6e-06bd-46b6-b50d-9489bb00e7a6)

### With this PR

![image](https://github.com/tikv/client-go/assets/9587680/1eb79dc8-a4b6-4a90-afe7-568c901502fa)

## Benchmark

Test with sysbench point select, but wrap it in txn:

```
begin;
point select with same id n times;
commit;
```

|n|Before thisPR(txn/s)|With this PR(txn/s)|
|-|-|-|
|2|59029|68541|
|3|43032|57330|
|4|34583|49275|

![image](https://github.com/tikv/client-go/assets/9587680/3ae5539a-41cd-448e-a6df-f5bdc30f2562)

