### PR TITLE
refine region request debug log

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -829,7 +829,7 @@ func (s *RegionRequestSender) SendReqCtx(
 				if err := s.replicaSelector.backoffOnNoCandidate(bo); err != nil {
 					return nil, nil, retryTimes, err
 				}
-				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 					s.logSendReqError(bo, "throwing pseudo region error due to no replica available", regionID, retryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 				}
 			}
@@ -870,7 +870,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)
 		req.IsRetryRequest = true
 		if err != nil {
-			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 				msg := fmt.Sprintf("send request failed, err: %v", err.Error())
 				s.logSendReqError(bo, msg, regionID, retryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 			}
@@ -906,7 +906,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		if regionErr != nil {
 			retry, err = s.onRegionError(bo, rpcCtx, req, regionErr)
 			if err != nil {
-				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+				if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 					msg := fmt.Sprintf("send request on region error failed, err: %v", err.Error())
 					s.logSendReqError(bo, msg, regionID, retryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 				}
@@ -916,7 +916,7 @@ func (s *RegionRequestSender) SendReqCtx(
 				retryTimes++
 				continue
 			}
-			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout {
+			if cost := time.Since(startTime); cost > slowLogSendReqTime || cost > timeout || bo.GetTotalSleep() > 1000 {
 				s.logSendReqError(bo, "send request meet region error without retry", regionID, retryTimes, req, cost, bo.GetTotalSleep()-startBackOff, timeout)
 			}
 		} else {


### PR DESCRIPTION
Log region request round failed log when total backoff duration is more than 1s.