### PR TITLE
transaction: add hook for async commit to track the life cycle of the async-commit goroutine and secondary lock cleanup goroutine

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -2520,7 +2520,7 @@ func (s *testCommitterSuite) Test2PCLifecycleHooks() {
 	var wg sync.WaitGroup
 
 	t1 := s.begin()
-	t1.SetSecondaryLockCleanupLifecycleHooks(transaction.LifecycleHooks{
+	t1.SetBackgroundGoroutineLifecycleHooks(transaction.LifecycleHooks{
 		Pre: func() {
 			wg.Add(1)
 
@@ -2550,7 +2550,7 @@ func (s *testCommitterSuite) Test2PCCleanupLifecycleHooks() {
 	var wg sync.WaitGroup
 
 	t1 := s.begin()
-	t1.SetCleanupLifecycleHooks(transaction.LifecycleHooks{
+	t1.SetBackgroundGoroutineLifecycleHooks(transaction.LifecycleHooks{
 		Pre: func() {
 			wg.Add(1)
 

--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -641,7 +641,7 @@ func (s *testAsyncCommitSuite) TestAsyncCommitLifecycleHooks() {
 	var wg sync.WaitGroup
 
 	t1 := s.beginAsyncCommit()
-	t1.SetAsyncCommitLifecycleHooks(transaction.LifecycleHooks{
+	t1.SetBackgroundGoroutineLifecycleHooks(transaction.LifecycleHooks{
 		Pre: func() {
 			wg.Add(1)
 

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -289,6 +289,11 @@ func (c CommitterProbe) Cleanup(ctx context.Context) {
 	c.cleanWg.Wait()
 }
 
+// CleanupWithoutWait cleans dirty data of a committer without waiting.
+func (c CommitterProbe) CleanupWithoutWait(ctx context.Context) {
+	c.cleanup(ctx)
+}
+
 // WaitCleanup waits for the committer to complete.
 func (c CommitterProbe) WaitCleanup() {
 	c.cleanWg.Wait()


### PR DESCRIPTION
This PR adds two hooks to execute before the start of async-commit goroutine and after the finish of async-commit goroutines.

It can be used to add some external logic to track the lifecycle of the async-commit goroutines. For example, in `TiDB` we'll need to wait for the background goroutines to finish before shutdown.