### PR TITLE
only set MinSafeTS to 0 when all stores' are 0

### DIFF
--- a/internal/logutil/log.go
+++ b/internal/logutil/log.go
@@ -36,6 +36,7 @@ package logutil
 
 import (
 	"context"
+	"testing"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -60,3 +61,11 @@ type ctxLogKeyType struct{}
 // CtxLogKey is the key to retrieve logger from context.
 // It can be assigned to another value.
 var CtxLogKey interface{} = ctxLogKeyType{}
+
+// AssertWarn panics when in testing mode, and logs a warning msg otherwise.
+func AssertWarn(logger *zap.Logger, msg string, fields ...zap.Field) {
+	if testing.Testing() {
+		logger.Panic(msg, fields...)
+	}
+	logger.Warn(msg, fields...)
+}

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -44,7 +44,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -576,11 +575,7 @@ func (s *KVStore) GetMinSafeTS(txnScope string) uint64 {
 func (s *KVStore) setMinSafeTS(txnScope string, safeTS uint64) {
 	// ensure safeTS is not set to max uint64
 	if safeTS == math.MaxUint64 {
-		if testing.Testing() {
-			panic(fmt.Errorf("unreachable"))
-		} else {
-			logutil.BgLogger().Warn("skip setting min-safe-ts to max uint64", zap.String("txnScope", txnScope), zap.Stack("stack"))
-		}
+		logutil.AssertWarn(logutil.BgLogger(), "skip setting min-safe-ts to max uint64", zap.String("txnScope", txnScope), zap.Stack("stack"))
 		return
 	}
 	s.minSafeTS.Store(txnScope, safeTS)
@@ -623,11 +618,7 @@ func (s *KVStore) getSafeTS(storeID uint64) (bool, uint64) {
 func (s *KVStore) setSafeTS(storeID, safeTS uint64) {
 	// ensure safeTS is not set to max uint64
 	if safeTS == math.MaxUint64 {
-		if testing.Testing() {
-			panic(fmt.Errorf("unreachable"))
-		} else {
-			logutil.BgLogger().Warn("skip setting safe-ts to max uint64", zap.Uint64("storeID", storeID), zap.Stack("stack"))
-		}
+		logutil.AssertWarn(logutil.BgLogger(), "skip setting safe-ts to max uint64", zap.Uint64("storeID", storeID), zap.Stack("stack"))
 		return
 	}
 	s.safeTSMap.Store(storeID, safeTS)
@@ -646,12 +637,16 @@ func (s *KVStore) updateMinSafeTS(txnScope string, storeIDs []uint64) {
 		ok, safeTS := s.getSafeTS(store)
 		if ok {
 			// safeTS is guaranteed to be less than math.MaxUint64 (by setSafeTS and its callers)
-			if safeTS < minSafeTS {
+			if safeTS != 0 && safeTS < minSafeTS {
 				minSafeTS = safeTS
 			}
 		} else {
 			minSafeTS = 0
 		}
+	}
+	// if minSafeTS is still math.MaxUint64, that means all store safe ts are 0, then we set minSafeTS to 0.
+	if minSafeTS == math.MaxUint64 {
+		minSafeTS = 0
 	}
 	s.setMinSafeTS(txnScope, minSafeTS)
 }

--- a/tikv/kv_test.go
+++ b/tikv/kv_test.go
@@ -242,7 +242,7 @@ func (s *testKVSuite) TestMinSafeTsFromMixed1() {
 	s.Eventually(func() bool {
 		ts := s.store.GetMinSafeTS("z1")
 		s.Require().False(math.MaxUint64 == ts)
-		return ts == uint64(10)
+		return ts == uint64(10) && s.store.GetMinSafeTS(oracle.GlobalTxnScope) == uint64(10)
 	}, 15*time.Second, time.Second)
 	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(1))
 	s.Require().Equal(uint64(10), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
@@ -267,7 +267,7 @@ func (s *testKVSuite) TestMinSafeTsFromMixed2() {
 	s.Eventually(func() bool {
 		ts := s.store.GetMinSafeTS("z2")
 		s.Require().False(math.MaxUint64 == ts)
-		return ts == uint64(10)
+		return ts == uint64(10) && s.store.GetMinSafeTS(oracle.GlobalTxnScope) == uint64(10)
 	}, 15*time.Second, time.Second)
 	s.Require().GreaterOrEqual(atomic.LoadInt32(&mockClient.requestCount), int32(1))
 	s.Require().Equal(uint64(10), s.store.GetMinSafeTS(oracle.GlobalTxnScope))


### PR DESCRIPTION
https://github.com/tikv/client-go/pull/1277 introduce a regression: there might be a store whose safe ts is 0 for a long time, in this case, flashback will be blocked (ref: https://github.com/tikv/tikv/issues/13675). We should `setMinSafeTS(0)` only when all (NOT any) of `store.safe_ts = 0`.