### PR TITLE
txn-file: Calculate RU

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -41,6 +41,10 @@ type RequestInfo struct {
 	bypass bool
 }
 
+func NewRequestInfo(writeBytes int64, storeID uint64, replicaNumber int64, bypass bool) *RequestInfo {
+	return &RequestInfo{writeBytes: writeBytes, storeID: storeID, replicaNumber: replicaNumber, bypass: bypass}
+}
+
 // MakeRequestInfo extracts the relevant information from a BatchRequest.
 func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 	var bypass bool


### PR DESCRIPTION
### Changes

- Calculate RU for txn file

### Manual Test

Get RU result from `http://pd/metrics`, keyspace `7`:

1. Write 10MB pessimistic transaction

    `resource_manager_resource_unit_write_request_unit_sum{name="7",type="tp"} 35633.62499999955`

2. Write 10MB txn file transaction

    `resource_manager_resource_unit_write_request_unit_sum{name="7",type="tp"} 67347.73828124952`

3. Write 20MB pessimistic transaction

    `resource_manager_resource_unit_write_request_unit_sum{name="7",type="tp"} 138614.98828124886`

4. Write 20MB txn file transaction

    `resource_manager_resource_unit_write_request_unit_sum{name="7",type="tp"} 202043.21484374919`
