### PR TITLE
txn: abort pipelined dml when pk rollback

### DIFF
--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -462,5 +462,7 @@ func (s *testPipelinedMemDBSuite) TestPipelinedDMLFailedByPKRollback() {
 	flushed, err = txn.GetMemBuffer().Flush(true)
 	s.Nil(err)
 	s.True(flushed)
-	s.NotNil(txn.GetMemBuffer().FlushWait())
+	err = txn.GetMemBuffer().FlushWait()
+	s.NotNil(err)
+	s.ErrorContains(err, "ttl manager is closed")
 }

--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -187,6 +187,7 @@ func (s *testPipelinedMemDBSuite) TestPipelinedFlushBlock() {
 	s.Nil(failpoint.Disable("tikvclient/beforePipelinedFlush"))
 	<-flushReturned
 	s.Nil(txn.GetMemBuffer().FlushWait())
+	s.Nil(txn.Rollback())
 }
 
 func (s *testPipelinedMemDBSuite) TestPipelinedSkipFlushedLock() {
@@ -455,7 +456,7 @@ func (s *testPipelinedMemDBSuite) TestPipelinedDMLFailedByPKRollback() {
 
 	s.Eventuallyf(func() bool {
 		return !txnProbe.GetCommitter().IsTTLRunning()
-	}, 5*time.Second, 100*time.Millisecond, "ttl manager should stop after primary lock resolved")
+	}, 5*time.Second, 100*time.Millisecond, "ttl manager should stop after primary lock is resolved")
 
 	txn.Set([]byte("key2"), []byte("value2"))
 	flushed, err = txn.GetMemBuffer().Flush(true)

--- a/internal/unionstore/pipelined_memdb_test.go
+++ b/internal/unionstore/pipelined_memdb_test.go
@@ -63,7 +63,7 @@ func TestPipelinedFlushTrigger(t *testing.T) {
 	})
 	for i := 0; i < MinFlushKeys-1; i++ {
 		key := []byte(strconv.Itoa(i))
-		value := make([]byte, avgKeySize-len(key)+1)
+		value := make([]byte, avgKeySize*2-len(key)+1)
 		// (key + value) * (MinFLushKeys - 1) > MinFlushMemSize
 		memdb.Set(key, value)
 		flushed, err := memdb.Flush(false)
@@ -82,7 +82,7 @@ func TestPipelinedFlushTrigger(t *testing.T) {
 	})
 	for i := 0; i < MinFlushKeys; i++ {
 		key := []byte(strconv.Itoa(i))
-		value := make([]byte, avgKeySize-len(key)+1) // (key + value) * MinFLushKeys > MinFlushKeys
+		value := make([]byte, avgKeySize*2-len(key)+1) // (key + value) * MinFLushKeys > MinFlushKeys
 		memdb.Set(key, value)
 		flushed, err := memdb.Flush(false)
 		require.Nil(t, err)

--- a/tikv/test_probe.go
+++ b/tikv/test_probe.go
@@ -60,8 +60,8 @@ func (s StoreProbe) NewLockResolver() LockResolverProbe {
 }
 
 // Begin starts a transaction.
-func (s StoreProbe) Begin() (transaction.TxnProbe, error) {
-	txn, err := s.KVStore.Begin()
+func (s StoreProbe) Begin(opts ...TxnOption) (transaction.TxnProbe, error) {
+	txn, err := s.KVStore.Begin(opts...)
 	return transaction.TxnProbe{KVTxn: txn}, err
 }
 

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1158,7 +1158,7 @@ func (tm *ttlManager) run(c *twoPhaseCommitter, lockCtx *kv.LockCtx, isPipelined
 	tm.ch = make(chan struct{})
 	tm.lockCtx = lockCtx
 
-	go keepAlive(c, tm.ch, c.primary(), lockCtx, isPipelinedTxn)
+	go keepAlive(c, tm, c.primary(), lockCtx, isPipelinedTxn)
 }
 
 func (tm *ttlManager) close() {
@@ -1180,7 +1180,7 @@ const pessimisticLockMaxBackoff = 20000
 const maxConsecutiveFailure = 10
 
 func keepAlive(
-	c *twoPhaseCommitter, closeCh chan struct{}, primaryKey []byte,
+	c *twoPhaseCommitter, tm *ttlManager, primaryKey []byte,
 	lockCtx *kv.LockCtx, isPipelinedTxn bool,
 ) {
 	// Ticker is set to 1/2 of the ManagedLockTTL.
@@ -1193,7 +1193,7 @@ func keepAlive(
 	keepFail := 0
 	for {
 		select {
-		case <-closeCh:
+		case <-tm.ch:
 			return
 		case <-ticker.C:
 			// If kill signal is received, the ttlManager should exit.
@@ -1254,6 +1254,12 @@ func keepAlive(
 						zap.Uint64("txnStartTS", c.startTS),
 						zap.Bool("isPipelinedTxn", isPipelinedTxn),
 					)
+					if isPipelinedTxn {
+						// pipelined DML cannot run without the ttlManager.
+						// Once the ttl manager fails, the transaction should be rolled back to avoid writing useless locks.
+						// close the ttlManager and the further flush will stop.
+						tm.close()
+					}
 					return
 				}
 				continue

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1158,7 +1158,7 @@ func (tm *ttlManager) run(c *twoPhaseCommitter, lockCtx *kv.LockCtx, isPipelined
 	tm.ch = make(chan struct{})
 	tm.lockCtx = lockCtx
 
-	go keepAlive(c, tm, c.primary(), lockCtx, isPipelinedTxn)
+	go keepAlive(c, tm.ch, tm, c.primary(), lockCtx, isPipelinedTxn)
 }
 
 func (tm *ttlManager) close() {
@@ -1180,7 +1180,7 @@ const pessimisticLockMaxBackoff = 20000
 const maxConsecutiveFailure = 10
 
 func keepAlive(
-	c *twoPhaseCommitter, tm *ttlManager, primaryKey []byte,
+	c *twoPhaseCommitter, closeCh chan struct{}, tm *ttlManager, primaryKey []byte,
 	lockCtx *kv.LockCtx, isPipelinedTxn bool,
 ) {
 	// Ticker is set to 1/2 of the ManagedLockTTL.
@@ -1193,7 +1193,8 @@ func keepAlive(
 	keepFail := 0
 	for {
 		select {
-		case <-tm.ch:
+		// because ttlManager can be reset, closeCh may not be equal to tm.ch.
+		case <-closeCh:
 			return
 		case <-ticker.C:
 			// If kill signal is received, the ttlManager should exit.


### PR DESCRIPTION
ref pingcap/tidb#52760, tikv/tikv#16291

Once the pipelined dml's ttl manager is stopped, fail the pipelined dml to avoid GC blocking and writing meaningless locks.

```sql
MySQL [test1]> insert into sbtest4_gc_max select * from sbtest4;
ERROR 1105 (HY000): ttl manager is closed
```
