### PR TITLE
Do not broadcast txn status when heartbeat fail

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.21.0"
+        go-version: "1.23.0"
 
     - name: Checkout Client-Go
       uses: actions/checkout@v2

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1349,7 +1349,7 @@ func keepAlive(
 			}
 
 			// broadcast to all stores
-			if isPipelinedTxn {
+			if err != nil && isPipelinedTxn {
 				broadcastToAllStores(
 					c.txn,
 					c.store,

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1412,6 +1412,7 @@ func broadcastToAllStores(
 					ResourceGroupName: resourceGroupName,
 				}
 				req.Context.ResourceGroupTag = resourceGroupTag
+				req.Context.RequestSource = txn.GetRequestSource()
 
 				_, err := store.GetTiKVClient().SendRequest(
 					bo.GetCtx(),


### PR DESCRIPTION
This ensures that PK is the single source of truth for transaction status on the TiKV side. It prevents potential inconsistencies where the cached information might be more up-to-date than the info stored in the PK.