### PR TITLE
txn-file: Skip write to empty region

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -41,6 +41,7 @@ import (
 	errors2 "errors"
 	"math"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -329,6 +330,13 @@ type CommitterMutations interface {
 	IsAssertExists(i int) bool
 	IsAssertNotExist(i int) bool
 	NeedConstraintCheckInPrewrite(i int) bool
+}
+
+func IsMutationsEmptyInRange(mutations CommitterMutations, start []byte, end []byte) bool {
+	pos := sort.Search(mutations.Len(), func(i int) bool {
+		return bytes.Compare(mutations.GetKey(i), start) >= 0
+	})
+	return pos == mutations.Len() || bytes.Compare(mutations.GetKey(pos), end) >= 0
 }
 
 // PlainMutations contains transaction operations.

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -332,11 +332,11 @@ type CommitterMutations interface {
 	NeedConstraintCheckInPrewrite(i int) bool
 }
 
-func IsMutationsEmptyInRange(mutations CommitterMutations, start []byte, end []byte) bool {
+func MutationsHasDataInRange(mutations CommitterMutations, start []byte, end []byte) bool {
 	pos := sort.Search(mutations.Len(), func(i int) bool {
 		return bytes.Compare(mutations.GetKey(i), start) >= 0
 	})
-	return pos == mutations.Len() || bytes.Compare(mutations.GetKey(pos), end) >= 0
+	return pos < mutations.Len() && (len(end) == 0 || bytes.Compare(mutations.GetKey(pos), end) < 0)
 }
 
 // PlainMutations contains transaction operations.

--- a/txnkv/transaction/2pc_test.go
+++ b/txnkv/transaction/2pc_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transaction
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMutationsHasDataInRange(t *testing.T) {
+	assert := assert.New(t)
+
+	iToKey := func(i int) []byte {
+		if i < 0 {
+			return []byte{}
+		}
+		return []byte(fmt.Sprintf("%04d", i))
+	}
+
+	muts := NewPlainMutations(10)
+	for i := 10; i < 20; i += 2 {
+		key := iToKey(i)
+		muts.Push(kvrpcpb.Op_Put, key, key, false, false, false, false)
+	}
+
+	type Case struct {
+		start   int
+		end     int
+		expectd bool
+	}
+	cases := []Case{
+		{-1, -1, true},
+		{-1, 5, false},
+		{0, 10, false},
+		{0, 11, true},
+		{0, 30, true},
+		{0, -1, true},
+		{10, 20, true},
+		{15, 16, false},
+		{15, 17, true},
+		{15, -1, true},
+		{20, 30, false},
+		{21, 30, false},
+		{21, -1, false},
+	}
+
+	for _, c := range cases {
+		got := MutationsHasDataInRange(&muts, iToKey(c.start), iToKey(c.end))
+		assert.Equal(c.expectd, got)
+	}
+}

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -214,7 +214,7 @@ func (r *txnChunkRange) getOverlapRegions(c *locate.RegionCache, bo *retry.Backo
 			logutil.Logger(bo.GetCtx()).Error("locate key failed", zap.Error(err), zap.String("startKey", kv.StrKey(startKey)))
 			return nil, errors.Wrap(err, "locate key failed")
 		}
-		if !IsMutationsEmptyInRange(mutations, loc.StartKey, loc.EndKey) {
+		if MutationsHasDataInRange(mutations, loc.StartKey, loc.EndKey) {
 			regions = append(regions, loc)
 		}
 		if len(loc.EndKey) == 0 {

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -69,7 +69,8 @@ type chunkBatch struct {
 }
 
 func (b chunkBatch) String() string {
-	return fmt.Sprintf("chunkBatch{region: %s, isPrimary: %t, txnChunkSlice: %s}", b.region.String(), b.isPrimary, b.txnChunkSlice.String())
+	return fmt.Sprintf("chunkBatch{region: %d, isPrimary: %t, txnChunkSlice: %v}",
+		b.region.Region.GetID(), b.isPrimary, b.txnChunkSlice.chunkIDs)
 }
 
 // chunkBatch.txnChunkSlice should be sorted by smallest.


### PR DESCRIPTION
## Changes

- Check whether the txn chunk has no kv in the specified region and skip to write to it.