### PR TITLE
fix rpc client panic cause by concurrent close

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -467,7 +467,8 @@ func (c *RPCClient) closeConns() {
 	if !c.isClosed {
 		c.isClosed = true
 		// close all connections
-		for _, array := range c.conns {
+		for addr, array := range c.conns {
+			delete(c.conns, addr)
 			array.Close()
 		}
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -723,3 +723,23 @@ func TestBatchClientRecoverAfterServerRestart(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestConcurrentCloseConnPanic(t *testing.T) {
+	client := NewRPCClient()
+	addr := "127.0.0.1:6379"
+	_, err := client.getConnArray(addr, true)
+	assert.Nil(t, err)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		err := client.Close()
+		assert.Nil(t, err)
+	}()
+	go func() {
+		defer wg.Done()
+		err := client.CloseAddr(addr)
+		assert.Nil(t, err)
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
fix rpc client panic cause by concurrent close.

And add a test for it, before this PR, the run test with race flag will failed:

```go
▶ go test -race -run=TestConcurrentCloseConnPanic
panic: close of closed channel

goroutine 64 [running]:
github.com/tikv/client-go/v2/internal/client.(*batchConn).Close(...)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_batch.go:769
github.com/tikv/client-go/v2/internal/client.(*connArray).Close(0xc0004b20c0)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client.go:330 +0xdc
github.com/tikv/client-go/v2/internal/client.(*RPCClient).CloseAddr(0xc00003c8c0, {0x1055f306e, 0xe})
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client.go:797 +0x1a0
github.com/tikv/client-go/v2/internal/client.TestConcurrentCloseConnPanic.func2()
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_test.go:741 +0x9c
created by github.com/tikv/client-go/v2/internal/client.TestConcurrentCloseConnPanic in goroutine 54
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_test.go:739 +0x2b8
exit status 2
FAIL    github.com/tikv/client-go/v2/internal/client    0.317s
```