### PR TITLE
membuffer: implement snapshot get and iterator for ART

### DIFF
--- a/internal/unionstore/art/art_iterator.go
+++ b/internal/unionstore/art/art_iterator.go
@@ -84,6 +84,15 @@ func (it *Iterator) Value() []byte {
 	return it.tree.allocator.vlogAllocator.GetValue(it.currLeaf.vAddr)
 }
 
+// HasValue returns false if it is flags only.
+func (it *Iterator) HasValue() bool {
+	return !it.isFlagsOnly()
+}
+
+func (it *Iterator) isFlagsOnly() bool {
+	return it.currLeaf != nil && it.currLeaf.vAddr.IsNull()
+}
+
 func (it *Iterator) Next() error {
 	if !it.valid {
 		// iterate is finished

--- a/internal/unionstore/art/art_iterator.go
+++ b/internal/unionstore/art/art_iterator.go
@@ -50,7 +50,10 @@ func (t *ART) iter(lowerBound, upperBound []byte, reverse, includeFlags bool) (*
 		inner: &baseIter{
 			allocator: &t.allocator,
 		},
-		currAddr: arena.BadAddr, // the default value of currAddr is not equal to any valid address
+		// the default value of currAddr is not equal to any valid address
+		// arena.BadAddr's idx is maxuint32 - 1, which is impossible in common cases,
+		// this avoids the initial value of currAddr equals to endAddr.
+		currAddr: arena.BadAddr,
 		endAddr:  arena.NullAddr,
 	}
 	it.init(lowerBound, upperBound)

--- a/internal/unionstore/memdb.go
+++ b/internal/unionstore/memdb.go
@@ -49,7 +49,7 @@ type MemDBCheckpoint = arena.MemDBCheckpoint
 
 type MemKeyHandle = arena.MemKeyHandle
 
-type MemDB = rbtDBWithContext
+type MemDB = artDBWithContext
 
-var NewMemDB = newRbtDBWithContext
-var NewMemDBWithContext = newRbtDBWithContext
+var NewMemDB = newArtDBWithContext
+var NewMemDBWithContext = newArtDBWithContext

--- a/internal/unionstore/memdb_art.go
+++ b/internal/unionstore/memdb_art.go
@@ -118,7 +118,7 @@ func (db *artDBWithContext) FlushWait() error { return nil }
 
 // GetMemDB implements the MemBuffer interface.
 func (db *artDBWithContext) GetMemDB() *MemDB {
-	panic("unimplemented")
+	return db
 }
 
 // BatchGet returns the values for given keys from the MemBuffer.

--- a/internal/unionstore/memdb_art.go
+++ b/internal/unionstore/memdb_art.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:unused
 package unionstore
 
 import (
@@ -36,7 +35,6 @@ type artDBWithContext struct {
 	skipMutex bool
 }
 
-//nolint:unused
 func newArtDBWithContext() *artDBWithContext {
 	return &artDBWithContext{ART: art.New()}
 }

--- a/internal/unionstore/memdb_rbt.go
+++ b/internal/unionstore/memdb_rbt.go
@@ -125,7 +125,7 @@ func (db *rbtDBWithContext) FlushWait() error { return nil }
 
 // GetMemDB implements the MemBuffer interface.
 func (db *rbtDBWithContext) GetMemDB() *MemDB {
-	return db
+	return nil
 }
 
 // BatchGet returns the values for given keys from the MemBuffer.

--- a/internal/unionstore/memdb_rbt.go
+++ b/internal/unionstore/memdb_rbt.go
@@ -42,6 +42,7 @@ func newRbtDBWithContext() *rbtDBWithContext {
 	}
 }
 
+//nolint:unused
 func (db *rbtDBWithContext) setSkipMutex(skip bool) {
 	db.skipMutex = skip
 }

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -1089,21 +1089,19 @@ func testIterNoResult(t *testing.T, buffer MemBuffer) {
 	assert := assert.New(t)
 
 	assert.Nil(buffer.Set([]byte{1, 1}, []byte{1, 1}))
-	// Test lower bound and upper bound seek same position
-	iter, err := buffer.Iter([]byte{1, 0, 0}, []byte{1, 0, 1})
-	assert.Nil(err)
-	assert.False(iter.Valid())
-	iter, err = buffer.IterReverse([]byte{1, 0, 1}, []byte{1, 0, 0})
-	assert.Nil(err)
-	assert.False(iter.Valid())
-	// Test lower bound >= upper bound
-	iter, err = buffer.Iter([]byte{1, 0, 1}, []byte{1, 0, 0})
-	assert.Nil(err)
-	assert.False(iter.Valid())
-	iter, err = buffer.IterReverse([]byte{1, 0, 0}, []byte{1, 0, 1})
-	assert.Nil(err)
-	assert.False(iter.Valid())
-	iter, err = buffer.Iter([]byte{1, 1}, []byte{1, 1})
-	assert.Nil(err)
-	assert.False(iter.Valid())
+
+	checkFn := func(lowerBound, upperBound []byte) {
+		iter, err := buffer.Iter(lowerBound, upperBound)
+		assert.Nil(err)
+		assert.False(iter.Valid())
+		iter, err = buffer.IterReverse(upperBound, lowerBound)
+		assert.Nil(err)
+		assert.False(iter.Valid())
+	}
+
+	// Test lower bound and upper bound seek to the same position
+	checkFn([]byte{1, 1}, []byte{1, 1})
+	checkFn([]byte{1, 0, 0}, []byte{1, 0, 1})
+	// Test lower bound > upper bound
+	checkFn([]byte{1, 0, 1}, []byte{1, 0, 0})
 }

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -995,6 +995,7 @@ func testUnsetTemporaryFlag(t *testing.T, buffer MemBuffer) {
 
 func TestSnapshotGetIter(t *testing.T) {
 	testSnapshotGetIter(t, newRbtDBWithContext())
+	testSnapshotGetIter(t, newArtDBWithContext())
 }
 
 func testSnapshotGetIter(t *testing.T, db MemBuffer) {


### PR DESCRIPTION
ref pingcap/tidb#55287

This PR implements [Snapshot](https://github.com/tikv/client-go/blob/7d0f0bc93b5bae761fa1e7c9c4994686e6107cc3/internal/unionstore/union_store.go#L200-L205) and other methods of `MemBuffer` interface for ART.