### PR TITLE
txn-file: Get sample keys from `CommitterMutations`

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -332,11 +332,15 @@ type CommitterMutations interface {
 	NeedConstraintCheckInPrewrite(i int) bool
 }
 
-func MutationsHasDataInRange(mutations CommitterMutations, start []byte, end []byte) bool {
+func MutationsHasDataInRange(mutations CommitterMutations, start []byte, end []byte) ([]byte, bool) {
 	pos := sort.Search(mutations.Len(), func(i int) bool {
 		return bytes.Compare(mutations.GetKey(i), start) >= 0
 	})
-	return pos < mutations.Len() && (len(end) == 0 || bytes.Compare(mutations.GetKey(pos), end) < 0)
+	ok := pos < mutations.Len() && (len(end) == 0 || bytes.Compare(mutations.GetKey(pos), end) < 0)
+	if ok {
+		return mutations.GetKey(pos), true
+	}
+	return nil, false
 }
 
 // PlainMutations contains transaction operations.

--- a/txnkv/transaction/2pc_test.go
+++ b/txnkv/transaction/2pc_test.go
@@ -39,28 +39,32 @@ func TestMutationsHasDataInRange(t *testing.T) {
 	}
 
 	type Case struct {
-		start   int
-		end     int
-		expectd bool
+		start    int
+		end      int
+		expectd  bool
+		firstKey int
 	}
 	cases := []Case{
-		{-1, -1, true},
-		{-1, 5, false},
-		{0, 10, false},
-		{0, 11, true},
-		{0, 30, true},
-		{0, -1, true},
-		{10, 20, true},
-		{15, 16, false},
-		{15, 17, true},
-		{15, -1, true},
-		{20, 30, false},
-		{21, 30, false},
-		{21, -1, false},
+		{-1, -1, true, 10},
+		{-1, 5, false, -1},
+		{0, 10, false, -1},
+		{0, 11, true, 10},
+		{0, 30, true, 10},
+		{0, -1, true, 10},
+		{10, 20, true, 10},
+		{15, 16, false, 16},
+		{15, 17, true, 16},
+		{15, -1, true, 16},
+		{20, 30, false, -1},
+		{21, 30, false, -1},
+		{21, -1, false, -1},
 	}
 
 	for _, c := range cases {
-		got := MutationsHasDataInRange(&muts, iToKey(c.start), iToKey(c.end))
+		firstKey, got := MutationsHasDataInRange(&muts, iToKey(c.start), iToKey(c.end))
 		assert.Equal(c.expectd, got)
+		if got {
+			assert.Equal(iToKey(c.firstKey), firstKey)
+		}
 	}
 }

--- a/txnkv/transaction/txn_file.go
+++ b/txnkv/transaction/txn_file.go
@@ -69,8 +69,9 @@ type txnFileCtx struct {
 
 type chunkBatch struct {
 	txnChunkSlice
-	region    *locate.KeyLocation
-	isPrimary bool
+	region     *locate.KeyLocation
+	sampleKeys [][]byte
+	isPrimary  bool
 }
 
 func (b chunkBatch) String() string {
@@ -78,22 +79,8 @@ func (b chunkBatch) String() string {
 		b.region.Region.GetID(), b.isPrimary, b.txnChunkSlice.chunkIDs)
 }
 
-// chunkBatch.txnChunkSlice should be sorted by smallest.
 func (b *chunkBatch) getSampleKeys() [][]byte {
-	keys := make([][]byte, 0)
-	start := sort.Search(b.txnChunkSlice.Len(), func(i int) bool {
-		return bytes.Compare(b.region.StartKey, b.txnChunkSlice.chunkRanges[i].smallest) <= 0
-	})
-	end := b.txnChunkSlice.Len()
-	if len(b.region.EndKey) > 0 {
-		end = sort.Search(b.txnChunkSlice.Len(), func(i int) bool {
-			return bytes.Compare(b.txnChunkSlice.chunkRanges[i].smallest, b.region.EndKey) >= 0
-		})
-	}
-	for i := start; i < end; i++ {
-		keys = append(keys, b.txnChunkSlice.chunkRanges[i].smallest)
-	}
-	return keys
+	return b.sampleKeys
 }
 
 // txnChunkSlice should be sorted by txnChunkRange.smallest and no overlapping.
@@ -176,19 +163,27 @@ func (cs *txnChunkSlice) groupToBatches(c *locate.RegionCache, bo *retry.Backoff
 	}
 	batchMap := make(map[batchMapKey]*chunkBatch)
 	for i, chunkRange := range cs.chunkRanges {
-		regions, err := chunkRange.getOverlapRegions(c, bo, mutations)
+		chunkID := cs.chunkIDs[i]
+
+		regions, firstKeys, err := chunkRange.getOverlapRegions(c, bo, mutations)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 
-		for _, r := range regions {
-			key := batchMapKey{regionID: r.Region.GetID(), regionVer: r.Region.GetVer()}
-			if batchMap[key] == nil {
-				batchMap[key] = &chunkBatch{
-					region: r,
+		for j, r := range regions {
+			firstKey := firstKeys[j]
+
+			bk := batchMapKey{regionID: r.Region.GetID(), regionVer: r.Region.GetVer()}
+			if batchMap[bk] == nil {
+				batchMap[bk] = &chunkBatch{
+					region:     r,
+					sampleKeys: make([][]byte, 0, 1),
 				}
 			}
-			batchMap[key].append(cs.chunkIDs[i], chunkRange)
+
+			batch := batchMap[bk]
+			batch.append(chunkID, chunkRange)
+			batch.sampleKeys = append(batch.sampleKeys, firstKey)
 		}
 	}
 
@@ -227,24 +222,27 @@ func newTxnChunkRange(smallest []byte, biggest []byte) txnChunkRange {
 	}
 }
 
-func (r *txnChunkRange) getOverlapRegions(c *locate.RegionCache, bo *retry.Backoffer, mutations CommitterMutations) ([]*locate.KeyLocation, error) {
+func (r *txnChunkRange) getOverlapRegions(c *locate.RegionCache, bo *retry.Backoffer, mutations CommitterMutations) ([]*locate.KeyLocation, [][]byte, error) {
 	regions := make([]*locate.KeyLocation, 0)
+	firstKeys := make([][]byte, 0)
 	startKey := r.smallest
 	for bytes.Compare(startKey, r.biggest) <= 0 {
 		loc, err := c.LocateKey(bo, startKey)
 		if err != nil {
 			logutil.Logger(bo.GetCtx()).Error("locate key failed", zap.Error(err), zap.String("startKey", kv.StrKey(startKey)))
-			return nil, errors.Wrap(err, "locate key failed")
+			return nil, nil, errors.Wrap(err, "locate key failed")
 		}
-		if MutationsHasDataInRange(mutations, loc.StartKey, loc.EndKey) {
+		firstKey, ok := MutationsHasDataInRange(mutations, loc.StartKey, loc.EndKey)
+		if ok {
 			regions = append(regions, loc)
+			firstKeys = append(firstKeys, firstKey)
 		}
 		if len(loc.EndKey) == 0 {
 			break
 		}
 		startKey = loc.EndKey
 	}
-	return regions, nil
+	return regions, firstKeys, nil
 }
 
 type txnFileAction interface {


### PR DESCRIPTION
Meet error of `TxnLockNotFound` when commit secondary keys:

`[2024/08/27 07:24:01.830 +00:00] [WARN] [txn_file.go:817] ["txn file: async execute secondaries failed"] [keyspaceName=xxx] [keyspaceID=xxx] [startTS=xxx] [action=txnFileCommit] [error="Error(Txn(Error(Mvcc(Error(TxnLockNotFound { start_ts: TimeStamp(xxx), commit_ts: TimeStamp(xxx), key: [] })))))"]`

### Changes

- Get sample keys from `CommitterMutations` to make sure that the keys must exist in the region.
