### PR TITLE
Introduce a new method MemHookSet

### DIFF
--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -898,3 +898,8 @@ func (db *MemDB) SetEntrySizeLimit(entryLimit, bufferLimit uint64) {
 func (db *MemDB) setSkipMutex(skip bool) {
 	db.skipMutex = skip
 }
+
+// MemHookSet implements the MemBuffer interface.
+func (db *MemDB) MemHookSet() bool {
+	return db.allocator.memChangeHook.Load() != nil
+}

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -525,3 +525,8 @@ func (p *PipelinedMemDB) GetFlushMetrics() FlushMetrics {
 		WaitDuration: p.flushWaitDuration,
 	}
 }
+
+// MemHookSet implements the MemBuffer interface.
+func (p *PipelinedMemDB) MemHookSet() bool {
+	return p.memChangeHook != nil
+}

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -212,6 +212,8 @@ type MemBuffer interface {
 	Dirty() bool
 	// SetMemoryFootprintChangeHook sets the hook for memory footprint change.
 	SetMemoryFootprintChangeHook(hook func(uint64))
+	// MemHookSet returns whether the memory footprint change hook is set.
+	MemHookSet() bool
 	// Mem returns the memory usage of MemBuffer.
 	Mem() uint64
 	// Len returns the count of entries in the MemBuffer.

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1703,3 +1703,8 @@ func (txn *KVTxn) SetRequestSourceType(tp string) {
 func (txn *KVTxn) SetExplicitRequestSourceType(tp string) {
 	txn.RequestSource.SetExplicitRequestSourceType(tp)
 }
+
+// MemHookSet returns whether the mem buffer has a memory footprint change hook set.
+func (txn *KVTxn) MemHookSet() bool {
+	return txn.us.GetMemBuffer().MemHookSet()
+}


### PR DESCRIPTION
part of [pingcap/tidb#53832](https://github.com/pingcap/tidb/pull/53764)
Add a method to show whether the hook is set, to avoid redundantly setting it.