### PR TITLE
membuffer: fix memory leak in red-black tree

### DIFF
--- a/internal/unionstore/memdb_test.go
+++ b/internal/unionstore/memdb_test.go
@@ -1231,7 +1231,7 @@ func testMemBufferCache(t *testing.T, buffer MemBuffer) {
 }
 
 func TestMemDBLeafFragmentation(t *testing.T) {
-	// RBT cannot pass the leaf fragmentation test.
+	testMemDBLeafFragmentation(t, newRbtDBWithContext())
 	testMemDBLeafFragmentation(t, newArtDBWithContext())
 }
 

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -349,8 +349,7 @@ func (db *RBT) Set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 	// the NeedConstraintCheckInPrewrite flag is temporary,
 	// every write to the node removes the flag unless it's explicitly set.
 	// This set must be in the latest stage so no special processing is needed.
-	var flags kv.KeyFlags
-	flags = x.GetKeyFlags()
+	flags := x.GetKeyFlags()
 	if flags == 0 && x.vptr.IsNull() && x.isDeleted() {
 		db.count++
 		db.size += int(x.klen)
@@ -365,9 +364,6 @@ func (db *RBT) Set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 		db.dirty = true
 	}
 	x.setKeyFlags(flags)
-	if x.isDeleted() {
-		panic("")
-	}
 
 	if value == nil {
 		return nil

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -911,7 +911,7 @@ func (n *memdbNode) markDelete() {
 	n.flags = (nodeColorBit & n.flags) | deleteFlag
 }
 
-func (n *memdbNode) markUndelete() {
+func (n *memdbNode) unmarkDelete() {
 	n.flags &= ^deleteFlag
 }
 

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -124,8 +124,8 @@ func (db *RBT) RevertVAddr(hdr *arena.MemdbVlogHdr) {
 			db.count--
 			db.size -= int(node.klen)
 		} else {
-			node.setKeyFlags(keptFlags)
 			db.dirty = true
+			node.setKeyFlags(keptFlags)
 		}
 	} else {
 		db.size += len(db.vlog.GetValue(hdr.OldValue))
@@ -908,7 +908,7 @@ func (n *memdbNode) setKeyFlags(f kv.KeyFlags) {
 }
 
 func (n *memdbNode) markDelete() {
-	n.flags |= deleteFlag
+	n.flags = (nodeColorBit & n.flags) | deleteFlag
 }
 
 func (n *memdbNode) isDeleted() bool {

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -125,7 +125,7 @@ func (db *RBT) RevertVAddr(hdr *arena.MemdbVlogHdr) {
 			db.size -= int(node.klen)
 		} else {
 			db.dirty = true
-			node.setKeyFlags(keptFlags)
+			node.resetKeyFlags(keptFlags)
 		}
 	} else {
 		db.size += len(db.vlog.GetValue(hdr.OldValue))
@@ -364,7 +364,7 @@ func (db *RBT) Set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 	if flags.AndPersistent() != 0 {
 		db.dirty = true
 	}
-	x.setKeyFlags(flags)
+	x.resetKeyFlags(flags)
 
 	if value == nil {
 		return nil
@@ -903,7 +903,7 @@ func (n *memdbNode) getKeyFlags() kv.KeyFlags {
 	return kv.KeyFlags(n.flags & nodeFlagsMask)
 }
 
-func (n *memdbNode) setKeyFlags(f kv.KeyFlags) {
+func (n *memdbNode) resetKeyFlags(f kv.KeyFlags) {
 	n.flags = (^nodeFlagsMask & n.flags) | uint16(f)
 }
 

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -120,7 +120,9 @@ func (db *RBT) RevertVAddr(hdr *arena.MemdbVlogHdr) {
 		// If there are no flags associated with this key, we need to delete this node.
 		keptFlags := node.getKeyFlags().AndPersistent()
 		if keptFlags == 0 {
-			db.deleteNode(node)
+			node.markDelete()
+			db.count--
+			db.size -= int(node.klen)
 		} else {
 			node.setKeyFlags(keptFlags)
 			db.dirty = true
@@ -279,7 +281,7 @@ func (db *RBT) SelectValueHistory(key []byte, predicate func(value []byte) bool)
 // GetFlags returns the latest flags associated with key.
 func (db *RBT) GetFlags(key []byte) (kv.KeyFlags, error) {
 	x := db.traverse(key, false)
-	if x.isNull() {
+	if x.isNull() || x.isDeleted() {
 		return 0, tikverr.ErrNotExist
 	}
 	return x.getKeyFlags(), nil
@@ -348,16 +350,24 @@ func (db *RBT) Set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 	// every write to the node removes the flag unless it's explicitly set.
 	// This set must be in the latest stage so no special processing is needed.
 	var flags kv.KeyFlags
+	flags = x.GetKeyFlags()
+	if flags == 0 && x.vptr.IsNull() && x.isDeleted() {
+		db.count++
+		db.size += int(x.klen)
+	}
 	if value != nil {
-		flags = kv.ApplyFlagsOps(x.getKeyFlags(), append([]kv.FlagsOp{kv.DelNeedConstraintCheckInPrewrite}, ops...)...)
+		flags = kv.ApplyFlagsOps(flags, append([]kv.FlagsOp{kv.DelNeedConstraintCheckInPrewrite}, ops...)...)
 	} else {
 		// an UpdateFlag operation, do not delete the NeedConstraintCheckInPrewrite flag.
-		flags = kv.ApplyFlagsOps(x.getKeyFlags(), ops...)
+		flags = kv.ApplyFlagsOps(flags, ops...)
 	}
 	if flags.AndPersistent() != 0 {
 		db.dirty = true
 	}
 	x.setKeyFlags(flags)
+	if x.isDeleted() {
+		panic("")
+	}
 
 	if value == nil {
 		return nil
@@ -881,8 +891,11 @@ func (n *memdbNode) getKey() []byte {
 
 const (
 	// bit 1 => red, bit 0 => black
-	nodeColorBit  uint16 = 0x8000
-	nodeFlagsMask        = ^nodeColorBit
+	nodeColorBit uint16 = 0x8000
+	// bit 1 => node is deleted, bit 0 => node is not deleted
+	// This flag is used to mark a node as deleted, so that we can reuse the node to avoid memory leak.
+	deleteFlag    uint16 = 1 << 14
+	nodeFlagsMask        = ^(nodeColorBit | deleteFlag)
 )
 
 func (n *memdbNode) GetKeyFlags() kv.KeyFlags {
@@ -894,7 +907,16 @@ func (n *memdbNode) getKeyFlags() kv.KeyFlags {
 }
 
 func (n *memdbNode) setKeyFlags(f kv.KeyFlags) {
-	n.flags = (^nodeFlagsMask & n.flags) | uint16(f)
+	// only keep the color bit.
+	n.flags = (nodeColorBit & n.flags) | uint16(f)
+}
+
+func (n *memdbNode) markDelete() {
+	n.flags |= deleteFlag
+}
+
+func (n *memdbNode) isDeleted() bool {
+	return n.flags&deleteFlag != 0
 }
 
 // RemoveFromBuffer removes a record from the mem buffer. It should be only used for test.

--- a/internal/unionstore/rbt/rbt.go
+++ b/internal/unionstore/rbt/rbt.go
@@ -351,7 +351,7 @@ func (db *RBT) Set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 	// This set must be in the latest stage so no special processing is needed.
 	flags := x.GetKeyFlags()
 	if flags == 0 && x.vptr.IsNull() && x.isDeleted() {
-		x.markUndelete()
+		x.unmarkDelete()
 		db.count++
 		db.size += int(x.klen)
 	}

--- a/internal/unionstore/rbt/rbt_iterator.go
+++ b/internal/unionstore/rbt/rbt_iterator.go
@@ -199,6 +199,9 @@ func (i *RBTIterator) seekToFirst() {
 	}
 
 	i.curr = y
+	for !i.curr.isNull() && i.curr.isDeleted() {
+		i.curr = i.db.successor(i.curr)
+	}
 }
 
 func (i *RBTIterator) seekToLast() {
@@ -211,6 +214,9 @@ func (i *RBTIterator) seekToLast() {
 	}
 
 	i.curr = y
+	for !i.curr.isNull() && i.curr.isDeleted() {
+		i.curr = i.db.predecessor(i.curr)
+	}
 }
 
 func (i *RBTIterator) seek(key []byte) {

--- a/internal/unionstore/rbt/rbt_iterator.go
+++ b/internal/unionstore/rbt/rbt_iterator.go
@@ -119,7 +119,7 @@ func (i *RBTIterator) init() {
 		}
 	}
 
-	if i.isFlagsOnly() && !i.includeFlags {
+	if (i.isFlagsOnly() && !i.includeFlags) || (!i.curr.isNull() && i.curr.isDeleted()) {
 		err := i.Next()
 		_ = err // memdbIterator will never fail
 	}
@@ -172,6 +172,10 @@ func (i *RBTIterator) Next() error {
 			i.curr = i.db.predecessor(i.curr)
 		} else {
 			i.curr = i.db.successor(i.curr)
+		}
+
+		if i.curr.isDeleted() {
+			continue
 		}
 
 		// We need to skip persistent flags only nodes.

--- a/internal/unionstore/rbt/rbt_iterator.go
+++ b/internal/unionstore/rbt/rbt_iterator.go
@@ -142,7 +142,7 @@ func (i *RBTIterator) Flags() kv.KeyFlags {
 func (i *RBTIterator) UpdateFlags(ops ...kv.FlagsOp) {
 	origin := i.curr.getKeyFlags()
 	n := kv.ApplyFlagsOps(origin, ops...)
-	i.curr.setKeyFlags(n)
+	i.curr.resetKeyFlags(n)
 }
 
 // HasValue returns false if it is flags only.

--- a/internal/unionstore/rbt/rbt_test.go
+++ b/internal/unionstore/rbt/rbt_test.go
@@ -84,8 +84,16 @@ func TestDiscard(t *testing.T) {
 	}
 	it, _ := db.Iter(nil, nil)
 	it.seekToFirst()
+	// find a non-deleted key after seek.
+	for !it.curr.isNull() && it.curr.isDeleted() {
+		_ = it.Next()
+	}
 	assert.False(it.Valid())
 	it.seekToLast()
+	// find a non-deleted key after seek.
+	for !it.curr.isNull() && it.curr.isDeleted() {
+		_ = it.Next()
+	}
 	assert.False(it.Valid())
 	it.seek([]byte{0xff})
 	assert.False(it.Valid())

--- a/internal/unionstore/rbt/rbt_test.go
+++ b/internal/unionstore/rbt/rbt_test.go
@@ -84,16 +84,8 @@ func TestDiscard(t *testing.T) {
 	}
 	it, _ := db.Iter(nil, nil)
 	it.seekToFirst()
-	// find a non-deleted key after seek.
-	for !it.curr.isNull() && it.curr.isDeleted() {
-		_ = it.Next()
-	}
 	assert.False(it.Valid())
 	it.seekToLast()
-	// find a non-deleted key after seek.
-	for !it.curr.isNull() && it.curr.isDeleted() {
-		_ = it.Next()
-	}
 	assert.False(it.Valid())
 	it.seek([]byte{0xff})
 	assert.False(it.Valid())


### PR DESCRIPTION
close #1375, ref pingcap/tidb#56837

The issue #1375 figures out that the RBT membuffer cannot reuse free nodes which causes a memory leak. This pr uses marking the node as deleted to replace the actual deletion.

Pros:

- Because the memory arena cannot handle the memory fragmentation well, we avoid the memory leak by this mark-delete strategy.

Cons:

- In certain cases, the mark-delete tree may be taller than the actual deletion, which can slightly impact the performance.
 