### PR TITLE
membuffer: fix data race when `IsReadOnly` and Set may be concurrently invoked

### DIFF
--- a/internal/unionstore/memdb_art.go
+++ b/internal/unionstore/memdb_art.go
@@ -138,6 +138,15 @@ func (db *artDBWithContext) BatchGet(ctx context.Context, keys [][]byte) (map[st
 	return m, nil
 }
 
+// Dirty implements the MemBuffer interface.
+func (db *artDBWithContext) Dirty() bool {
+	if !db.skipMutex {
+		db.RLock()
+		defer db.RUnlock()
+	}
+	return db.ART.Dirty()
+}
+
 // GetMetrics implements the MemBuffer interface.
 func (db *artDBWithContext) GetMetrics() Metrics { return Metrics{} }
 

--- a/internal/unionstore/memdb_rbt.go
+++ b/internal/unionstore/memdb_rbt.go
@@ -148,6 +148,15 @@ func (db *rbtDBWithContext) BatchGet(ctx context.Context, keys [][]byte) (map[st
 	return m, nil
 }
 
+// Dirty implements the MemBuffer interface.
+func (db *rbtDBWithContext) Dirty() bool {
+	if !db.skipMutex {
+		db.RLock()
+		defer db.RUnlock()
+	}
+	return db.RBT.Dirty()
+}
+
 // GetMetrics implements the MemBuffer interface.
 func (db *rbtDBWithContext) GetMetrics() Metrics { return Metrics{} }
 


### PR DESCRIPTION
ref pingcap/tidb#56178

TiDB concurrently call `IsReadOnly` and some write operations in union statement, so we need to avoid data race by mutex.