### PR TITLE
txn-file: Support RU discount

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -105,6 +105,9 @@ type TiKVClient struct {
 	TxnChunkMaxSize uint64 `toml:"txn-chunk-max-size" json:"txn-chunk-max-size"`
 	// TxnFileMinMutationSize is the minimum size of mutations to use file-based txn.
 	TxnFileMinMutationSize uint64 `toml:"txn-file-min-mutation-size" json:"txn-file-min-mutation-size"`
+	// TxnFileRUDiscountRatio is the discount ratio of resource unit for file-based txn.
+	// Will be ignored if it's <= 0 or >= 1.
+	TxnFileRUDiscountRatio float64
 }
 
 // AsyncCommit is the config for the async commit feature. The switch to enable it is a system variable.
@@ -180,6 +183,7 @@ func DefaultTiKVClient() TiKVClient {
 		TxnChunkWriterConcurrency: 4,
 		TxnChunkMaxSize:           128 * 1024 * 1024,
 		TxnFileMinMutationSize:    16 * 1024 * 1024,
+		TxnFileRUDiscountRatio:    0.125, // filed-based txn costs 1/8 RU of normal txn.
 	}
 }
 

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -996,8 +996,14 @@ func (c *twoPhaseCommitter) beforeExecuteTxnFile(
 		}
 	}
 
+	writeBytes := int64(c.txn.Size())
+	discountRatio := config.GetGlobalConfig().TiKVClient.TxnFileRUDiscountRatio
+	if discountRatio > 0.0 && discountRatio < 1.0 {
+		writeBytes = int64(float64(writeBytes) * discountRatio)
+	}
+
 	reqInfo := resourcecontrol.NewRequestInfo(
-		int64(c.txn.Size()),
+		writeBytes,
 		region.GetLeaderStoreID(),
 		replicaNumber,
 		false,


### PR DESCRIPTION
### Changes

Support RU discount for file based transaction.

### Manual Test

RU base: `113895.00000000393`

Perform 10 x 32MB normal txn: `1.2529470000000296e+06`, cost: `139052`

Perform 10 x 32MB file-based txn: `1.3793565802734673e+06`, cost: `126409`

Perform 40 x 32MB normal txn: `5.942659016603314e+06`, cost: `4563302`

Perform 40 x 32MB file-based txn: `6.448379828322069e+06`, cost: `505720`

RU base: `7.138956353321901e+06`

Perform 80 x 32MB normal txn: `1.6308955402701495e+07`, cost: `9169999`

Perform 80 x 32MB file-based txn: `1.7320355780826386e+07`, cost: `1011400`
