### PR TITLE
refine region request debug log

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1482,7 +1482,7 @@ func (s *RegionRequestSender) SendReqCtx(
 
 			// TODO: Change the returned error to something like "region missing in cache",
 			// and handle this error like EpochNotMatch, which means to re-split the request and retry.
-			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 				s.logSendReqError(bo, "throwing pseudo region error due to no replica available", regionID, tryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 			}
 			resp, err = tikvrpc.GenRegionErrorResp(req, &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}})
@@ -1519,7 +1519,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)
 		req.IsRetryRequest = true
 		if err != nil {
-			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 				msg := fmt.Sprintf("send request failed, err: %v", err.Error())
 				s.logSendReqError(bo, msg, regionID, tryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 			}
@@ -1556,7 +1556,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		if regionErr != nil {
 			retry, err = s.onRegionError(bo, rpcCtx, req, regionErr)
 			if err != nil {
-				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 					msg := fmt.Sprintf("send request on region error failed, err: %v", err.Error())
 					s.logSendReqError(bo, msg, regionID, tryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 				}
@@ -1566,7 +1566,7 @@ func (s *RegionRequestSender) SendReqCtx(
 				tryTimes++
 				continue
 			}
-			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 				s.logSendReqError(bo, "send request meet region error without retry", regionID, tryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 			}
 		} else {


### PR DESCRIPTION
cherry-pick #1408

Log region request round failed log when total backoff duration is more than 1s.