### PR TITLE
memdb: use atomic u64 addr to reduce allocation

### DIFF
--- a/internal/unionstore/arena/arena.go
+++ b/internal/unionstore/arena/arena.go
@@ -62,6 +62,14 @@ type MemdbArenaAddr struct {
 	off uint32
 }
 
+func U64ToAddr(u64 uint64) MemdbArenaAddr {
+	return MemdbArenaAddr{uint32(u64 >> 32), uint32(u64)}
+}
+
+func (addr MemdbArenaAddr) AsU64() uint64 {
+	return uint64(addr.idx)<<32 | uint64(addr.off)
+}
+
 func (addr MemdbArenaAddr) IsNull() bool {
 	// Combine all checks into a single condition
 	return addr == NullAddr || addr.idx == math.MaxUint32 || addr.off == math.MaxUint32

--- a/internal/unionstore/arena/arena.go
+++ b/internal/unionstore/arena/arena.go
@@ -51,10 +51,11 @@ const (
 )
 
 var (
-	Tombstone = []byte{}
-	NullAddr  = MemdbArenaAddr{math.MaxUint32, math.MaxUint32}
-	BadAddr   = MemdbArenaAddr{math.MaxUint32 - 1, math.MaxUint32}
-	endian    = binary.LittleEndian
+	Tombstone          = []byte{}
+	NullAddr           = MemdbArenaAddr{math.MaxUint32, math.MaxUint32}
+	NullU64Addr uint64 = math.MaxUint64
+	BadAddr            = MemdbArenaAddr{math.MaxUint32 - 1, math.MaxUint32}
+	endian             = binary.LittleEndian
 )
 
 type MemdbArenaAddr struct {

--- a/internal/unionstore/memdb_art.go
+++ b/internal/unionstore/memdb_art.go
@@ -160,7 +160,7 @@ func (db *artDBWithContext) SnapshotIter(lower, upper []byte) Iterator {
 
 // SnapshotIterReverse returns a reversed Iterator for a snapshot of MemBuffer.
 func (db *artDBWithContext) SnapshotIterReverse(upper, lower []byte) Iterator {
-	return db.ART.SnapshotIter(upper, lower)
+	return db.ART.SnapshotIterReverse(upper, lower)
 }
 
 // SnapshotGetter returns a Getter for a snapshot of MemBuffer.

--- a/internal/unionstore/memdb_rbt.go
+++ b/internal/unionstore/memdb_rbt.go
@@ -167,7 +167,7 @@ func (db *rbtDBWithContext) SnapshotIter(lower, upper []byte) Iterator {
 
 // SnapshotIterReverse returns a reversed Iterator for a snapshot of MemBuffer.
 func (db *rbtDBWithContext) SnapshotIterReverse(upper, lower []byte) Iterator {
-	return db.RBT.SnapshotIter(upper, lower)
+	return db.RBT.SnapshotIterReverse(upper, lower)
 }
 
 // SnapshotGetter returns a Getter for a snapshot of MemBuffer.

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -86,7 +86,7 @@ func New() *RBT {
 	db.stages = make([]arena.MemDBCheckpoint, 0, 2)
 	db.entrySizeLimit = unlimitedSize
 	db.bufferSizeLimit = unlimitedSize
-	db.lastTraversedNode.Store(math.MaxUint64)
+	db.lastTraversedNode.Store(arena.NullU64Addr)
 	return db
 }
 
@@ -98,7 +98,7 @@ func (db *RBT) updateLastTraversed(node MemdbNodeAddr) {
 // checkKeyInCache retrieves the last traversed node if the key matches
 func (db *RBT) checkKeyInCache(key []byte) (MemdbNodeAddr, bool) {
 	addrU64 := db.lastTraversedNode.Load()
-	if addrU64 == math.MaxUint64 {
+	if addrU64 == arena.NullU64Addr {
 		return nullNodeAddr, false
 	}
 	addr := arena.U64ToAddr(addrU64)
@@ -212,7 +212,7 @@ func (db *RBT) Reset() {
 	db.count = 0
 	db.vlog.Reset()
 	db.allocator.reset()
-	db.lastTraversedNode.Store(math.MaxUint64)
+	db.lastTraversedNode.Store(arena.NullU64Addr)
 }
 
 // DiscardValues releases the memory used by all values.
@@ -597,7 +597,7 @@ func (db *RBT) rightRotate(y MemdbNodeAddr) {
 func (db *RBT) deleteNode(z MemdbNodeAddr) {
 	var x, y MemdbNodeAddr
 	if db.lastTraversedNode.Load() == z.addr.AsU64() {
-		db.lastTraversedNode.Store(math.MaxUint64)
+		db.lastTraversedNode.Store(arena.NullU64Addr)
 	}
 
 	db.count--


### PR DESCRIPTION
After #1389, we cache the last traversed node in memdb, but it's an atomic pointer, which need a heap allocation every time we update it, so the benchmark has little regression.

```
go test ./internal/unionstore -v -benchmem -bench=BenchmarkMemDbBufferSequential -run=^a -benchtime=1x

before  #1389
BenchmarkMemDbBufferSequential-8               1          42312917 ns/op        12576704 B/op         31 allocs/op

after #1389
BenchmarkMemDbBufferSequential-8               1          46407916 ns/op        15776704 B/op     200031 allocs/op

this pr
BenchmarkMemDbBufferSequential-8               1          44018167 ns/op        12576704 B/op         31 allocs/op
```

This PR also fixes some bugs of memdb:
- The refactor leave a mistake of the snapshot reverse iterator.
- The cached addr should be reset when memdb is reset.