### PR TITLE
fix: duration logs for pipelined DML

### DIFF
--- a/internal/unionstore/union_store.go
+++ b/internal/unionstore/union_store.go
@@ -243,7 +243,8 @@ type MemBuffer interface {
 }
 
 type FlushMetrics struct {
-	WaitDuration time.Duration
+	WaitDuration  time.Duration
+	TotalDuration time.Duration
 }
 
 var (

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -305,6 +305,7 @@ func (c *twoPhaseCommitter) commitFlushedMutations(bo *retry.Backoffer) error {
 		"[pipelined dml] start to commit transaction",
 		zap.Int("keys", c.txn.GetMemBuffer().Len()),
 		zap.Duration("flush_wait_duration", c.txn.GetMemBuffer().GetFlushMetrics().WaitDuration),
+		zap.Duration("total_duration", c.txn.GetMemBuffer().GetFlushMetrics().TotalDuration),
 		zap.String("size", units.HumanSize(float64(c.txn.GetMemBuffer().Size()))),
 		zap.Uint64("startTS", c.startTS),
 	)


### PR DESCRIPTION
Previous tracking of flush_wait is wrong. This PR fixes it.
It also logs the total execution time prior to commit, providing better performance insights.