### PR TITLE
txn-file: Remove retry of pre split regions

### DIFF
--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -441,8 +441,8 @@ func (c *twoPhaseCommitter) executeTxnFile(ctx context.Context) (err error) {
 	if err = c.buildTxnFiles(bo, c.mutations); err != nil {
 		return
 	}
-	if errSplit := c.preSplitTxnFileRegions(bo); errSplit != nil {
-		logutil.Logger(ctx).Warn("txn file pre split regions failed", zap.Error(errSplit))
+	if err = c.preSplitTxnFileRegions(bo); err != nil {
+		return
 	}
 	err = c.executeTxnFileActionWithRetry(bo, c.txnFileCtx.slice, txnFilePrewriteAction{})
 	if err != nil {

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -169,7 +169,8 @@ func (r *txnChunkRange) getOverlapRegions(c *locate.RegionCache, bo *retry.Backo
 	for bytes.Compare(startKey, r.biggest) <= 0 {
 		loc, err := c.LocateKey(bo, startKey)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			logutil.Logger(bo.GetCtx()).Error("locate key failed", zap.Error(err), zap.String("startKey", kv.StrKey(startKey)))
+			return nil, errors.Wrap(err, "locate key failed")
 		}
 		regions = append(regions, loc)
 		if len(loc.EndKey) == 0 {


### PR DESCRIPTION
As there is already retry inside `SplitRegions` (see [`batchSendSingleRegion`](https://github.com/tikv/client-go/blob/tidb-cse-7.5/tikv/split_region.go#L170)), it's not necessary to retry in `preSplitTxnFileRegions`. Otherwise, when split regions failed due to, e.g., txn file lock, `preSplitTxnFileRegions` will cost very long time to finish.

The retry for `groupToBatches` should also be removed, as `LocateKey` has internal retry as well. See [`RegionCache::loadRegion`](https://github.com/tikv/client-go/blob/15f5f67f8a1fac098155aab2e51d25df7ff67f49/internal/locate/region_cache.go#L1644).

### Changes

Remove retry for `preSplitTxnFileRegions`.
