### PR TITLE
retry stale read on follower if leader timeout

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -526,10 +526,6 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 	}
 
 	rpcCtx.contextPatcher.staleRead = &state.isStaleRead
-	if state.isStaleRead {
-		// reset the state so that next replica read is not stale
-		state.isStaleRead = false
-	}
 	return rpcCtx, nil
 }
 

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -526,6 +526,10 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 	}
 
 	rpcCtx.contextPatcher.staleRead = &state.isStaleRead
+	if state.isStaleRead {
+		// reset the state so that next replica read is not stale
+		state.isStaleRead = false
+	}
 	return rpcCtx, nil
 }
 

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -524,8 +524,8 @@ func (state *tryFollower) next(bo *retry.Backoffer, selector *replicaSelector) (
 		replicaRead := true
 		rpcCtx.contextPatcher.replicaRead = &replicaRead
 	}
-	staleRead := false
-	rpcCtx.contextPatcher.staleRead = &staleRead
+
+	rpcCtx.contextPatcher.staleRead = &state.isStaleRead
 	return rpcCtx, nil
 }
 


### PR DESCRIPTION
issue number : https://github.com/tikv/tikv/issues/17422

Currently stale read is always retried as leader read or follower read. Follower read can overwhelm the leader if is leader raft state machine is slow.
In this fix, request is retried as stale reads to replica if leader read returns deadline_exceeded error. 

After this fix : 
If original request is doing stale read
Retry 1 : Try Leader read
if error is deadline exceeded
Retry 2 : Try replica 1 with stale read
Retry 3 : try replica 2 with stale read

If there is any other error
Retry 2: Try replica 1 with follower read
Retry 3 : Try replica 2 with follower read
