### PR TITLE
Export commitTS of KVTxn

### DIFF
--- a/integration_tests/1pc_test.go
+++ b/integration_tests/1pc_test.go
@@ -112,12 +112,12 @@ func (s *testOnePCSuite) Test1PC() {
 	s.Equal(txn.GetCommitter().GetOnePCCommitTS(), txn.GetCommitter().GetCommitTS())
 	s.Greater(txn.GetCommitter().GetOnePCCommitTS(), txn.StartTS())
 	// Check keys are committed with the same version
-	s.mustGetFromSnapshot(txn.GetCommitTS(), k3, v3)
-	s.mustGetFromSnapshot(txn.GetCommitTS(), k4, v4)
-	s.mustGetFromSnapshot(txn.GetCommitTS(), k5, v5)
-	s.mustGetNoneFromSnapshot(txn.GetCommitTS()-1, k3)
-	s.mustGetNoneFromSnapshot(txn.GetCommitTS()-1, k4)
-	s.mustGetNoneFromSnapshot(txn.GetCommitTS()-1, k5)
+	s.mustGetFromSnapshot(txn.CommitTS(), k3, v3)
+	s.mustGetFromSnapshot(txn.CommitTS(), k4, v4)
+	s.mustGetFromSnapshot(txn.CommitTS(), k5, v5)
+	s.mustGetNoneFromSnapshot(txn.CommitTS()-1, k3)
+	s.mustGetNoneFromSnapshot(txn.CommitTS()-1, k4)
+	s.mustGetNoneFromSnapshot(txn.CommitTS()-1, k5)
 
 	// Overwriting in MVCC
 	v5New := []byte("v5new")
@@ -129,8 +129,8 @@ func (s *testOnePCSuite) Test1PC() {
 	s.True(txn.GetCommitter().IsOnePC())
 	s.Equal(txn.GetCommitter().GetOnePCCommitTS(), txn.GetCommitter().GetCommitTS())
 	s.Greater(txn.GetCommitter().GetOnePCCommitTS(), txn.StartTS())
-	s.mustGetFromSnapshot(txn.GetCommitTS(), k5, v5New)
-	s.mustGetFromSnapshot(txn.GetCommitTS()-1, k5, v5)
+	s.mustGetFromSnapshot(txn.CommitTS(), k5, v5New)
+	s.mustGetFromSnapshot(txn.CommitTS()-1, k5, v5)
 
 	// Check all keys
 	keys := [][]byte{k1, k2, k3, k4, k5}
@@ -175,8 +175,8 @@ func (s *testOnePCSuite) Test1PCIsolation() {
 	s.mustGetFromTxn(txn2, k, v1)
 	s.Nil(txn2.Rollback())
 
-	s.mustGetFromSnapshot(txn.GetCommitTS(), k, v2)
-	s.mustGetFromSnapshot(txn.GetCommitTS()-1, k, v1)
+	s.mustGetFromSnapshot(txn.CommitTS(), k, v2)
+	s.mustGetFromSnapshot(txn.CommitTS()-1, k, v1)
 }
 
 func (s *testOnePCSuite) Test1PCDisallowMultiRegion() {

--- a/integration_tests/assertion_test.go
+++ b/integration_tests/assertion_test.go
@@ -81,7 +81,7 @@ func (s *testAssertionSuite) testAssertionImpl(keyPrefix string, pessimistic boo
 	err = prepareTxn.Commit(context.Background())
 	s.Nil(err)
 	prepareStartTS := prepareTxn.GetCommitter().GetStartTS()
-	prepareCommitTS := prepareTxn.GetCommitTS()
+	prepareCommitTS := prepareTxn.CommitTS()
 
 	// A helper to perform a complete transaction. When multiple keys are passed in, assertion will be set on only
 	// the last key.

--- a/integration_tests/async_commit_test.go
+++ b/integration_tests/async_commit_test.go
@@ -112,7 +112,7 @@ func (s *testAsyncCommitCommon) putKV(key, value []byte, enableAsyncCommit bool)
 	s.Nil(err)
 	err = txn.Commit(context.Background())
 	s.Nil(err)
-	return txn.StartTS(), txn.GetCommitTS()
+	return txn.StartTS(), txn.CommitTS()
 }
 
 func (s *testAsyncCommitCommon) mustGetFromTxn(txn transaction.TxnProbe, key, expectedValue []byte) {
@@ -440,8 +440,8 @@ func (s *testAsyncCommitSuite) TestAsyncCommitLinearizability() {
 	s.Nil(err)
 	err = t1.Commit(ctx)
 	s.Nil(err)
-	commitTS1 := t1.GetCommitTS()
-	commitTS2 := t2.GetCommitTS()
+	commitTS1 := t1.CommitTS()
+	commitTS2 := t2.CommitTS()
 	s.Less(commitTS2, commitTS1)
 }
 

--- a/integration_tests/isolation_test.go
+++ b/integration_tests/isolation_test.go
@@ -96,7 +96,7 @@ func (s *testIsolationSuite) SetWithRetry(k, v []byte) writeRecord {
 		if err == nil {
 			return writeRecord{
 				startTS:  txn.StartTS(),
-				commitTS: txn.GetCommitTS(),
+				commitTS: txn.CommitTS(),
 			}
 		}
 	}

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -142,7 +142,7 @@ func (s *testLockSuite) putKV(key, value []byte) (uint64, uint64) {
 	s.Nil(err)
 	err = txn.Commit(context.Background())
 	s.Nil(err)
-	return txn.StartTS(), txn.GetCommitTS()
+	return txn.StartTS(), txn.CommitTS()
 }
 
 func (s *testLockSuite) prepareAlphabetLocks() {
@@ -1311,7 +1311,7 @@ func (s *testLockWithTiKVSuite) TestPrewriteCheckForUpdateTS() {
 			info := simulatedTxn.GetAggressiveLockingKeysInfo()
 			s.Equal(1, len(info))
 			s.Equal(k1, info[0].Key())
-			s.Equal(txn2.GetCommitTS(), info[0].ActualLockForUpdateTS())
+			s.Equal(txn2.CommitTS(), info[0].ActualLockForUpdateTS())
 
 			simulatedTxn.DoneAggressiveLocking(context.Background())
 			defer func() {
@@ -1324,12 +1324,12 @@ func (s *testLockWithTiKVSuite) TestPrewriteCheckForUpdateTS() {
 		s.Error(err)
 		s.Regexp("[pP]essimistic ?[lL]ock ?[nN]ot ?[fF]ound", err.Error())
 
-		snapshot := s.store.GetSnapshot(txn2.GetCommitTS())
+		snapshot := s.store.GetSnapshot(txn2.CommitTS())
 		v, err := snapshot.Get(context.Background(), k1)
 		s.NoError(err)
 		s.Equal(v2, v)
 
-		snapshot = s.store.GetSnapshot(txn2.GetCommitTS() - 1)
+		snapshot = s.store.GetSnapshot(txn2.CommitTS() - 1)
 		_, err = snapshot.Get(context.Background(), k1)
 		s.Equal(tikverr.ErrNotExist, err)
 
@@ -1369,7 +1369,7 @@ func (s *testLockWithTiKVSuite) TestPrewriteCheckForUpdateTS() {
 
 		s.NoError(txn.Commit(ctx))
 
-		snapshot = s.store.GetSnapshot(txn.GetCommitTS())
+		snapshot = s.store.GetSnapshot(txn.CommitTS())
 		v, err = snapshot.Get(context.Background(), k2)
 		s.NoError(err)
 		s.Equal(v1, v)
@@ -1377,7 +1377,7 @@ func (s *testLockWithTiKVSuite) TestPrewriteCheckForUpdateTS() {
 		s.NoError(err)
 		s.Equal(v1, v)
 
-		snapshot = s.store.GetSnapshot(txn.GetCommitTS() - 1)
+		snapshot = s.store.GetSnapshot(txn.CommitTS() - 1)
 		v, err = snapshot.Get(context.Background(), k2)
 		s.NoError(err)
 		s.Equal(v2, v)

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -38,11 +38,6 @@ func (txn TxnProbe) SetStartTS(ts uint64) {
 	txn.startTS = ts
 }
 
-// GetCommitTS returns the commit ts.
-func (txn TxnProbe) GetCommitTS() uint64 {
-	return txn.commitTS
-}
-
 // GetUnionStore returns transaction's embedded unionstore.
 func (txn TxnProbe) GetUnionStore() *unionstore.KVUnionStore {
 	return txn.us

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1704,6 +1704,10 @@ func (txn *KVTxn) StartTS() uint64 {
 	return txn.startTS
 }
 
+func (txn *KVTxn) CommitTS() uint64 {
+	return txn.commitTS
+}
+
 // Valid returns if the transaction is valid.
 // A transaction become invalid after commit or rollback.
 func (txn *KVTxn) Valid() bool {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1704,6 +1704,7 @@ func (txn *KVTxn) StartTS() uint64 {
 	return txn.startTS
 }
 
+// CommitTS returns the commit timestamp of the already committed transaction, or zero if it's not committed yet.
 func (txn *KVTxn) CommitTS() uint64 {
 	return txn.commitTS
 }


### PR DESCRIPTION
Ref: https://github.com/pingcap/tidb/issues/57165
Close: https://github.com/tikv/client-go/issues/1488

Export KVTxn.CommitTS to make it available in TiDB.