### PR TITLE
config: change grpc-keepalive-timeout from uint to float64, for support millisecond timeout

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -154,7 +154,7 @@ func DefaultTiKVClient() TiKVClient {
 	return TiKVClient{
 		GrpcConnectionCount:       4,
 		GrpcKeepAliveTime:         10,
-		GrpcKeepAliveTimeout:      0.2,
+		GrpcKeepAliveTimeout:      3,
 		GrpcCompressionType:       "none",
 		GrpcSharedBufferPool:      false,
 		GrpcInitialWindowSize:     DefGrpcInitialWindowSize,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/stretchr/testify/assert"
@@ -75,4 +76,16 @@ func TestTxnScopeValue(t *testing.T) {
 
 	err = failpoint.Disable("tikvclient/injectTxnScope")
 	assert.Nil(t, err)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultTiKVClient()
+	assert.Nil(t, cfg.Valid())
+	assert.Equal(t, time.Millisecond*200, cfg.GetGrpcKeepAliveTimeout())
+	cfg.GrpcKeepAliveTimeout = 0.05
+	assert.Nil(t, cfg.Valid())
+	assert.Equal(t, time.Millisecond*50, cfg.GetGrpcKeepAliveTimeout())
+	cfg.GrpcKeepAliveTimeout = 0.04
+	assert.NotNil(t, cfg.Valid())
+	assert.Equal(t, "grpc-keepalive-timeout should be at least 0.05, but got 0.040000", cfg.Valid().Error())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -78,7 +78,7 @@ func TestTxnScopeValue(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestDefaultConfig(t *testing.T) {
+func TestValidateGRPCKeepAliveTimeout(t *testing.T) {
 	cfg := DefaultTiKVClient()
 	assert.Nil(t, cfg.Valid())
 	assert.Equal(t, time.Second*3, cfg.GetGrpcKeepAliveTimeout())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,7 +81,7 @@ func TestTxnScopeValue(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultTiKVClient()
 	assert.Nil(t, cfg.Valid())
-	assert.Equal(t, time.Millisecond*200, cfg.GetGrpcKeepAliveTimeout())
+	assert.Equal(t, time.Second*3, cfg.GetGrpcKeepAliveTimeout())
 	cfg.GrpcKeepAliveTimeout = 0.05
 	assert.Nil(t, cfg.Valid())
 	assert.Equal(t, time.Millisecond*50, cfg.GetGrpcKeepAliveTimeout())

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -303,7 +303,6 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 		a.batchConn.initMetrics(a.target)
 	}
 	keepAlive := cfg.TiKVClient.GrpcKeepAliveTime
-	keepAliveTimeout := cfg.TiKVClient.GrpcKeepAliveTimeout
 	for i := range a.v {
 		ctx, cancel := context.WithTimeout(context.Background(), a.dialTimeout)
 		var callOptions []grpc.CallOption
@@ -330,7 +329,7 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 			}),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:    time.Duration(keepAlive) * time.Second,
-				Timeout: time.Duration(keepAliveTimeout) * time.Second,
+				Timeout: cfg.TiKVClient.GetGrpcKeepAliveTimeout(),
 			}),
 		}, opts...)
 		if cfg.TiKVClient.GrpcSharedBufferPool {

--- a/internal/locate/store_cache.go
+++ b/internal/locate/store_cache.go
@@ -775,7 +775,6 @@ func createKVHealthClient(ctx context.Context, addr string) (*grpc.ClientConn, h
 		opt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 	keepAlive := cfg.TiKVClient.GrpcKeepAliveTime
-	keepAliveTimeout := cfg.TiKVClient.GrpcKeepAliveTimeout
 	conn, err := grpc.DialContext(
 		ctx,
 		addr,
@@ -793,7 +792,7 @@ func createKVHealthClient(ctx context.Context, addr string) (*grpc.ClientConn, h
 		}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    time.Duration(keepAlive) * time.Second,
-			Timeout: time.Duration(keepAliveTimeout) * time.Second,
+			Timeout: cfg.TiKVClient.GetGrpcKeepAliveTimeout(),
 		}),
 	)
 	if err != nil {

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -91,7 +91,7 @@ func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, erro
 			DialTimeout:          5 * time.Second,
 			TLS:                  tlsConfig,
 			DialKeepAliveTime:    time.Second * time.Duration(cfg.TiKVClient.GrpcKeepAliveTime),
-			DialKeepAliveTimeout: time.Second * time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout),
+			DialKeepAliveTimeout: cfg.TiKVClient.GetGrpcKeepAliveTimeout(),
 		},
 	)
 	if err != nil {
@@ -308,7 +308,7 @@ func NewPDClient(pdAddrs []string) (pd.Client, error) {
 			grpc.WithKeepaliveParams(
 				keepalive.ClientParameters{
 					Time:    time.Duration(cfg.TiKVClient.GrpcKeepAliveTime) * time.Second,
-					Timeout: time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout) * time.Second,
+					Timeout: cfg.TiKVClient.GetGrpcKeepAliveTimeout(),
 				},
 			),
 		),


### PR DESCRIPTION
- change `grpc-keepalive-timeout` from uint to float64, for support millisecond timeout