### PR TITLE
Let memdb cache last traversed node

### DIFF
--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -40,7 +40,6 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -48,9 +47,6 @@ import (
 )
 
 var tombstone = []byte{}
-
-const sampleIntervalBits = 5 // sample every 2^5 = 32 times
-const sampleIntervalMask = (1 << sampleIntervalBits) - 1
 
 // IsTombstone returns whether the value is a tombstone.
 func IsTombstone(val []byte) bool { return len(val) == 0 }
@@ -96,12 +92,8 @@ type MemDB struct {
 
 	// The lastTraversedNode must exist
 	lastTraversedNode atomic.Pointer[memdbNodeAddr]
-	cacheEnabled      bool
 	hitCount          atomic.Uint64
 	missCount         atomic.Uint64
-
-	sampleCounter         atomic.Uint32
-	sampledTraverseTimeNs atomic.Uint64
 }
 
 func newMemDB() *MemDB {
@@ -114,15 +106,12 @@ func newMemDB() *MemDB {
 	db.vlog.memdb = db
 	db.skipMutex = false
 	db.lastTraversedNode.Store(&nullNodeAddr)
-	db.cacheEnabled = true
 	return db
 }
 
 // updateLastTraversed updates the last traversed node atomically
 func (db *MemDB) updateLastTraversed(node memdbNodeAddr) {
-	if db.cacheEnabled {
-		db.lastTraversedNode.Store(&node)
-	}
+	db.lastTraversedNode.Store(&node)
 }
 
 // checkKeyInCache retrieves the last traversed node if the key matches
@@ -433,20 +422,11 @@ func (db *MemDB) setValue(x memdbNodeAddr, value []byte) {
 // traverse search for and if not found and insert is true, will add a new node in.
 // Returns a pointer to the new node, or the node found.
 func (db *MemDB) traverse(key []byte, insert bool) memdbNodeAddr {
-	counter := db.sampleCounter.Add(1)
-	if counter&sampleIntervalMask == 0 {
-		start := time.Now()
-		defer func() {
-			db.sampledTraverseTimeNs.Add(uint64(time.Since(start).Nanoseconds()))
-		}()
+	if node, found := db.checkKeyInCache(key); found {
+		db.hitCount.Add(1)
+		return node
 	}
-	if db.cacheEnabled {
-		if node, found := db.checkKeyInCache(key); found {
-			db.hitCount.Add(1)
-			return node
-		}
-		db.missCount.Add(1)
-	}
+	db.missCount.Add(1)
 
 	x := db.getRoot()
 	y := memdbNodeAddr{nil, nullAddr}

--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -434,11 +434,16 @@ func (db *MemDB) traverse(key []byte, insert bool) memdbNodeAddr {
 
 	// walk x down the tree
 	for !x.isNull() && !found {
-		y = x
 		cmp := bytes.Compare(key, x.getKey())
 		if cmp < 0 {
+			if insert && x.left.isNull() {
+				y = x
+			}
 			x = x.getLeft(db)
 		} else if cmp > 0 {
+			if insert && x.right.isNull() {
+				y = x
+			}
 			x = x.getRight(db)
 		} else {
 			found = true

--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -92,6 +92,8 @@ type MemDB struct {
 
 	// The lastTraversedNode must exist
 	lastTraversedNode atomic.Pointer[memdbNodeAddr]
+	hitCount          atomic.Uint64
+	missCount         atomic.Uint64
 }
 
 func newMemDB() *MemDB {
@@ -421,8 +423,10 @@ func (db *MemDB) setValue(x memdbNodeAddr, value []byte) {
 // Returns a pointer to the new node, or the node found.
 func (db *MemDB) traverse(key []byte, insert bool) memdbNodeAddr {
 	if node, found := db.checkKeyInCache(key); found {
+		db.hitCount.Add(1)
 		return node
 	}
+	db.missCount.Add(1)
 
 	x := db.getRoot()
 	y := memdbNodeAddr{nil, nullAddr}

--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -279,7 +279,7 @@ func (a *nodeAllocator) freeNode(addr memdbArenaAddr) {
 		n.vptr = badAddr
 		return
 	}
-	// TODO: reuse freed nodes.
+	// TODO: reuse freed nodes. Need to fix lastTraversedNode when implementing this.
 }
 
 func (a *nodeAllocator) reset() {

--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -54,8 +54,9 @@ const (
 )
 
 var (
-	nullAddr = memdbArenaAddr{math.MaxUint32, math.MaxUint32}
-	endian   = binary.LittleEndian
+	nullAddr     = memdbArenaAddr{math.MaxUint32, math.MaxUint32}
+	nullNodeAddr = memdbNodeAddr{nil, nullAddr}
+	endian       = binary.LittleEndian
 )
 
 type memdbArenaAddr struct {

--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -63,8 +63,8 @@ type memdbArenaAddr struct {
 }
 
 func (addr memdbArenaAddr) isNull() bool {
-    // Combine all checks into a single condition
-    return addr == nullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32
+	// Combine all checks into a single condition
+	return addr == nullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32
 }
 
 // store and load is used by vlog, due to pointer in vlog is not aligned.

--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -63,8 +63,8 @@ type memdbArenaAddr struct {
 }
 
 func (addr memdbArenaAddr) isNull() bool {
-	// Combine all checks into a single condition
-	return addr == nullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32
+    // Combine all checks into a single condition
+    return addr == nullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32
 }
 
 // store and load is used by vlog, due to pointer in vlog is not aligned.

--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -39,10 +39,8 @@ import (
 	"math"
 	"unsafe"
 
-	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/kv"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 )
 
 const (
@@ -65,17 +63,8 @@ type memdbArenaAddr struct {
 }
 
 func (addr memdbArenaAddr) isNull() bool {
-	if addr == nullAddr {
-		return true
-	}
-	if addr.idx == math.MaxUint32 || addr.off == math.MaxUint32 {
-		// defensive programming, the code should never run to here.
-		// it always means something wrong... (maybe caused by data race?)
-		// because we never set part of idx/off to math.MaxUint64
-		logutil.BgLogger().Warn("Invalid memdbArenaAddr", zap.Uint32("idx", addr.idx), zap.Uint32("off", addr.off))
-		return true
-	}
-	return false
+    // Combine all checks into a single condition
+    return addr == nullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32
 }
 
 // store and load is used by vlog, due to pointer in vlog is not aligned.

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -530,3 +530,15 @@ func (p *PipelinedMemDB) GetFlushMetrics() FlushMetrics {
 func (p *PipelinedMemDB) MemHookSet() bool {
 	return p.memChangeHook != nil
 }
+
+func (p *PipelinedMemDB) EnableCache() {
+	if p.memDB != nil {
+		p.memDB.EnableCache()
+	}
+}
+
+func (p *PipelinedMemDB) DisableCache() {
+	if p.memDB != nil {
+		p.memDB.DisableCache()
+	}
+}

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -530,15 +530,3 @@ func (p *PipelinedMemDB) GetFlushMetrics() FlushMetrics {
 func (p *PipelinedMemDB) MemHookSet() bool {
 	return p.memChangeHook != nil
 }
-
-func (p *PipelinedMemDB) EnableCache() {
-	if p.memDB != nil {
-		p.memDB.EnableCache()
-	}
-}
-
-func (p *PipelinedMemDB) DisableCache() {
-	if p.memDB != nil {
-		p.memDB.DisableCache()
-	}
-}

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -529,8 +529,8 @@ func (p *PipelinedMemDB) GetMetrics() Metrics {
 	hitCount := p.hitCount
 	missCount := p.missCount
 	if p.memDB != nil {
-		hitCount = p.memDB.hitCount.Load()
-		missCount = p.memDB.missCount.Load()
+		hitCount += p.memDB.hitCount.Load()
+		missCount += p.memDB.missCount.Load()
 	}
 	return Metrics{
 		WaitDuration:   p.flushWaitDuration,

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -295,13 +295,16 @@ func (p *PipelinedMemDB) Flush(force bool) (bool, error) {
 		return false, nil
 	}
 	if p.flushingMemDB != nil {
+		startTime := time.Now()
 		if err := <-p.errCh; err != nil {
 			if err != nil {
 				err = p.handleAlreadyExistErr(err)
 			}
 			p.flushingMemDB = nil
+			p.flushWaitDuration += time.Since(startTime)
 			return false, err
 		}
+		p.flushWaitDuration += time.Since(startTime)
 	}
 	p.onFlushing.Store(true)
 	p.flushingMemDB = p.memDB

--- a/internal/unionstore/pipelined_memdb.go
+++ b/internal/unionstore/pipelined_memdb.go
@@ -60,7 +60,6 @@ type PipelinedMemDB struct {
 	flushWaitDuration time.Duration
 	hitCount          uint64
 	missCount         uint64
-	traverseTimeNs    uint64
 }
 
 const (
@@ -310,7 +309,6 @@ func (p *PipelinedMemDB) Flush(force bool) (bool, error) {
 	p.size += p.flushingMemDB.Size()
 	p.missCount += p.memDB.missCount.Load()
 	p.hitCount += p.memDB.hitCount.Load()
-	p.traverseTimeNs += p.memDB.sampledTraverseTimeNs.Load()
 	p.memDB = newMemDB()
 	p.memDB.SetEntrySizeLimit(p.entryLimit, p.bufferLimit)
 	p.memDB.setSkipMutex(true)
@@ -530,17 +528,14 @@ func (p *PipelinedMemDB) RevertToCheckpoint(*MemDBCheckpoint) {
 func (p *PipelinedMemDB) GetMetrics() Metrics {
 	hitCount := p.hitCount
 	missCount := p.missCount
-	sampledTraverseTimeNs := p.traverseTimeNs
 	if p.memDB != nil {
 		hitCount += p.memDB.hitCount.Load()
 		missCount += p.memDB.missCount.Load()
-		sampledTraverseTimeNs += p.memDB.sampledTraverseTimeNs.Load()
 	}
 	return Metrics{
-		WaitDuration:     p.flushWaitDuration,
-		MemDBHitCount:    hitCount,
-		MemDBMissCount:   missCount,
-		TraverseDuration: time.Duration(sampledTraverseTimeNs * (1 << sampleIntervalBits)),
+		WaitDuration:   p.flushWaitDuration,
+		MemDBHitCount:  hitCount,
+		MemDBMissCount: missCount,
 	}
 }
 

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -241,10 +241,6 @@ type MemBuffer interface {
 	FlushWait() error
 	// GetFlushDetails returns the metrics related to flushing
 	GetFlushMetrics() FlushMetrics
-	// EnableCache enables the cache for `Get`. Never enable it if there may be concurrent `get`s.
-	EnableCache()
-	// DisableCache disables the cache for `Get`
-	DisableCache()
 }
 
 type FlushMetrics struct {

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -241,6 +241,10 @@ type MemBuffer interface {
 	FlushWait() error
 	// GetFlushDetails returns the metrics related to flushing
 	GetFlushMetrics() FlushMetrics
+	// EnableCache enables the cache for `Get`. Never enable it if there may be concurrent `get`s.
+	EnableCache()
+	// DisableCache disables the cache for `Get`
+	DisableCache()
 }
 
 type FlushMetrics struct {

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -244,9 +244,10 @@ type MemBuffer interface {
 }
 
 type Metrics struct {
-	WaitDuration   time.Duration
-	MemDBHitCount  uint64
-	MemDBMissCount uint64
+	WaitDuration     time.Duration
+	MemDBHitCount    uint64
+	MemDBMissCount   uint64
+	TraverseDuration time.Duration
 }
 
 var (

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -244,10 +244,9 @@ type MemBuffer interface {
 }
 
 type Metrics struct {
-	WaitDuration     time.Duration
-	MemDBHitCount    uint64
-	MemDBMissCount   uint64
-	TraverseDuration time.Duration
+	WaitDuration   time.Duration
+	MemDBHitCount  uint64
+	MemDBMissCount uint64
 }
 
 var (

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -245,6 +245,7 @@ type MemBuffer interface {
 
 type Metrics struct {
 	WaitDuration   time.Duration
+	TotalDuration  time.Duration
 	MemDBHitCount  uint64
 	MemDBMissCount uint64
 }

--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -239,12 +239,14 @@ type MemBuffer interface {
 	Flush(force bool) (bool, error)
 	// FlushWait waits for the flushing task done and return error.
 	FlushWait() error
-	// GetFlushDetails returns the metrics related to flushing
-	GetFlushMetrics() FlushMetrics
+	// GetMetrics returns the metrics related to flushing
+	GetMetrics() Metrics
 }
 
-type FlushMetrics struct {
-	WaitDuration time.Duration
+type Metrics struct {
+	WaitDuration   time.Duration
+	MemDBHitCount  uint64
+	MemDBMissCount uint64
 }
 
 var (
@@ -298,4 +300,4 @@ func (db *MemDBWithContext) BatchGet(ctx context.Context, keys [][]byte) (map[st
 }
 
 // GetFlushMetrisc implements the MemBuffer interface.
-func (db *MemDBWithContext) GetFlushMetrics() FlushMetrics { return FlushMetrics{} }
+func (db *MemDBWithContext) GetMetrics() Metrics { return Metrics{} }

--- a/tikv/unionstore_export.go
+++ b/tikv/unionstore_export.go
@@ -57,3 +57,6 @@ type MemBuffer = unionstore.MemBuffer
 
 // MemDBCheckpoint is the checkpoint of memory DB.
 type MemDBCheckpoint = unionstore.MemDBCheckpoint
+
+// Metrics is the metrics of unionstore.
+type Metrics = unionstore.Metrics

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -174,7 +174,7 @@ func (action actionPessimisticLock) handleSingleBatch(
 			for _, m := range mutations {
 				keys = append(keys, hex.EncodeToString(m.Key))
 			}
-			logutil.BgLogger().Info(
+			logutil.BgLogger().Debug(
 				"[failpoint] injected lock ttl = 1 on pessimistic lock",
 				zap.Uint64("txnStartTS", c.startTS), zap.Strings("keys", keys),
 			)

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -304,6 +304,7 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 	logutil.Logger(bo.GetCtx()).Info(
 		"[pipelined dml] start to commit transaction",
 		zap.Int("keys", c.txn.GetMemBuffer().Len()),
+		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetFlushMetrics().WaitDuration),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -304,7 +304,9 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 	logutil.Logger(bo.GetCtx()).Info(
 		"[pipelined dml] start to commit transaction",
 		zap.Int("keys", c.txn.GetMemBuffer().Len()),
-		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetFlushMetrics().WaitDuration),
+		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetMetrics().WaitDuration),
+		zap.Uint64("memdb cache hit count", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
+		zap.Uint64("memdb cache miss count", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -307,6 +307,7 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetMetrics().WaitDuration),
 		zap.Uint64("memdb cache hit count", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
 		zap.Uint64("memdb cache miss count", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
+		zap.Duration("approximate memdb traverse time", time.Duration(c.txn.GetMemBuffer().GetMetrics().TraverseDuration)),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -305,6 +305,7 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 		"[pipelined dml] start to commit transaction",
 		zap.Int("keys", c.txn.GetMemBuffer().Len()),
 		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetMetrics().WaitDuration),
+		zap.Duration("total_duration", c.txn.GetMemBuffer().GetMetrics().TotalDuration),
 		zap.Uint64("memdb cache hit count", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
 		zap.Uint64("memdb cache miss count", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -307,7 +307,6 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetMetrics().WaitDuration),
 		zap.Uint64("memdb cache hit count", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
 		zap.Uint64("memdb cache miss count", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
-		zap.Duration("approximate memdb traverse time", time.Duration(c.txn.GetMemBuffer().GetMetrics().TraverseDuration)),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -306,8 +306,8 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 		zap.Int("keys", c.txn.GetMemBuffer().Len()),
 		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetMetrics().WaitDuration),
 		zap.Duration("total_duration", c.txn.GetMemBuffer().GetMetrics().TotalDuration),
-		zap.Uint64("memdb cache hit count", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
-		zap.Uint64("memdb cache miss count", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
+		zap.Uint64("memdb traversal cache hit", c.txn.GetMemBuffer().GetMetrics().MemDBHitCount),
+		zap.Uint64("memdb traversal cache miss", c.txn.GetMemBuffer().GetMetrics().MemDBMissCount),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -876,7 +876,7 @@ func (txn *KVTxn) onCommitted(err error) {
 			AsyncCommitFallback: txn.committer.hasTriedAsyncCommit && !isAsyncCommit,
 			OnePCFallback:       txn.committer.hasTriedOnePC && !isOnePC,
 			Pipelined:           txn.IsPipelined(),
-			FlushWaitMs:         txn.GetMemBuffer().GetFlushMetrics().WaitDuration.Milliseconds(),
+			FlushWaitMs:         txn.GetMemBuffer().GetMetrics().WaitDuration.Milliseconds(),
 		}
 		if err != nil {
 			info.ErrMsg = err.Error()


### PR DESCRIPTION
A common usage in TiDB is to access a same key multiple times consecutively. We can save subsequent traversals when this happen.

## Benchmark
### Sysbench (standard DML)

I tested oltp_write_only, no diff found compared with master.

### YCSB benchmark (pipelined DML)

In a YCSB 3M rows benchmark, the computation duration (total duration - flush wait) decreases, proving the optimization works as expected. We also observe a significant increase in flush_wait when applying this optimization. That should be a standalone problem to track and solve, IMO.

Master
insert 47.73-9.74=37.99s
update 30.74-2.78=27.96s
delete 23.81-5.98=17.83s
```
[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=2669674502] [session_alias=] [keys=5999998] [flush_wait_duration=9.742798374s] [total_duration=47.735029816s] [size=3.506GB] [startTS=451525108111769604]

[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=2669674506] [session_alias=] [keys=2999999] [flush_wait_duration=2.787723191s] [total_duration=30.74270092s] [size=3.243GB] [startTS=451525199285190657]

[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=2669674510] [session_alias=] [keys=5999998] [flush_wait_duration=5.983734665s] [total_duration=23.811122881s] [size=198MB] [startTS=451525285989580803]
```

This PR
insert 43.12-10.50=32.62s
update 31.76-4.96=26.8s
delete 28.82-15.06=13.76s
```
[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=3839885318] [session_alias=] [keys=5999998] [flush_wait_duration=10.507358104s] [total_duration=43.121563977s] ["memdb cache hit count"=11999996] ["memdb cache miss count"=11999996] [size=3.506GB] [startTS=451516433638621187]

[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=3839885320] [session_alias=] [keys=2999999] [flush_wait_duration=4.96714099s] [total_duration=31.767803066s] ["memdb cache hit count"=5999998] ["memdb cache miss count"=2999999] [size=3.243GB] [startTS=451516523593334791]

[pipelined_flush.go:304] ["[pipelined dml] start to commit transaction"] [conn=3839885324] [session_alias=] [keys=5999998] [flush_wait_duration=15.061686795s] [total_duration=28.810620825s] ["memdb cache hit count"=8999997] ["memdb cache miss count"=8999997] [size=198MB] [startTS=451516610572976131]
```

### microbenchmark
master:
```
go test -run=^$ -bench=Record -benchtime=30s
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/table/tables
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkAddRecordInPipelinedDML-12       	    3243	  10031009 ns/op	         0 cacheHit/op	         0 cacheMiss/op	      2006 ns/record
BenchmarkRemoveRecordInPipelinedDML-12    	    5106	   7356123 ns/op	         0 cacheHit/op	         0 cacheMiss/op	      1471 ns/record
BenchmarkUpdateRecordInPipelinedDML-12    	    4496	   8319425 ns/op	         0 cacheHit/op	         0 cacheMiss/op	      1664 ns/record
PASS
ok  	github.com/pingcap/tidb/pkg/table/tables	130.371s
```

This PR:
```
go test -run=^$ -bench=Record -benchtime=30s
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/pkg/table/tables
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkAddRecordInPipelinedDML-12       	    4514	   8312115 ns/op	         2.000 cacheHit/op	         2.000 cacheMiss/op	      1662 ns/record
BenchmarkRemoveRecordInPipelinedDML-12    	    6220	   5921161 ns/op	         1.000 cacheHit/op	         2.000 cacheMiss/op	      1184 ns/record
BenchmarkUpdateRecordInPipelinedDML-12    	    5998	   6389768 ns/op	         2.000 cacheHit/op	         1.000 cacheMiss/op	      1278 ns/record
PASS
ok  	github.com/pingcap/tidb/pkg/table/tables	133.874s
```