### PR TITLE
Use Mem() instead of Size() to estimate pipelined-memdb size

### DIFF
--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -62,32 +62,32 @@ const (
 	// small batch can lead to poor performance and resource waste in random write workload.
 	// 10K batch size is large enough to get good performance with random write workloads in tests.
 	MinFlushKeys = 10000
-	// MinFlushSize is the minimum size of MemDB to trigger flush.
-	MinFlushSize = 16 * 1024 * 1024 // 16MB
-	// ForceFlushSizeThreshold is the threshold to force flush MemDB, which controls the max memory consumption of PipelinedMemDB.
-	ForceFlushSizeThreshold = 128 * 1024 * 1024 // 128MB
+	// MinFlushMemSize is the minimum size of MemDB to trigger flush.
+	MinFlushMemSize uint64 = 16 * 1024 * 1024 // 16MB
+	// ForceFlushMemSizeThreshold is the threshold to force flush MemDB, which controls the max memory consumption of PipelinedMemDB.
+	ForceFlushMemSizeThreshold uint64 = 128 * 1024 * 1024 // 128MB
 )
 
 type flushOption struct {
-	MinFlushKeys            uint64
-	MinFlushSize            uint64
-	ForceFlushSizeThreshold uint64
+	MinFlushKeys               uint64
+	MinFlushMemSize            uint64
+	ForceFlushMemSizeThreshold uint64
 }
 
 func newFlushOption() flushOption {
 	opt := flushOption{
-		MinFlushKeys:            MinFlushKeys,
-		MinFlushSize:            MinFlushSize,
-		ForceFlushSizeThreshold: ForceFlushSizeThreshold,
+		MinFlushKeys:               MinFlushKeys,
+		MinFlushMemSize:            MinFlushMemSize,
+		ForceFlushMemSizeThreshold: ForceFlushMemSizeThreshold,
 	}
 	if val, err := util.EvalFailpoint("pipelinedMemDBMinFlushKeys"); err == nil && val != nil {
 		opt.MinFlushKeys = uint64(val.(int))
 	}
 	if val, err := util.EvalFailpoint("pipelinedMemDBMinFlushSize"); err == nil && val != nil {
-		opt.MinFlushSize = uint64(val.(int))
+		opt.MinFlushMemSize = uint64(val.(int))
 	}
 	if val, err := util.EvalFailpoint("pipelinedMemDBForceFlushSizeThreshold"); err == nil && val != nil {
-		opt.ForceFlushSizeThreshold = uint64(val.(int))
+		opt.ForceFlushMemSizeThreshold = uint64(val.(int))
 	}
 	return opt
 }
@@ -324,16 +324,32 @@ func (p *PipelinedMemDB) Flush(force bool) (bool, error) {
 
 func (p *PipelinedMemDB) needFlush() bool {
 	size := p.memDB.Mem()
-	// size < MinFlushSize, do not flush.
-	// MinFlushSize <= size < ForceFlushSizeThreshold && keys < MinFlushKeys, do not flush.
-	// MinFlushSize <= size < ForceFlushSizeThreshold && keys >= MinFlushKeys, flush.
-	// size >= ForceFlushSizeThreshold, flush.
-	if size < p.flushOption.MinFlushSize ||
+	// mem size < MinFlushMemSize, do not flush.
+	// MinFlushMemSize <= mem size < ForceFlushMemSizeThreshold && keys < MinFlushKeys, do not flush.
+	// MinFlushMemSize <= mem size < ForceFlushMemSizeThreshold && keys >= MinFlushKeys, flush.
+	// mem size >= ForceFlushMemSizeThreshold, flush.
+
+	/*
+	              Keys
+	               ^
+	               |       |
+	               |       |
+	               |       |
+	               |       |    Flush
+	               |       |
+	   MinKey(10k) |       +------------+
+	               |       |            |
+	               |  No   |  No Flush  |   Flush
+	               | Flush |            |
+	               +-----------------------------------------> Size
+	               0   MinSize(16MB)   Force(128MB)
+	*/
+	if size < p.flushOption.MinFlushMemSize ||
 		(uint64(p.memDB.Len()) < p.flushOption.MinFlushKeys &&
-			size < p.flushOption.ForceFlushSizeThreshold) {
+			size < p.flushOption.ForceFlushMemSizeThreshold) {
 		return false
 	}
-	if p.onFlushing.Load() && size < p.flushOption.ForceFlushSizeThreshold {
+	if p.onFlushing.Load() && size < p.flushOption.ForceFlushMemSizeThreshold {
 		return false
 	}
 	return true


### PR DESCRIPTION
ref tikv/tikv#16291

By default, a pipelined-txn can use more than 1GB memory, most of which are consumed by memdb. 
Use `Mem()` as an estimate to more accurately control the total memory usage.