### PR TITLE
txn-file: Asynchronously commit/rollback secondaries

### DIFF
--- a/txnkv/transaction/txn_file_test.go
+++ b/txnkv/transaction/txn_file_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tikv/client-go/v2/internal/locate"
+)
+
+func TestTxnFileChunkBatch(t *testing.T) {
+	assert := assert.New(t)
+	chunkSlice := txnChunkSlice{
+		chunkIDs: []uint64{1, 2, 3},
+		chunkRanges: []txnChunkRange{
+			{
+				smallest: []byte("k01"),
+				biggest:  []byte("k01"),
+			},
+			{
+				smallest: []byte("k02"),
+				biggest:  []byte("k04"),
+			},
+			{
+				smallest: []byte("k05"),
+				biggest:  []byte("k08"),
+			},
+		},
+	}
+
+	cases := []struct {
+		startKey string
+		endKey   string
+		expected []string
+	}{
+		{
+			"", "", []string{"k01", "k02", "k05"},
+		},
+		{
+			"k01", "k05", []string{"k01", "k02"},
+		},
+		{
+			"k010", "k05", []string{"k02"},
+		},
+		{
+			"k03", "k05", []string{},
+		},
+		{
+			"k03", "", []string{"k05"},
+		},
+	}
+
+	for _, c := range cases {
+		batch := chunkBatch{
+			txnChunkSlice: chunkSlice,
+			region: &locate.KeyLocation{
+				StartKey: []byte(c.startKey),
+				EndKey:   []byte(c.endKey),
+			},
+		}
+		keys := batch.getSampleKeys()
+		strKeys := make([]string, 0, len(keys))
+		for _, key := range keys {
+			strKeys = append(strKeys, string(key))
+		}
+		assert.Equal(c.expected, strKeys)
+	}
+}

--- a/util/merge_ranges.go
+++ b/util/merge_ranges.go
@@ -1,0 +1,132 @@
+// Copyright 2024 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"container/list"
+)
+
+// To make life easier.
+// MergeRanges is used for txn file only, all keys are TiDB keys, and must not be bigger than following `maxEndKey`.
+var maxEndKey = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+
+type keyRange struct {
+	start []byte
+	end   []byte
+}
+
+type MergeRanges struct {
+	ranges *list.List
+}
+
+func NewMergeRanges() *MergeRanges {
+	r := &MergeRanges{
+		ranges: list.New(),
+	}
+	return r
+}
+
+func (m *MergeRanges) IsEmpty() bool {
+	return m.ranges.Len() == 0
+}
+
+// searchByStart search range by start key.
+// If the key is found, return the element and true.
+// If the key is not found, return the element to insert BEFORE and false. When the mark is nil, push to the back.
+func (m *MergeRanges) searchByStart(key []byte) (mark *list.Element, ok bool) {
+	for e := m.ranges.Front(); e != nil; e = e.Next() {
+		cmp := bytes.Compare(e.Value.(*keyRange).start, key)
+		if cmp == 0 {
+			return e, true
+		} else if cmp > 0 {
+			return e, false
+		}
+	}
+	return nil, false
+}
+
+// searchOverlapped search the overlapped range for key.
+// range.start <= key <= range.end
+// If the key is found, return the element and true.
+// If the key is not found, return the element to insert BEFORE and false. When the mark is nil, push to the back.
+func (m *MergeRanges) searchOverlapped(key []byte) (mark *list.Element, ok bool) {
+	mark, ok = m.searchByStart(key)
+	if ok {
+		return mark, true
+	}
+
+	var prev *list.Element
+	if mark == nil {
+		prev = m.ranges.Back()
+	} else {
+		prev = mark.Prev()
+	}
+
+	if prev == nil {
+		return m.ranges.Front(), false
+	}
+	if bytes.Compare(key, prev.Value.(*keyRange).end) <= 0 {
+		return prev, true
+	}
+	return mark, false
+}
+
+func (m *MergeRanges) Covered(start []byte, end []byte) bool {
+	if len(end) == 0 {
+		end = maxEndKey
+	}
+
+	mark, ok := m.searchOverlapped(start)
+	if ok {
+		return bytes.Compare(end, mark.Value.(*keyRange).end) <= 0
+	}
+	return false
+}
+
+func (m *MergeRanges) Insert(start []byte, end []byte) {
+	if len(end) == 0 {
+		end = maxEndKey
+	}
+
+	left, ok := m.searchOverlapped(start)
+	if ok {
+		if bytes.Compare(end, left.Value.(*keyRange).end) <= 0 {
+			return
+		}
+		start = left.Value.(*keyRange).start
+	}
+
+	if left == nil {
+		m.ranges.PushBack(&keyRange{start, end})
+		return
+	}
+
+	right, ok := m.searchOverlapped(end)
+	rightBound := right
+	if ok {
+		end = right.Value.(*keyRange).end
+		rightBound = right.Next()
+	}
+
+	m.ranges.InsertBefore(&keyRange{start, end}, left)
+
+	// Remove overlapped.
+	var next *list.Element
+	for e := left; e != rightBound; e = next {
+		next = e.Next()
+		m.ranges.Remove(e)
+	}
+}

--- a/util/merge_ranges_test.go
+++ b/util/merge_ranges_test.go
@@ -1,0 +1,220 @@
+// Copyright 2024 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	// "container/list"
+	// "container/list"
+	"container/list"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeRangesSearchOverlapped(t *testing.T) {
+	assert := require.New(t)
+
+	mr := NewMergeRanges()
+	type Case struct {
+		key int
+		ok  bool
+		rng *keyRange
+	}
+	checkOverlapped := func(c Case) {
+		mark, ok := mr.searchOverlapped(iToKey(c.key))
+		assert.Equal(c.ok, ok)
+		if c.rng == nil {
+			assert.Nil(mark)
+		} else {
+			assert.Equal(c.rng, mark.Value.(*keyRange))
+		}
+	}
+
+	checkOverlapped(Case{0, false, nil})
+
+	insert(mr, 0, 1)
+	cases := []Case{
+		{0, true, makeKeyRange(0, 1)},
+		{1, true, makeKeyRange(0, 1)},
+		{2, false, nil},
+	}
+	for _, c := range cases {
+		checkOverlapped(c)
+	}
+
+	insert(mr, 3, 5)
+	cases = []Case{
+		{0, true, makeKeyRange(0, 1)},
+		{1, true, makeKeyRange(0, 1)},
+		{2, false, makeKeyRange(3, 5)},
+		{3, true, makeKeyRange(3, 5)},
+		{4, true, makeKeyRange(3, 5)},
+		{5, true, makeKeyRange(3, 5)},
+		{6, false, nil},
+	}
+	for _, c := range cases {
+		checkOverlapped(c)
+	}
+}
+
+func TestMergeRangesCovered(t *testing.T) {
+	assert := require.New(t)
+
+	mr := NewMergeRanges()
+	type Case struct {
+		start    int
+		end      int
+		expected bool
+	}
+	checkCovered := func(c Case) {
+		assert.Equal(c.expected, mr.Covered(iToKey(c.start), iToKey(c.end)))
+	}
+
+	checkCovered(Case{0, 1, false})
+
+	insert(mr, 0, 1)
+	cases := []Case{
+		{0, 1, true},
+		{1, 2, false},
+	}
+	for _, c := range cases {
+		checkCovered(c)
+	}
+
+	insert(mr, 2, 4)
+	cases = []Case{
+		{0, 1, true},
+		{1, 2, false},
+		{2, 3, true},
+		{2, 4, true},
+		{1, 2, false},
+		{1, 3, false},
+		{1, 4, false},
+		{1, 5, false},
+		{2, 5, false},
+		{4, 5, false},
+		{0, 4, false},
+	}
+	for _, c := range cases {
+		checkCovered(c)
+	}
+}
+
+func TestMergeRangesInsert(t *testing.T) {
+	assert := require.New(t)
+
+	mr := NewMergeRanges()
+	checkMr := func(keys [][2]int) {
+		expected := makeMergeRanges(keys)
+		assert.Equal(expected.ranges, mr.ranges)
+	}
+
+	insert(mr, 2, 3)
+	checkMr([][2]int{{2, 3}})
+	insert(mr, 3, 4)
+	checkMr([][2]int{{2, 4}})
+
+	insert(mr, 0, 1)
+	checkMr([][2]int{{0, 1}, {2, 4}})
+	insert(mr, 1, 2)
+	checkMr([][2]int{{0, 4}})
+
+	insert(mr, 5, 6)
+	checkMr([][2]int{{0, 4}, {5, 6}})
+	insert(mr, 4, 5)
+	checkMr([][2]int{{0, 6}})
+
+	insert(mr, 10, 11)
+	checkMr([][2]int{{0, 6}, {10, 11}})
+	insert(mr, 3, 12)
+	checkMr([][2]int{{0, 12}})
+
+	assert.True(mr.Covered(iToKey(0), iToKey(12)))
+}
+
+func TestMergeRangesOverlappingRanges(t *testing.T) {
+	assert := require.New(t)
+
+	mr := makeMergeRanges([][2]int{{2, 12}})
+	checkMr := func(keys [][2]int) {
+		expected := makeMergeRanges(keys)
+		assert.Equal(expected.ranges, mr.ranges)
+	}
+
+	insert(mr, 2, 6)
+	checkMr([][2]int{{2, 12}})
+
+	insert(mr, 3, 8)
+	checkMr([][2]int{{2, 12}})
+
+	insert(mr, 6, 12)
+	checkMr([][2]int{{2, 12}})
+
+	insert(mr, 1, 4)
+	checkMr([][2]int{{1, 12}})
+
+	insert(mr, 4, 15)
+	checkMr([][2]int{{1, 15}})
+
+	insert(mr, 20, 21)
+	insert(mr, 22, 23)
+	insert(mr, 24, 25)
+	insert(mr, 14, 30)
+	checkMr([][2]int{{1, 30}})
+
+	insert(mr, 40, 41)
+	insert(mr, 42, 43)
+	insert(mr, 50, 51)
+	insert(mr, 53, 54)
+	insert(mr, 0, 42)
+	checkMr([][2]int{{0, 43}, {50, 51}, {53, 54}})
+}
+
+func TestMergeRangesEmptyKey(t *testing.T) {
+	assert := require.New(t)
+
+	mr := NewMergeRanges()
+
+	assert.False(mr.Covered(nil, nil))
+
+	mr.Insert(nil, iToKey(10))
+	mr.Insert(iToKey(10), nil)
+	assert.True(mr.Covered(iToKey(0), iToKey(100)))
+	assert.True(mr.Covered(nil, nil))
+}
+
+func iToKey(i int) []byte {
+	return []byte(fmt.Sprintf("%04d", i))
+}
+
+func makeKeyRange(start, end int) *keyRange {
+	return &keyRange{
+		start: iToKey(start),
+		end:   iToKey(end),
+	}
+}
+
+func insert(mr *MergeRanges, start, end int) {
+	mr.Insert(iToKey(start), iToKey(end))
+}
+
+func makeMergeRanges(keys [][2]int) *MergeRanges {
+	l := list.New()
+	for _, key := range keys {
+		l.PushBack(&keyRange{iToKey(key[0]), iToKey(key[1])})
+	}
+	return &MergeRanges{ranges: l}
+}


### PR DESCRIPTION
### Changes

- Asynchronously commit/rollback secondary keys.
  - Rename `executeTxnFileAction` -> `executeTxnFileSlice`, `executeTxnFileActionWithRetry` -> `executeTxnFileSliceWithRetry`.
  - Separate execution of primary batch from `executeTxnFileSlice` to `executeTxnFilePrimaryBatch`.
  - Add `executeTxnFileAction`, execute primary batch (`executeTxnFilePrimaryBatch`) first, then execute secondaries synchronously/asynchronously according to `action.asyncExecuteSecondaries()`.
- Fill `Keys` of commit & rollback request to help detecting duplicated.