### PR TITLE
region cache: batch find regions by key ranges from cache

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1240,24 +1240,48 @@ func (c *RegionCache) BatchLocateKeyRanges(bo *retry.Backoffer, keyRanges []kv.K
 				keyRange.StartKey = lastRegion.EndKey()
 			}
 		}
+		// TODO: find all the cached regions in the range.
+		// now we only check if the region is cached from the lower bound, if there is a uncached hole in the middle,
+		// we will load the rest regions even they are cached.
+		r := c.tryFindRegionByKey(keyRange.StartKey, false)
+		lastRegion = r
+		if r == nil {
+			// region cache miss, add the cut range to uncachedRanges, load from PD later.
+			uncachedRanges = append(uncachedRanges, pd.KeyRange{StartKey: keyRange.StartKey, EndKey: keyRange.EndKey})
+			continue
+		}
+		// region cache hit, add the region to cachedRegions.
+		cachedRegions = append(cachedRegions, r)
+		if r.ContainsByEnd(keyRange.EndKey) {
+			// the range is fully hit in the region cache.
+			continue
+		}
+		keyRange.StartKey = r.EndKey()
+		// Batch load rest regions from Cache.
+		batchSize := 100
+	outer:
 		for {
-			// TODO: find all the cached regions in the range.
-			// now we only check if the region is cached from the lower bound, if there is a uncached hole in the middle,
-			// we will load the rest regions even they are cached.
-			r := c.tryFindRegionByKey(keyRange.StartKey, false)
-			lastRegion = r
-			if r == nil {
-				// region cache miss, add the cut range to uncachedRanges, load from PD later.
+			batchRegionInCache, err := c.scanRegionsFromCache(bo, keyRange.StartKey, keyRange.EndKey, batchSize)
+			if err != nil {
+				return nil, err
+			}
+			for _, r = range batchRegionInCache {
+				if !r.Contains(keyRange.StartKey) { // uncached hole, load the rest regions
+					uncachedRanges = append(uncachedRanges, pd.KeyRange{StartKey: keyRange.StartKey, EndKey: keyRange.EndKey})
+					break outer
+				}
+				cachedRegions = append(cachedRegions, r)
+				lastRegion = r
+				if r.ContainsByEnd(keyRange.EndKey) {
+					// the range is fully hit in the region cache.
+					break outer
+				}
+				keyRange.StartKey = r.EndKey()
+			}
+			if len(batchRegionInCache) < batchSize { // region cache miss, load the rest regions
 				uncachedRanges = append(uncachedRanges, pd.KeyRange{StartKey: keyRange.StartKey, EndKey: keyRange.EndKey})
-				break
+				break outer
 			}
-			// region cache hit, add the region to cachedRegions.
-			cachedRegions = append(cachedRegions, r)
-			if r.ContainsByEnd(keyRange.EndKey) {
-				// the range is fully hit in the region cache.
-				break
-			}
-			keyRange.StartKey = r.EndKey()
 		}
 	}
 
@@ -2078,7 +2102,8 @@ func (c *RegionCache) loadRegionByID(bo *retry.Backoffer, regionID uint64) (*Reg
 	}
 }
 
-// TODO(youjiali1995): for optimizing BatchLoadRegionsWithKeyRange, not used now.
+// For optimizing BatchLocateKeyRanges, scanRegionsFromCache scans at most `limit` regions from cache.
+// The first region's startKey is `startKey`, all regions returned are continuous and have no hole.
 func (c *RegionCache) scanRegionsFromCache(bo *retry.Backoffer, startKey, endKey []byte, limit int) ([]*Region, error) {
 	if limit == 0 {
 		return nil, nil
@@ -2089,9 +2114,6 @@ func (c *RegionCache) scanRegionsFromCache(bo *retry.Backoffer, startKey, endKey
 	defer c.mu.RUnlock()
 	regions = c.mu.sorted.AscendGreaterOrEqual(startKey, endKey, limit)
 
-	if len(regions) == 0 {
-		return nil, errors.New("no regions in the cache")
-	}
 	return regions, nil
 }
 

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -2255,10 +2255,27 @@ func (s *testRegionRequestToSingleStoreSuite) TestRefreshCache() {
 
 	region, _ := s.cache.LocateRegionByID(s.bo, s.region)
 	v2 := region.Region.confVer + 1
-	r2 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: region.Region.ver, ConfVer: v2}, StartKey: []byte{1}}
+	r2 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: region.Region.ver, ConfVer: v2}, StartKey: []byte{2}}
 	st := newUninitializedStore(s.store)
 	s.cache.insertRegionToCache(&Region{meta: &r2, store: unsafe.Pointer(st), ttl: nextTTLWithoutJitter(time.Now().Unix())}, true, true)
 
+	// Since region cache doesn't remove the first intersected region(it scan intersected region by AscendGreaterOrEqual), the outdated region (-inf, inf) is still alive.
+	// The new inserted valid region [{2}, inf) is ignored because the first seen region (-inf, inf) contains all the required ranges.
+	r, _ = s.cache.scanRegionsFromCache(s.bo, []byte{}, nil, 10)
+	s.Equal(len(r), 1)
+	s.Equal(r[0].StartKey(), []byte(nil))
+
+	// regions: (-inf,2), [2, +inf).  Get all regions.
+	v3 := region.Region.confVer + 2
+	r3 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: region.Region.ver, ConfVer: v3}, StartKey: []byte{}, EndKey: []byte{2}}
+	s.cache.insertRegionToCache(&Region{meta: &r3, store: unsafe.Pointer(st), ttl: nextTTLWithoutJitter(time.Now().Unix())}, true, true)
+	r, _ = s.cache.scanRegionsFromCache(s.bo, []byte{}, nil, 10)
+	s.Equal(len(r), 2)
+
+	// regions: (-inf,1), [2, +inf).  Get region (-inf, 1).
+	v4 := region.Region.confVer + 3
+	r4 := metapb.Region{Id: region.Region.id, RegionEpoch: &metapb.RegionEpoch{Version: region.Region.ver, ConfVer: v4}, StartKey: []byte{}, EndKey: []byte{1}}
+	s.cache.insertRegionToCache(&Region{meta: &r4, store: unsafe.Pointer(st), ttl: nextTTLWithoutJitter(time.Now().Unix())}, true, true)
 	r, _ = s.cache.scanRegionsFromCache(s.bo, []byte{}, nil, 10)
 	s.Equal(len(r), 1)
 
@@ -2286,7 +2303,7 @@ func (s *testRegionRequestToSingleStoreSuite) TestRegionCacheStartNonEmpty() {
 	// region cache after insert: [[1, +inf)]
 
 	r, _ = s.cache.scanRegionsFromCache(s.bo, []byte{}, nil, 10)
-	s.Equal(len(r), 0) // fail in current implementation
+	s.Equal(len(r), 0)
 }
 
 func (s *testRegionRequestToSingleStoreSuite) TestRefreshCacheConcurrency() {

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -37,6 +37,7 @@ package locate
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -2873,4 +2874,41 @@ func (s *testRegionCacheSuite) TestIssue1401() {
 		return newStore1.getResolveState() == resolved && newStore1.getLivenessState() == reachable
 	}, 3*time.Second, time.Second)
 	s.Require().True(isStoreContainLabel(newStore1.labels, "host", "0.0.0.0:20161"))
+}
+
+func BenchmarkBatchLocateKeyRangesFromCache(t *testing.B) {
+	t.StopTimer()
+	s := new(testRegionCacheSuite)
+	s.SetT(&testing.T{})
+	s.SetupTest()
+
+	regionNum := 10000
+	regions := s.cluster.AllocIDs(regionNum)
+	regions = append([]uint64{s.region1}, regions...)
+
+	peers := [][]uint64{{s.peer1, s.peer2}}
+	for i := 0; i < regionNum-1; i++ {
+		peers = append(peers, s.cluster.AllocIDs(2))
+	}
+
+	for i := 0; i < regionNum-1; i++ {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, uint64(i*2))
+		s.cluster.Split(regions[i], regions[i+1], b, peers[i+1], peers[i+1][0])
+	}
+
+	// cache all regions
+	keyLocation, err := s.cache.BatchLocateKeyRanges(s.bo, []kv.KeyRange{{StartKey: []byte(""), EndKey: []byte("")}})
+	if err != nil || len(keyLocation) != regionNum {
+		t.FailNow()
+	}
+
+	t.StartTimer()
+	for i := 0; i < t.N; i++ {
+		keyLocation, err := s.cache.BatchLocateKeyRanges(s.bo, []kv.KeyRange{{StartKey: []byte(""), EndKey: []byte("")}})
+		if err != nil || len(keyLocation) != regionNum {
+			t.FailNow()
+		}
+	}
+	s.TearDownTest()
 }

--- a/internal/locate/sorted_btree.go
+++ b/internal/locate/sorted_btree.go
@@ -92,7 +92,7 @@ func (s *SortedRegions) AscendGreaterOrEqual(startKey, endKey []byte, limit int)
 		if !region.checkRegionCacheTTL(now) {
 			return false
 		}
-		if len(lastStartKey) > 0 && !region.Contains(lastStartKey) { // uncached hole
+		if !region.Contains(lastStartKey) { // uncached hole
 			return false
 		}
 		lastStartKey = region.EndKey()

--- a/internal/locate/sorted_btree.go
+++ b/internal/locate/sorted_btree.go
@@ -80,7 +80,7 @@ func (s *SortedRegions) SearchByKey(key []byte, isEndKey bool) (r *Region) {
 }
 
 // AscendGreaterOrEqual returns all items that are greater than or equal to the key.
-// The first region's startKey is `startKey`, all regions returned are continuous and have no hole.
+// It is the caller's responsibility to make sure that startKey is a node in the B-tree, otherwise, the startKey will not be included in the return regions.
 func (s *SortedRegions) AscendGreaterOrEqual(startKey, endKey []byte, limit int) (regions []*Region) {
 	now := time.Now().Unix()
 	lastStartKey := startKey

--- a/internal/locate/sorted_btree.go
+++ b/internal/locate/sorted_btree.go
@@ -82,13 +82,14 @@ func (s *SortedRegions) SearchByKey(key []byte, isEndKey bool) (r *Region) {
 // AscendGreaterOrEqual returns all items that are greater than or equal to the key.
 // The first region's startKey is `startKey`, all regions returned are continuous and have no hole.
 func (s *SortedRegions) AscendGreaterOrEqual(startKey, endKey []byte, limit int) (regions []*Region) {
+	now := time.Now().Unix()
 	lastStartKey := startKey
 	s.b.AscendGreaterOrEqual(newBtreeSearchItem(startKey), func(item *btreeItem) bool {
 		region := item.cachedRegion
 		if len(endKey) > 0 && bytes.Compare(region.StartKey(), endKey) >= 0 {
 			return false
 		}
-		if !region.checkRegionCacheTTL(time.Now().Unix()) {
+		if !region.checkRegionCacheTTL(now) {
 			return false
 		}
 		if !region.Contains(lastStartKey) { // uncached hole

--- a/internal/locate/sorted_btree.go
+++ b/internal/locate/sorted_btree.go
@@ -92,7 +92,7 @@ func (s *SortedRegions) AscendGreaterOrEqual(startKey, endKey []byte, limit int)
 		if !region.checkRegionCacheTTL(now) {
 			return false
 		}
-		if !region.Contains(lastStartKey) { // uncached hole
+		if len(lastStartKey) > 0 && !region.Contains(lastStartKey) { // uncached hole
 			return false
 		}
 		lastStartKey = region.EndKey()


### PR DESCRIPTION
Currently, client-go only supports batch reading of region information from pd, but not from region cache. 
If there is a large table with 200k regions, even if all regions are in memory, it still takes 0.8-0.9s to read all regions. 
This PR optimizes the querying times to the B-tree, the time consumption reduces by about 40%.

```
This PR
Running tool: /gosdk/go1.22.1/bin/go test -benchmem -run=^$ -bench ^BenchmarkBatchLocateKeyRanges$ github.com/tikv/client-go/v2/internal/locate --tags=intest --count=1 -v

goos: linux
goarch: amd64
pkg: github.com/tikv/client-go/v2/internal/locate
cpu: 13th Gen Intel(R) Core(TM) i9-13900KF
BenchmarkBatchLocateKeyRanges
BenchmarkBatchLocateKeyRanges-32    	    1116	   1305628 ns/op	 1412405 B/op	   10921 allocs/op
PASS
ok  	github.com/tikv/client-go/v2/internal/locate	1.987s

Running tool: /gosdk/go1.22.1/bin/go test -benchmem -run=^$ -bench ^BenchmarkBatchLocateKeyRanges$ github.com/tikv/client-go/v2/internal/locate --tags=intest --count=1 -v

Master Branch
goos: linux
goarch: amd64
pkg: github.com/tikv/client-go/v2/internal/locate
cpu: 13th Gen Intel(R) Core(TM) i9-13900KF
BenchmarkBatchLocateKeyRanges
BenchmarkBatchLocateKeyRanges-32    	     502	   2367271 ns/op	 1512372 B/op	   20020 allocs/op
PASS
ok  	github.com/tikv/client-go/v2/internal/locate	1.831s
```