### PR TITLE
txn-file: Add config item to specify minimum mutation size to use txn file

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -171,7 +171,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		TxnChunkWriterConcurrency: 4,
 		TxnChunkMaxSize:           128 * 1024 * 1024,
-		TxnFileMinMutationSize:    8 * 1024 * 1024,
+		TxnFileMinMutationSize:    16 * 1024 * 1024,
 	}
 }
 

--- a/config/client.go
+++ b/config/client.go
@@ -97,6 +97,8 @@ type TiKVClient struct {
 	TxnChunkWriterConcurrency uint `toml:"txn-chunk-writer-concurrency" json:"txn-chunk-writer-concurrency"`
 	// TxnChunkMaxSize is the maximum size of a txn chunk of file-based txn.
 	TxnChunkMaxSize uint64 `toml:"txn-chunk-max-size" json:"txn-chunk-max-size"`
+	// TxnFileMinMutationSize is the minimum size of mutations to use file-based txn.
+	TxnFileMinMutationSize uint64 `toml:"txn-file-min-mutation-size" json:"txn-file-min-mutation-size"`
 }
 
 // AsyncCommit is the config for the async commit feature. The switch to enable it is a system variable.
@@ -169,6 +171,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		TxnChunkWriterConcurrency: 4,
 		TxnChunkMaxSize:           128 * 1024 * 1024,
+		TxnFileMinMutationSize:    8 * 1024 * 1024,
 	}
 }
 

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -50,11 +50,8 @@ type Variables struct {
 	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
 
-	// TxnFileMinMutationSize specifies the minimum size of mutations to use file-based txn.
-	// <0: disabled.
-	// 0: use defalut value specified by config item TiKVClient.TxnFileMinMutationSize.
-	// >0: use the specified value.
-	TxnFileMinMutationSize int64
+	// EnableTxnFile specifies whether file-based txn is enabled.
+	EnableTxnFile bool
 }
 
 // NewVariables create a new Variables instance with default values.
@@ -63,6 +60,7 @@ func NewVariables(killed *uint32) *Variables {
 		BackoffLockFast: DefBackoffLockFast,
 		BackOffWeight:   DefBackOffWeight,
 		Killed:          killed,
+		EnableTxnFile:   true,
 	}
 }
 

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -49,6 +49,12 @@ type Variables struct {
 	// When its value is 0, it's not killed
 	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
+
+	// TxnFileMinMutationSize specifies the minimum size of mutations to use file-based txn.
+	// <0: disabled.
+	// 0: use defalut value specified by config item TiKVClient.TxnFileMinMutationSize.
+	// >0: use the specified value.
+	TxnFileMinMutationSize int64
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -504,6 +504,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	}()
 	if committer.useTxnFile() {
 		err = committer.executeTxnFile(ctx)
+		// TODO: fall back to normal 2PC when tikv-worker is unavailable.
 		if val == nil || sessionID > 0 {
 			txn.onCommitted(err)
 		}

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -807,19 +807,17 @@ func (c *twoPhaseCommitter) buildTxnFiles(bo *retry.Backoffer, mutations Committ
 }
 
 func (c *twoPhaseCommitter) useTxnFile() bool {
-	conf := config.GetGlobalConfig()
-
 	if c.txn == nil || c.txn.isPessimistic || c.txn.isInternal() ||
-		c.txn.vars.TxnFileMinMutationSize < 0 ||
-		len(conf.TiKVClient.TxnChunkWriterAddr) == 0 {
+		c.txn.vars.TxnFileMinMutationSize < 0 {
 		return false
 	}
-
+	conf := config.GetGlobalConfig()
 	minMutationSize := uint64(c.txn.vars.TxnFileMinMutationSize)
 	if minMutationSize == 0 {
 		minMutationSize = conf.TiKVClient.TxnFileMinMutationSize
 	}
-	return uint64(c.txn.GetMemBuffer().Size()) >= minMutationSize
+	return len(conf.TiKVClient.TxnChunkWriterAddr) > 0 &&
+		uint64(c.txn.GetMemBuffer().Size()) >= minMutationSize
 }
 
 func (c *twoPhaseCommitter) preSplitTxnFileRegions(bo *retry.Backoffer) error {

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -266,7 +266,7 @@ func (a txnFilePrewriteAction) executeBatch(c *twoPhaseCommitter, bo *retry.Back
 			if err1 != nil {
 				return nil, err1
 			}
-			logutil.BgLogger().Info(
+			logutil.Logger(bo.GetCtx()).Info(
 				"prewrite txn file encounters lock",
 				zap.Uint64("session", c.sessionID),
 				zap.Uint64("txnID", c.startTS),
@@ -502,9 +502,11 @@ func (c *twoPhaseCommitter) executeTxnFile(ctx context.Context) (err error) {
 		undetermined := c.mu.undeterminedErr != nil
 		c.mu.RUnlock()
 		if !committed && !undetermined {
-			err1 := c.executeTxnFileAction(retry.NewBackofferWithVars(ctx, int(PrewriteMaxBackoff.Load()), c.txn.vars), c.txnFileCtx.slice, txnFileRollbackAction{})
-			if err1 != nil {
-				logutil.BgLogger().Error("executeTxnFileActionWithRetry failed", zap.Error(err1))
+			if c.txnFileCtx.slice.len() > 0 {
+				err1 := c.executeTxnFileAction(retry.NewBackofferWithVars(ctx, int(CommitMaxBackoff), c.txn.vars), c.txnFileCtx.slice, txnFileRollbackAction{})
+				if err1 != nil {
+					logutil.Logger(ctx).Error("txn file: rollback on error failed", zap.Error(err1))
+				}
 			}
 			metrics.TwoPCTxnCounterError.Inc()
 		} else {
@@ -519,28 +521,34 @@ func (c *twoPhaseCommitter) executeTxnFile(ctx context.Context) (err error) {
 			zap.Stringers("steps", steps))
 	}()
 
-	bo := retry.NewBackofferWithVars(ctx, int(PrewriteMaxBackoff.Load()), c.txn.vars)
-	err = c.buildTxnFiles(bo, c.mutations)
+	logutil.Logger(ctx).Debug("execute txn file", zap.Uint64("startTS", c.startTS))
+
+	buildBo := retry.NewBackofferWithVars(ctx, int(BuildTxnFileMaxBackoff.Load()), c.txn.vars)
+	err = c.buildTxnFiles(buildBo, c.mutations)
 	stepDone("build")
 	if err != nil {
 		return
 	}
 
-	err = c.preSplitTxnFileRegions(bo)
+	err = c.preSplitTxnFileRegions(buildBo)
 	stepDone("pre-split")
 	if err != nil {
 		return
 	}
-	err = c.executeTxnFileAction(bo, c.txnFileCtx.slice, txnFilePrewriteAction{})
+
+	prewriteBo := retry.NewBackofferWithVars(ctx, int(PrewriteMaxBackoff.Load()), c.txn.vars)
+	err = c.executeTxnFileAction(prewriteBo, c.txnFileCtx.slice, txnFilePrewriteAction{})
 	stepDone("prewrite")
 	if err != nil {
 		return
 	}
-	c.commitTS, err = c.store.GetTimestampWithRetry(bo, c.txn.GetScope())
+
+	commitBo := retry.NewBackofferWithVars(ctx, int(CommitMaxBackoff), c.txn.vars)
+	c.commitTS, err = c.store.GetTimestampWithRetry(commitBo, c.txn.GetScope())
 	if err != nil {
 		return
 	}
-	err = c.executeTxnFileAction(bo, c.txnFileCtx.slice, txnFileCommitAction{commitTS: c.commitTS})
+	err = c.executeTxnFileAction(commitBo, c.txnFileCtx.slice, txnFileCommitAction{commitTS: c.commitTS})
 	stepDone("commit")
 	return
 }
@@ -588,13 +596,12 @@ func (c *twoPhaseCommitter) executeTxnFileSlice(bo *retry.Backoffer, chunkSlice 
 					kvrpcpb.WriteConflict_Optimistic,
 				)
 			}
-
 		}
 		regionErr, err1 := resp.GetRegionError()
 		if err1 != nil {
 			return regionErrChunks, err1
 		}
-		if regionErr.GetEpochNotMatch() != nil {
+		if regionErr != nil {
 			regionErrChunks.appendSlice(&batch.txnChunkSlice)
 			continue
 		}
@@ -611,7 +618,7 @@ func (c *twoPhaseCommitter) executeTxnFileSliceWithRetry(bo *retry.Backoffer, ch
 		var regionErrChunks txnChunkSlice
 		regionErrChunks, err := c.executeTxnFileSlice(bo, currentChunks, currentBatches, action, successRanges)
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		if regionErrChunks.len() == 0 {
 			return nil
@@ -620,7 +627,7 @@ func (c *twoPhaseCommitter) executeTxnFileSliceWithRetry(bo *retry.Backoffer, ch
 		currentBatches = nil
 		err = bo.Backoff(retry.BoRegionMiss, errors.Errorf("txn file: execute failed, region miss"))
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 	}
 }
@@ -800,11 +807,19 @@ func (c *twoPhaseCommitter) buildTxnFiles(bo *retry.Backoffer, mutations Committ
 }
 
 func (c *twoPhaseCommitter) useTxnFile() bool {
-	if c.txn.isPessimistic || c.txn.GetMemBuffer().Size() < 16*1024*1024 {
+	conf := config.GetGlobalConfig()
+
+	if c.txn == nil || c.txn.isPessimistic || c.txn.isInternal() ||
+		c.txn.vars.TxnFileMinMutationSize < 0 ||
+		len(conf.TiKVClient.TxnChunkWriterAddr) == 0 {
 		return false
 	}
-	conf := config.GetGlobalConfig()
-	return len(conf.TiKVClient.TxnChunkWriterAddr) > 0
+
+	minMutationSize := uint64(c.txn.vars.TxnFileMinMutationSize)
+	if minMutationSize == 0 {
+		minMutationSize = conf.TiKVClient.TxnFileMinMutationSize
+	}
+	return uint64(c.txn.GetMemBuffer().Size()) >= minMutationSize
 }
 
 func (c *twoPhaseCommitter) preSplitTxnFileRegions(bo *retry.Backoffer) error {


### PR DESCRIPTION
### Changes

- Add config item to specify minimum mutation size to use txn file
- Check `c.txnFileCtx.slice.len() > 0` when rollback on error. When the error happen before building txn chunks, the `slice` will be empty and rollback will panic.
- Use specified backoff for different step (build/prewrite/commit).
- Fix region error judgement in `executeTxnFileSlice`.
- Do not use txn file for internal commands, to avoid affect system tables or metadata in case txn file has some bugs. Specially handle TTL and DDL tasks laster.