### PR TITLE
region_cache: fix issue that LocateKey may returns a wrong region

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1318,12 +1318,10 @@ func (c *RegionCache) findRegionByKey(bo *retry.Backoffer, key []byte, isEndKey 
 		}
 	} else if flags := r.resetSyncFlags(needReloadOnAccess | needDelayedReloadReady); flags > 0 {
 		// load region when it be marked as need reload.
-		var (
-			lr  *Region
-			err error
-		)
 		observeLoadRegion(tag, r, expired, flags)
-		lr, err = c.loadRegion(bo, key, isEndKey)
+		// NOTE: we can NOT use c.loadRegionByID(bo, r.GetID()) here because the new region (loaded by id) is not
+		// guaranteed to contain the key. (ref: https://github.com/tikv/client-go/pull/1299)
+		lr, err := c.loadRegion(bo, key, isEndKey)
 		if err != nil {
 			// ignore error and use old region info.
 			logutil.Logger(bo.GetCtx()).Error("load region failure",


### PR DESCRIPTION
https://github.com/tikv/client-go/pull/1122#discussion_r1469008167 here we introduce an issue: if a region is marked as NeedDelayedReload, then we try to reload it by id and return the new region directly without checking the range, which may cause `LocateKey` returns a wrong region when the region is just splitted. To fix this issue, we can:
1. always use `loadRegion` (by key)
2. check the range of the new region (returned by `loadRegionByID`), call `loadRegion` if it doesn't contain the key

Here we prefer the first solution for simplicity.