### PR TITLE
clean up locks when p-dml is failed

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1608,8 +1608,32 @@ func (c *twoPhaseCommitter) cleanup(ctx context.Context) {
 		cleanupKeysCtx := context.WithValue(c.store.Ctx(), retry.TxnStartKey, ctx.Value(retry.TxnStartKey))
 		var err error
 		if c.txn.IsPipelined() {
-			// TODO: cleanup pipelined txn
-			// TODO: broadcast txn status
+			if len(c.pipelinedCommitInfo.pipelinedStart) != 0 && len(c.pipelinedCommitInfo.pipelinedEnd) != 0 {
+				broadcastToAllStores(
+					c.txn,
+					c.store,
+					retry.NewBackofferWithVars(
+						ctx,
+						broadcastMaxBackoff,
+						c.txn.vars,
+					),
+					&kvrpcpb.TxnStatus{
+						StartTs:     c.startTS,
+						MinCommitTs: c.txn.committer.minCommitTSMgr.get(),
+						CommitTs:    0,
+						RolledBack:  true,
+						IsCompleted: false,
+					},
+					c.resourceGroupName,
+					c.resourceGroupTag,
+				)
+				c.resolveFlushedLocks(
+					retry.NewBackofferWithVars(cleanupKeysCtx, cleanupMaxBackoff, c.txn.vars),
+					c.pipelinedCommitInfo.pipelinedStart,
+					c.pipelinedCommitInfo.pipelinedEnd,
+					false,
+				)
+			}
 		} else if !c.isOnePC() {
 			err = c.cleanupMutations(retry.NewBackofferWithVars(cleanupKeysCtx, cleanupMaxBackoff, c.txn.vars), c.mutations)
 		} else if c.isPessimistic {

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -388,8 +388,8 @@ func (c *twoPhaseCommitter) buildPipelinedResolveHandler(commit bool, resolved *
 		Priority:         c.priority,
 		SyncLog:          c.syncLog,
 		ResourceGroupTag: c.resourceGroupTag,
-		DiskFullOpt:      c.txn.diskFullOpt,
-		TxnSource:        c.txn.txnSource,
+		DiskFullOpt:      c.diskFullOpt,
+		TxnSource:        c.txnSource,
 		RequestSource:    PipelinedRequestSource,
 		ResourceControlContext: &kvrpcpb.ResourceControlContext{
 			ResourceGroupName: c.resourceGroupName,


### PR DESCRIPTION
Ref: tikv/tikv#17459

When the pipelined transaction is failed in commit phase, we should also broadcast the txn status and cleanup failed locks.

## Test

Manually inject error when committing primary key of pipelined transaction. 

```sql
MySQL [test]> set session tidb_dml_type=bulk;
Query OK, 0 rows affected (0.000 sec)

MySQL [test]> insert into _sbtest1 select * from sbtest1;
ERROR 1105 (HY000): [pipelined dml] mock error
```

- Before, the locks can block resolved  ts.

![image](https://github.com/user-attachments/assets/9cf043df-a502-4953-9ca7-508519289627)


- This PR, the resolved ts is not blocked.

![image](https://github.com/user-attachments/assets/83ea9ea0-706a-41fe-9d5b-821eaca5db35)
