### PR TITLE
membuffer: implement cache for ART

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
-	github.com/pingcap/kvproto v0.0.0-20240620063548-118a4cab53e4 // indirect
+	github.com/pingcap/kvproto v0.0.0-20240924080114-4a3e17f5e62d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect

--- a/internal/unionstore/art/art.go
+++ b/internal/unionstore/art/art.go
@@ -18,6 +18,7 @@ package art
 import (
 	"fmt"
 	"math"
+	"sync/atomic"
 
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/unionstore/arena"
@@ -44,6 +45,12 @@ type ART struct {
 	bufferSizeLimit uint64
 	len             int
 	size            int
+
+	// The lastTraversedNode stores addr in uint64 of the last traversed node, include Get and Set.
+	// Compare to atomic.Pointer, atomic.Uint64 can avoid heap allocation, so it's more efficient.
+	lastTraversedNode atomic.Uint64
+	hitCount          atomic.Uint64
+	missCount         atomic.Uint64
 }
 
 func New() *ART {
@@ -583,10 +590,31 @@ func (t *ART) RemoveFromBuffer(key []byte) {
 	panic("unimplemented")
 }
 
+// updateLastTraversed updates the last traversed node atomically
+func (t *ART) updateLastTraversed(addr arena.MemdbArenaAddr) {
+	//db.lastTraversedNode.Store(node.addr.AsU64())
+}
+
+// checkKeyInCache retrieves the last traversed node if the key matches
+func (t *ART) checkKeyInCache(key []byte) (*artLeaf, arena.MemdbArenaAddr, bool) {
+	//addrU64 := db.lastTraversedNode.Load()
+	//if addrU64 == arena.NullU64Addr {
+	//	return nullNodeAddr, false
+	//}
+	//addr := arena.U64ToAddr(addrU64)
+	//node := db.getNode(addr)
+	//
+	//if bytes.Equal(key, node.memdbNode.getKey()) {
+	//	return node, true
+	//}
+	//
+	//return nullNodeAddr, false
+}
+
 func (t *ART) GetCacheHitCount() uint64 {
-	return 0
+	return t.hitCount.Load()
 }
 
 func (t *ART) GetCacheMissCount() uint64 {
-	return 0
+	return t.missCount.Load()
 }

--- a/internal/unionstore/memdb_bench_test.go
+++ b/internal/unionstore/memdb_bench_test.go
@@ -242,7 +242,8 @@ func BenchmarkMemBufferCache(b *testing.B) {
 		for i := range buf {
 			buffer.Get(ctx, buf[i][:])
 			for j := 0; j < 10; j++ {
-				buffer.Get(ctx, buf[i][:]) // if cache hit, the second get will be fast
+				// the cache hit get will be fast
+				buffer.Get(ctx, buf[i][:])
 			}
 		}
 	}

--- a/internal/unionstore/memdb_bench_test.go
+++ b/internal/unionstore/memdb_bench_test.go
@@ -37,6 +37,7 @@ package unionstore
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"testing"
 )
@@ -228,4 +229,28 @@ func benchIterator(b *testing.B, buffer MemBuffer) {
 		}
 		iter.Close()
 	}
+}
+
+func BenchmarkMemBufferCache(b *testing.B) {
+	type CacheStats interface {
+		GetCacheHitCount() uint64
+		GetCacheMissCount() uint64
+	}
+	fn := func(b *testing.B, buffer MemBuffer) {
+		buf := make([][keySize]byte, b.N)
+		for i := range buf {
+			binary.LittleEndian.PutUint32(buf[i][:], uint32(i))
+			buffer.Set(buf[i][:], buf[i][:])
+		}
+		fmt.Printf("p1 hit: %d, miss: %d\n", buffer.(CacheStats).GetCacheHitCount(), buffer.(CacheStats).GetCacheMissCount())
+		ctx := context.Background()
+		b.ResetTimer()
+		for i := range buf {
+			buffer.Get(ctx, buf[i][:])
+			buffer.Get(ctx, buf[i][:]) // if cache hit, the second get will be fast
+		}
+		fmt.Printf("p2 hit: %d, miss: %d\n", buffer.(CacheStats).GetCacheHitCount(), buffer.(CacheStats).GetCacheMissCount())
+	}
+	b.Run("RBT", func(b *testing.B) { fn(b, newRbtDBWithContext()) })
+	b.Run("ART", func(b *testing.B) { fn(b, newArtDBWithContext()) })
 }

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -1135,6 +1135,9 @@ func testMemBufferCache(t *testing.T, buffer MemBuffer) {
 	}
 
 	cacheCheck(false, func() {
+		assert.Nil(buffer.Set([]byte{1}, []byte{0}))
+	})
+	cacheCheck(true, func() {
 		assert.Nil(buffer.Set([]byte{1}, []byte{1}))
 	})
 	cacheCheck(false, func() {

--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -1109,7 +1109,7 @@ func testIterNoResult(t *testing.T, buffer MemBuffer) {
 
 func TestMemBufferCache(t *testing.T) {
 	testMemBufferCache(t, newRbtDBWithContext())
-	//testMemBufferCache(t, newArtDBWithContext())
+	testMemBufferCache(t, newArtDBWithContext())
 }
 
 func testMemBufferCache(t *testing.T, buffer MemBuffer) {


### PR DESCRIPTION
ref pingcap/tidb#55287

ART can also benefit from the cache of last visited leaf, this PR implement the cache, it's almost same as RBT's implementation.

The test result of new added `BenchmarkMemBufferCache`:

```text
// RBT, with cache, 1 cache-miss and 10 cache-hits for each key
BenchmarkMemBufferCache/RBT
BenchmarkMemBufferCache/RBT-32          10000000               185.9 ns/op             0 B/op          0 allocs/op

// master, no cache, 11 cache-miss for each key
BenchmarkMemBufferCache/ART
BenchmarkMemBufferCache/ART-32          10000000               223.3 ns/op             0 B/op          0 allocs/op

// this PR, with cache, 1 cache-miss and 10 cache-hits for each key
BenchmarkMemBufferCache/ART
BenchmarkMemBufferCache/ART-32          10000000               126.6 ns/op             0 B/op          0 allocs/op
```