### PR TITLE
add enable-replica-selector-v2 config back but mark it was deprecated

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -100,6 +100,9 @@ type TiKVClient struct {
 	// MaxConcurrencyRequestLimit is the max concurrency number of request to be sent the tikv
 	// 0 means auto adjust by feedback.
 	MaxConcurrencyRequestLimit int64 `toml:"max-concurrency-request-limit" json:"max-concurrency-request-limit"`
+	// EnableReplicaSelectorV2 was deprecated.
+	// TODO(crazycs520): remove this config in 9.2 LTS version.
+	EnableReplicaSelectorV2 bool `toml:"enable-replica-selector-v2" json:"enable-replica-selector-v2"`
 }
 
 // AsyncCommit is the config for the async commit feature. The switch to enable it is a system variable.
@@ -173,6 +176,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		ResolveLockLiteThreshold:   16,
 		MaxConcurrencyRequestLimit: DefMaxConcurrencyRequestLimit,
+		EnableReplicaSelectorV2:    true,
 	}
 }
 

--- a/config/client.go
+++ b/config/client.go
@@ -101,7 +101,7 @@ type TiKVClient struct {
 	// 0 means auto adjust by feedback.
 	MaxConcurrencyRequestLimit int64 `toml:"max-concurrency-request-limit" json:"max-concurrency-request-limit"`
 	// EnableReplicaSelectorV2 was deprecated.
-	// TODO(crazycs520): remove this config in 9.2 LTS version.
+	// TODO(crazycs520): remove this config in 8.6 LTS version.
 	EnableReplicaSelectorV2 bool `toml:"enable-replica-selector-v2" json:"enable-replica-selector-v2"`
 }
 


### PR DESCRIPTION
`enable-replica-selector-v2` has been removed by https://github.com/tikv/client-go/pull/1265

According to `Feature Removal Process`, I can't remove the config `enable-replica-selector-v2` directly in v8.2, it can only be deleted in v8.6. So I added this config back, but it was deprecated and does not take effect.