### PR TITLE
fix rpc client panic cause by concurrent close

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -535,7 +535,6 @@ func (c *RPCClient) closeConns() {
 		for _, array := range c.conns {
 			array.Close()
 		}
-		c.conns = nil
 	}
 	c.Unlock()
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -532,7 +532,8 @@ func (c *RPCClient) closeConns() {
 	if !c.isClosed {
 		c.isClosed = true
 		// close all connections
-		for _, array := range c.conns {
+		for addr, array := range c.conns {
+			delete(c.conns, addr)
 			array.Close()
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -532,10 +532,10 @@ func (c *RPCClient) closeConns() {
 	if !c.isClosed {
 		c.isClosed = true
 		// close all connections
-		for addr, array := range c.conns {
-			delete(c.conns, addr)
+		for _, array := range c.conns {
 			array.Close()
 		}
+		c.conns = nil
 	}
 	c.Unlock()
 }
@@ -861,6 +861,10 @@ func (c *RPCClient) CloseAddr(addr string) error {
 
 func (c *RPCClient) CloseAddrVer(addr string, ver uint64) error {
 	c.Lock()
+	if c.isClosed {
+		c.Unlock()
+		return nil
+	}
 	conn, ok := c.conns[addr]
 	if ok {
 		if conn.ver <= ver {


### PR DESCRIPTION
fix rpc client panic cause by concurrent close.

And add a test for it, before this PR, the run test with race flag will failed:

```go
▶ go test -race -run=TestConcurrentCloseConnPanic
panic: close of closed channel

goroutine 90 [running]:
github.com/tikv/client-go/v2/internal/client.(*batchConn).Close(...)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_batch.go:891
github.com/tikv/client-go/v2/internal/client.(*connArray).Close(0xc00014a240)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client.go:384 +0xdc
github.com/tikv/client-go/v2/internal/client.(*RPCClient).CloseAddrVer(0xc00011e230, {0x10503ec2e, 0xe}, 0xffffffffffffffff)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client.go:876 +0x500
github.com/tikv/client-go/v2/internal/client.(*RPCClient).CloseAddr(...)
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client.go:858
github.com/tikv/client-go/v2/internal/client.TestConcurrentCloseConnPanic.func2()
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_test.go:1065 +0xa4
created by github.com/tikv/client-go/v2/internal/client.TestConcurrentCloseConnPanic in goroutine 8
        /Users/cs/code/goread/src/github.com/pingcap/client-go/internal/client/client_test.go:1063 +0x2b8
exit status 2
FAIL    github.com/tikv/client-go/v2/internal/client    0.341s

```