### PR TITLE
txn-file: Get first key inside range of both region & txn chunk

### DIFF
--- a/util/misc.go
+++ b/util/misc.go
@@ -35,6 +35,7 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -206,4 +207,24 @@ func HexRegionKey(key []byte) []byte {
 // logs.
 func HexRegionKeyStr(key []byte) string {
 	return String(HexRegionKey(key))
+}
+
+func GetMaxStartKey(lhs []byte, rhs []byte) []byte {
+	if bytes.Compare(lhs, rhs) > 0 {
+		return lhs
+	}
+	return rhs
+}
+
+func GetMinEndKey(lhs []byte, rhs []byte) []byte {
+	if len(rhs) == 0 {
+		return lhs
+	}
+	if len(lhs) == 0 {
+		return rhs
+	}
+	if bytes.Compare(lhs, rhs) < 0 {
+		return lhs
+	}
+	return rhs
 }

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -97,3 +97,38 @@ func TestBytesToString(t *testing.T) {
 		assert.Equal(str, String(bytes))
 	}
 }
+
+func TestGetMaxStartKey(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		lhs, rhs, expected string
+	}{
+		{"", "", ""},
+		{"", "a", "a"},
+		{"a", "a", "a"},
+	}
+
+	for _, c := range cases {
+		assert.Equal([]byte(c.expected), GetMaxStartKey([]byte(c.lhs), []byte(c.rhs)))
+		assert.Equal([]byte(c.expected), GetMaxStartKey([]byte(c.rhs), []byte(c.lhs)))
+	}
+}
+
+func TestGetMinEndKey(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		lhs, rhs, expected string
+	}{
+		{"", "", ""},
+		{"a", "", "a"},
+		{"a", "a", "a"},
+		{"a", "b", "a"},
+	}
+
+	for _, c := range cases {
+		assert.Equal([]byte(c.expected), GetMinEndKey([]byte(c.lhs), []byte(c.rhs)))
+		assert.Equal([]byte(c.expected), GetMinEndKey([]byte(c.rhs), []byte(c.lhs)))
+	}
+}


### PR DESCRIPTION
### Changes

- Get first key inside range of both region & txn chunk
  - Otherwise, commit request will have duplicated keys as all txn chunks in the same region will get the same key.
  - An alternative solution is just passing one key for every batch. But it's more reasonable that the commit keys is in the range of txn chunks.

### Manual Test

From logs of tikv:

`[cmd="kv::command::txn_file start_ts: 452262720810778627 chunk_ids: 452262720810778634 user_meta: 01030014638CC246060500FC668CC24606 shard_ver: 70 inner_lower_bound: 748000000000000036 inner_upper_bound: 7480000000000000665F72 \"kv::command::commit [7800000174800000FF00000000645F7280FF0000000000000200FE] 452262720810778627 -> 452262720876314629 | region_id: 1298 region_epoch { conf_ver: 17 version: 70 } peer { id: 1385 store_id: 4 } max_execution_duration_ms: 60000 api_version: V2 request_source: \\\"external_Insert\\\" resource_control_context { resource_group_name: \\\"default\\\" penalty {} override_priority: 8 } keyspace_id: 1\""]`


`[cmd="kv::command::txn_file start_ts: 452262720810778631 chunk_ids: 452262721217101826 chunk_ids: 452262721217101828 chunk_ids: 452262721217101825 chunk_ids: 452262721230209027 user_meta: 01070014638CC246060100CC688DC24606 shard_ver: 92 inner_lower_bound: 74800000000000006B5F7203800000000000000103800000000000000403800000000000000A inner_upper_bound: 74800000000000006B5F7203800000000000000103800000000000000403800000000000000E \"kv::command::commit [7800000174800000FF000000006B5F7203FF8000000000000001FF0380000000000000FF0403800000000000FF000A000000000000F9, 7800000174800000FF000000006B5F7203FF8000000000000001FF0380000000000000FF0403800000000000FF000B000000000000F9, 7800000174800000FF000000006B5F7203FF8000000000000001FF0380000000000000FF0403800000000000FF000C000000000000F9, 7800000174800000FF000000006B5F7203FF8000000000000001FF0380000000000000FF0403800000000000FF000D000000000000F9] 452262720810778631 -> 452262725201690625 | region_id: 2802 region_epoch { conf_ver: 11 version: 92 } peer { id: 2805 store_id: 6 } max_execution_duration_ms: 60000 api_version: V2 request_source: \\\"external_Insert\\\" resource_control_context { resource_group_name: \\\"default\\\" penalty {} override_priority: 8 } keyspace_id: 1\""]`


`[cmd="kv::command::txn_file start_ts: 452262720810778631 chunk_ids: 452262720968065025 chunk_ids: 452262720982220803 chunk_ids: 452262720994279425 chunk_ids: 452262720994279427 user_meta: 01070014638CC246060100CC688DC24606 shard_ver: 92 inner_lower_bound: 74800000000000006B5F698000000000000002038000000000000001038000000000000004014241524241524553FF4500000000000000F801516E67316932336EFF3978766875000000FC038000000000000001038000000000000004038000000000000012 inner_upper_bound: 74800000000000006B5F698000000000000002038000000000000001038000000000000004014241524241525052FF4553000000000000F9014F61596661337250FF0000000000000000F7038000000000000001038000000000000004038000000000000017 \"kv::command::commit [7800000174800000FF000000006B5F6980FF0000000000000203FF8000000000000001FF0380000000000000FF0401424152424152FF4553FF4500000000FF000000F801516E67FF316932336EFF3978FF766875000000FC03FF8000000000000001FF0380000000000000FF0403800000000000FF0012000000000000F9, 7800000174800000FF000000006B5F6980FF0000000000000203FF8000000000000001FF0380000000000000FF0401424152424152FF4F55FF4748540000FF000000FA01424434FF726A4D7247FF5670FF4E5A3761344AFF00FF00000000000000F7FF0380000000000000FF0103800000000000FF0004038000000000FF00000F0000000000FA, 7800000174800000FF000000006B5F6980FF0000000000000203FF8000000000000001FF0380000000000000FF0401424152424152FF4F55FF4748540000FF000000FA01655A53FF636D356E78FF504CFF000000000000F903FF8000000000000001FF0380000000000000FF0403800000000000FF000E000000000000F9, 7800000174800000FF000000006B5F6980FF0000000000000203FF8000000000000001FF0380000000000000FF0401424152424152FF4F55FF4748540000FF000000FA01794E67FF366A4D4176FF0000FF000000000000F703FF8000000000000001FF0380000000000000FF0403800000000000FF0002000000000000F9] 452262720810778631 -> 452262725201690625 | region_id: 2786 region_epoch { conf_ver: 11 version: 92 } peer { id: 2789 store_id: 6 } max_execution_duration_ms: 60000 api_version: V2 request_source: \\\"external_Insert\\\" resource_control_context { resource_group_name: \\\"default\\\" penalty {} override_priority: 8 } keyspace_id: 1\""]`
