### PR TITLE
log: only log the first lock in every flush or prewrite response

### DIFF
--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -215,6 +215,7 @@ func (action actionPipelinedFlush) handleSingleBatch(
 		}
 		locks := make([]*txnlock.Lock, 0, len(keyErrs))
 
+		logged := false
 		for _, keyErr := range keyErrs {
 			// Check already exists error
 			if alreadyExist := keyErr.GetAlreadyExist(); alreadyExist != nil {
@@ -227,12 +228,15 @@ func (action actionPipelinedFlush) handleSingleBatch(
 			if err1 != nil {
 				return err1
 			}
-			logutil.Logger(bo.GetCtx()).Info(
-				"[pipelined dml] encounters lock",
-				zap.Uint64("txnID", c.startTS),
-				zap.Uint64("generation", action.generation),
-				zap.Stringer("lock", lock),
-			)
+			if !logged {
+				logutil.Logger(bo.GetCtx()).Info(
+					"[pipelined dml] flush encounters lock. More locks may be omitted",
+					zap.Uint64("txnID", c.startTS),
+					zap.Uint64("generation", action.generation),
+					zap.Stringer("lock", lock),
+				)
+				logged = true
+			}
 			// If an optimistic transaction encounters a lock with larger TS, this transaction will certainly
 			// fail due to a WriteConflict error. So we can construct and return an error here early.
 			// Pessimistic transactions don't need such an optimization. If this key needs a pessimistic lock,


### PR DESCRIPTION
close #595 
1 lock is enough for most of the cases.