### PR TITLE
membuffer: compare the keys of ART by chunk

### DIFF
--- a/internal/unionstore/art/art_iterator.go
+++ b/internal/unionstore/art/art_iterator.go
@@ -360,8 +360,8 @@ func (it *baseIter) next() artNode {
 			if idx >= 0 && idx < int(n4.nodeNum) {
 				it.idxes[depth] = idx
 				child = &n4.children[idx]
-			} else if idx == int(n4.nodeNum) {
-				// idx == n4.nodeNum means this node is drain, break to pop stack.
+			} else if idx >= int(n4.nodeNum) {
+				// idx >= n4.nodeNum means this node is drain, break to pop stack.
 				break
 			} else {
 				panicForInvalidIndex(idx)
@@ -380,8 +380,8 @@ func (it *baseIter) next() artNode {
 			if idx >= 0 && idx < int(n16.nodeNum) {
 				it.idxes[depth] = idx
 				child = &n16.children[idx]
-			} else if idx == int(n16.nodeNum) {
-				// idx == n16.nodeNum means this node is drain, break to pop stack.
+			} else if idx >= int(n16.nodeNum) {
+				// idx >= n16.nodeNum means this node is drain, break to pop stack.
 				break
 			} else {
 				panicForInvalidIndex(idx)

--- a/internal/unionstore/art/art_node.go
+++ b/internal/unionstore/art/art_node.go
@@ -16,7 +16,6 @@ package art
 
 import (
 	"bytes"
-	"encoding/binary"
 	"math"
 	"math/bits"
 	"runtime"
@@ -59,22 +58,6 @@ const (
 	node256size = int(unsafe.Sizeof(node256{}))
 	leafSize    = int(unsafe.Sizeof(artLeaf{}))
 )
-
-var nativeEndian binary.ByteOrder
-
-func init() {
-	buf := [2]byte{}
-	*(*uint16)(unsafe.Pointer(&buf[0])) = uint16(0xABCD)
-
-	switch buf {
-	case [2]byte{0xCD, 0xAB}:
-		nativeEndian = binary.LittleEndian
-	case [2]byte{0xAB, 0xCD}:
-		nativeEndian = binary.BigEndian
-	default:
-		panic("Could not determine native endianness.")
-	}
-}
 
 var nullArtNode = artNode{kind: typeInvalid, addr: arena.NullAddr}
 

--- a/internal/unionstore/art/art_node.go
+++ b/internal/unionstore/art/art_node.go
@@ -385,8 +385,9 @@ func longestCommonPrefixByChunk(l1Key, l2Key artKey, depth uint32) uint32 {
 			xor := *(*uint64)(p1) ^ *(*uint64)(p2)
 			return limit - remaining + uint32(bits.TrailingZeros64(xor)>>3) - depth
 		}
-		p1 = unsafe.Pointer(uintptr(p1) + 8)
-		p2 = unsafe.Pointer(uintptr(p2) + 8)
+
+		p1 = unsafe.Add(p1, 8)
+		p2 = unsafe.Add(p2, 8)
 		remaining -= 8
 	}
 

--- a/internal/unionstore/art/art_node.go
+++ b/internal/unionstore/art/art_node.go
@@ -346,14 +346,14 @@ func (an *artNode) asNode256(a *artAllocator) *node256 {
 	return a.getNode256(an.addr)
 }
 
+// for amd64 and arm64 architectures, we use the chunk comparison to speed up finding the longest common prefix.
+const enableChunkComparison = runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64"
+
 // longestCommonPrefix returns the length of the longest common prefix of two keys.
 // the LCP is calculated from the given depth, you need to guarantee l1Key[:depth] equals to l2Key[:depth] before calling this function.
 func longestCommonPrefix(l1Key, l2Key artKey, depth uint32) uint32 {
-	switch runtime.GOARCH {
-	case "amd64", "arm64":
-		// for amd64 and arm64 architectures, we use the chunk comparison to accelerate the calculation.
+	if enableChunkComparison {
 		return longestCommonPrefixByChunk(l1Key, l2Key, depth)
-	default:
 	}
 	// For other architectures, we use the byte-by-byte comparison.
 	idx, limit := depth, uint32(min(len(l1Key), len(l2Key)))

--- a/internal/unionstore/art/art_node_test.go
+++ b/internal/unionstore/art/art_node_test.go
@@ -415,3 +415,14 @@ func TestMinimumNode(t *testing.T) {
 	check(typeNode48)
 	check(typeNode256)
 }
+
+func TestKey2Chunk(t *testing.T) {
+	key := artKey([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	for i := 0; i < len(key); i++ {
+		diffKey := make(artKey, len(key))
+		copy(diffKey, key)
+		diffKey[i] = 255
+		require.Equal(t, uint32(i), longestCommonPrefix(key, diffKey, 0))
+	}
+}


### PR DESCRIPTION
ref pingcap/tidb#55287

In order to perform path compression in ART, we need to find the longest common prefix the keys in many places, when the common prefix is long, this can be slow.

This PR compares the keys by chunk. Because a chunk is a uint64 which can contains 8 bytes, this can improve the performance a lot when the common prefix is long.

- Long Common Prefix
```
# before
BenchmarkMemBufferSetGetLongKey
BenchmarkMemBufferSetGetLongKey/ART
BenchmarkMemBufferSetGetLongKey/ART-32           1000000               874.3 ns/op          2149 B/op          0 allocs/op

# this PR
BenchmarkMemBufferSetGetLongKey
BenchmarkMemBufferSetGetLongKey/ART
BenchmarkMemBufferSetGetLongKey/ART-32           1000000               524.5 ns/op          2149 B/op          0 allocs/op
```

- Common Cases

```
# before
BenchmarkPut
BenchmarkPut/ART
BenchmarkPut/ART-32              1000000                91.70 ns/op          335 B/op          0 allocs/op
BenchmarkPutRandom
BenchmarkPutRandom/ART
BenchmarkPutRandom/ART-32                1000000               182.1 ns/op           404 B/op          0 allocs/op
BenchmarkGet
BenchmarkGet/ART
BenchmarkGet/ART-32                      1000000                31.31 ns/op            0 B/op          0 allocs/op
BenchmarkGetRandom
BenchmarkGetRandom/ART
BenchmarkGetRandom/ART-32                1000000               142.7 ns/op    

# this PR
BenchmarkPut
BenchmarkPut/ART
BenchmarkPut/ART-32              1000000                89.18 ns/op          335 B/op          0 allocs/op
BenchmarkPutRandom
BenchmarkPutRandom/ART
BenchmarkPutRandom/ART-32                1000000               175.8 ns/op           404 B/op          0 allocs/op
BenchmarkGet
BenchmarkGet/ART
BenchmarkGet/ART-32                      1000000                31.74 ns/op            0 B/op          0 allocs/op
BenchmarkGetRandom
BenchmarkGetRandom/ART
BenchmarkGetRandom/ART-32                1000000               132.5 ns/op   
```
