### PR TITLE
p-dml: fail pipelined dml when max ttl exceeded (#1329)

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1229,6 +1229,11 @@ func keepAlive(
 				if c.isPessimistic && lockCtx != nil && lockCtx.LockExpired != nil {
 					atomic.StoreUint32(lockCtx.LockExpired, 1)
 				}
+				if isPipelinedTxn {
+					// the pipelined txn can last a long time after max ttl exceeded.
+					// if we don't stop it, it may fail when committing the primary key with high probability.
+					tm.close()
+				}
 				return
 			}
 


### PR DESCRIPTION
Cherry pick #1329 to tidb-8.1 branch

ref https://github.com/tikv/tikv/issues/16291

Once the ttl manager is automatically closed after max ttl. And the PK may be rolled back after it, stop the ttl manager and fail the dml to avoid committing PK failure.

Without this PR, the worst case is p-dml cannot be aware of PK rollback, and keep flushing locks which block GC for a long time.