### PR TITLE
fix issue of doesn't fast fail request when no available connections

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -44,9 +44,10 @@ import (
 
 const (
 	// DefStoreLivenessTimeout is the default value for store liveness timeout.
-	DefStoreLivenessTimeout      = "1s"
-	DefGrpcInitialWindowSize     = 1 << 27 // 128MiB
-	DefGrpcInitialConnWindowSize = 1 << 27 // 128MiB
+	DefStoreLivenessTimeout       = "1s"
+	DefGrpcInitialWindowSize      = 1 << 27 // 128MiB
+	DefGrpcInitialConnWindowSize  = 1 << 27 // 128MiB
+	DefMaxConcurrencyRequestLimit = math.MaxInt64
 )
 
 // TiKVClient is the config for tikv client.
@@ -174,7 +175,7 @@ func DefaultTiKVClient() TiKVClient {
 		CoprReqTimeout: 60 * time.Second,
 
 		ResolveLockLiteThreshold:   16,
-		MaxConcurrencyRequestLimit: math.MaxInt64,
+		MaxConcurrencyRequestLimit: DefMaxConcurrencyRequestLimit,
 		EnableReplicaSelectorV2:    true,
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -128,9 +128,15 @@ func TestCancelTimeoutRetErr(t *testing.T) {
 func TestSendWhenReconnect(t *testing.T) {
 	server, port := mockserver.StartMockTikvService()
 	require.True(t, port > 0)
+	restoreFn := config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.MaxConcurrencyRequestLimit = 10000
+	})
 
 	rpcClient := NewRPCClient()
-	defer rpcClient.Close()
+	defer func() {
+		rpcClient.Close()
+		restoreFn()
+	}()
 	addr := server.Addr()
 	conn, err := rpcClient.getConnArray(addr, true)
 	assert.Nil(t, err)
@@ -142,7 +148,7 @@ func TestSendWhenReconnect(t *testing.T) {
 
 	req := tikvrpc.NewRequest(tikvrpc.CmdEmpty, &tikvpb.BatchCommandsEmptyRequest{})
 	_, err = rpcClient.SendRequest(context.Background(), addr, req, 5*time.Second)
-	assert.True(t, strings.Contains(err.Error(), "timeout"))
+	require.Regexp(t, "wait recvLoop timeout,timeout:5s, wait_duration:.* context deadline exceeded", err.Error())
 	server.Stop()
 }
 
@@ -950,6 +956,7 @@ func TestRandomRestartStoreAndForwarding(t *testing.T) {
 					err.Error() == "rpc error: code = Unavailable desc = error reading from server: EOF" ||
 					strings.Contains(err.Error(), "context deadline exceeded") ||
 					strings.Contains(err.Error(), "connect: connection refused") ||
+					strings.Contains(err.Error(), "no available connections") ||
 					strings.Contains(err.Error(), "rpc error: code = Unavailable desc = error reading from server") {
 					continue
 				}
@@ -1009,4 +1016,34 @@ func TestErrConn(t *testing.T) {
 	errMsg := errors.New("unknown")
 	assert.True(t, errors.As(err1, &errMsg))
 	assert.EqualError(t, err1, errMsg.Error())
+}
+
+func TestFastFailWhenNoAvailableConn(t *testing.T) {
+	server, port := mockserver.StartMockTikvService()
+	require.True(t, port > 0)
+	require.True(t, server.IsRunning())
+	addr := server.Addr()
+	client := NewRPCClient()
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+		server.Stop()
+	}()
+
+	req := &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Coprocessor{Coprocessor: &coprocessor.Request{}}}
+	conn, err := client.getConnArray(addr, true)
+	assert.Nil(t, err)
+	_, err = sendBatchRequest(context.Background(), addr, "", conn.batchConn, req, time.Second, 0)
+	require.NoError(t, err)
+
+	for _, c := range conn.batchConn.batchCommandsClients {
+		// mock all client a in recreate.
+		c.lockForRecreate()
+	}
+	start := time.Now()
+	timeout := time.Second
+	_, err = sendBatchRequest(context.Background(), addr, "", conn.batchConn, req, timeout, 0)
+	require.Error(t, err)
+	require.Equal(t, "no available connections", err.Error())
+	require.Less(t, time.Since(start), timeout)
 }


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/53222

https://github.com/tikv/client-go/pull/1098/files#diff-289d0ab3e9da9a88db8dcf8ed7095af6756da3ea8da38212b352742a83d93ba2L383

If do not cancel the request in time, the upper layer will wait until it times out, and we should cancel requests when no available connections and let the upper layer try another replica again.

Before This PR:

Benchmark test with stop 1 tikv store. Many slow query execution time exceed 1 min.

<img width="1742" alt="image" src="https://github.com/tikv/client-go/assets/26020263/9702ddea-2d11-4ff4-8b38-612486ce46e1">

This PR:

Many slow query execution time is less than 25s.

<img width="1717" alt="image" src="https://github.com/tikv/client-go/assets/26020263/6f7e492c-2682-4e3a-b47b-e1f87f694363">


