### PR TITLE
skip TestReplicaReadAccessPathByGenError because it's unstable and slow

### DIFF
--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -2737,6 +2737,7 @@ func TestReplicaReadAvoidSlowStore(t *testing.T) {
 }
 
 func TestReplicaReadAccessPathByGenError(t *testing.T) {
+	t.Skip("skip TestReplicaReadAccessPathByGenError because it's unstable and slow.")
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer func(lv zapcore.Level) {


### PR DESCRIPTION
skip TestReplicaReadAccessPathByGenError because it's unstable and slow.

And the test will be removed in #1265