### PR TITLE
memdb: fix memdb snapshot get/iter is not actually snapshot (#1393)

### DIFF
--- a/internal/unionstore/memdb_arena.go
+++ b/internal/unionstore/memdb_arena.go
@@ -353,7 +353,7 @@ func (l *memdbVlog) getSnapshotValue(addr memdbArenaAddr, snap *MemDBCheckpoint)
 	if result.isNull() {
 		return nil, false
 	}
-	return l.getValue(addr), true
+	return l.getValue(result), true
 }
 
 func (l *memdbVlog) selectValueHistory(addr memdbArenaAddr, predicate func(memdbArenaAddr) bool) memdbArenaAddr {

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -37,7 +37,6 @@
 package unionstore
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -848,18 +847,22 @@ func TestSnapshotGetIter(t *testing.T) {
 	var getters []Getter
 	var iters []Iterator
 	for i := 0; i < 100; i++ {
+		expectValue := i
+		if expectValue > 50 {
+			expectValue = 50
+		}
 		assert.Nil(buffer.Set([]byte{byte(0)}, []byte{byte(i)}))
 		// getter
 		getter := buffer.SnapshotGetter()
-		val, err := getter.Get(context.Background(), []byte{byte(0)})
+		val, err := getter.Get([]byte{byte(0)})
 		assert.Nil(err)
-		assert.Equal(val, []byte{byte(min(i, 50))})
+		assert.Equal(val, []byte{byte(expectValue)})
 		getters = append(getters, getter)
 		// iter
 		iter := buffer.SnapshotIter(nil, nil)
 		assert.Nil(err)
 		assert.Equal(iter.Key(), []byte{byte(0)})
-		assert.Equal(iter.Value(), []byte{byte(min(i, 50))})
+		assert.Equal(iter.Value(), []byte{byte(expectValuet)})
 		iter.Close()
 		iters = append(iters, buffer.SnapshotIter(nil, nil))
 		if i == 50 {
@@ -867,7 +870,7 @@ func TestSnapshotGetIter(t *testing.T) {
 		}
 	}
 	for _, getter := range getters {
-		val, err := getter.Get(context.Background(), []byte{byte(0)})
+		val, err := getter.Get([]byte{byte(0)})
 		assert.Nil(err)
 		assert.Equal(val, []byte{byte(50)})
 	}

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -37,6 +37,7 @@
 package unionstore
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"testing"
@@ -839,4 +840,39 @@ func TestUnsetTemporaryFlag(t *testing.T) {
 	flags, err := db.GetFlags(key)
 	require.Nil(err)
 	require.False(flags.HasNeedConstraintCheckInPrewrite())
+}
+
+func TestSnapshotGetIter(t *testing.T) {
+	assert := assert.New(t)
+	buffer := newMemDB()
+	var getters []Getter
+	var iters []Iterator
+	for i := 0; i < 100; i++ {
+		assert.Nil(buffer.Set([]byte{byte(0)}, []byte{byte(i)}))
+		// getter
+		getter := buffer.SnapshotGetter()
+		val, err := getter.Get(context.Background(), []byte{byte(0)})
+		assert.Nil(err)
+		assert.Equal(val, []byte{byte(min(i, 50))})
+		getters = append(getters, getter)
+		// iter
+		iter := buffer.SnapshotIter(nil, nil)
+		assert.Nil(err)
+		assert.Equal(iter.Key(), []byte{byte(0)})
+		assert.Equal(iter.Value(), []byte{byte(min(i, 50))})
+		iter.Close()
+		iters = append(iters, buffer.SnapshotIter(nil, nil))
+		if i == 50 {
+			_ = buffer.Staging()
+		}
+	}
+	for _, getter := range getters {
+		val, err := getter.Get(context.Background(), []byte{byte(0)})
+		assert.Nil(err)
+		assert.Equal(val, []byte{byte(50)})
+	}
+	for _, iter := range iters {
+		assert.Equal(iter.Key(), []byte{byte(0)})
+		assert.Equal(iter.Value(), []byte{byte(50)})
+	}
 }

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -862,7 +862,7 @@ func TestSnapshotGetIter(t *testing.T) {
 		iter := buffer.SnapshotIter(nil, nil)
 		assert.Nil(err)
 		assert.Equal(iter.Key(), []byte{byte(0)})
-		assert.Equal(iter.Value(), []byte{byte(expectValuet)})
+		assert.Equal(iter.Value(), []byte{byte(expectValue)})
 		iter.Close()
 		iters = append(iters, buffer.SnapshotIter(nil, nil))
 		if i == 50 {


### PR DESCRIPTION
Cherry pick https://github.com/tikv/client-go/pull/1393 into tidb-7.1.

ref https://github.com/tikv/client-go/issues/1394