### PR TITLE
txn-file: Fix miss slice after region error is met or commit failed

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -744,7 +744,7 @@ func (c *twoPhaseCommitter) primary() []byte {
 		if c.mutations != nil {
 			return c.mutations.GetKey(0)
 		}
-		if c.txnFileCtx.slice.len() > 0 {
+		if c.txnFileCtx.slice.Len() > 0 {
 			return c.txnFileCtx.slice.chunkRanges[0].smallest
 		}
 		return nil
@@ -1228,7 +1228,7 @@ func keepAlive(c *twoPhaseCommitter, closeCh chan struct{}, primaryKey []byte, l
 			logutil.Logger(bo.GetCtx()).Info("send TxnHeartBeat",
 				zap.Uint64("startTS", c.startTS), zap.Uint64("newTTL", newTTL))
 			startTime := time.Now()
-			_, stopHeartBeat, err := sendTxnHeartBeat(bo, c.store, primaryKey, c.startTS, newTTL, c.txnFileCtx.slice.len() > 0)
+			_, stopHeartBeat, err := sendTxnHeartBeat(bo, c.store, primaryKey, c.startTS, newTTL, c.txnFileCtx.slice.Len() > 0)
 			if err != nil {
 				keepFail++
 				metrics.TxnHeartBeatHistogramError.Observe(time.Since(startTime).Seconds())

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -606,6 +606,9 @@ func (c *twoPhaseCommitter) executeTxnFile(ctx context.Context) (err error) {
 	}
 	err = c.executeTxnFileAction(commitBo, c.txnFileCtx.slice, txnFileCommitAction{commitTS: c.commitTS})
 	stepDone("commit")
+	if err != nil {
+		return
+	}
 
 	err = c.afterExecuteTxnFile(rcInterceptor, reqInfo, ruDetails)
 	return
@@ -757,11 +760,12 @@ func (c *twoPhaseCommitter) executeTxnFilePrimaryBatch(bo *retry.Backoffer, firs
 
 	firstBatch.isPrimary = true
 	resp, err := action.executeBatch(c, bo, firstBatch)
-	logutil.Logger(bo.GetCtx()).Debug("txn file: execute primary batch finished",
+	logutil.Logger(bo.GetCtx()).Info("txn file: execute primary batch finished",
 		zap.Uint64("startTS", c.startTS),
 		zap.String("primary", kv.StrKey(c.primary())),
 		zap.Stringer("action", action),
 		zap.Stringer("batch", firstBatch),
+		zap.Any("resp", resp),
 		zap.Error(err))
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
### Change

- Sort and deduplicate txn chunks slice after region error is met.
- Fix the ignorance of commit error.