### PR TITLE
Fix the problem that adaptive update interval doesn't recovers back and there's too much logs about setting the config

### DIFF
--- a/oracle/oracles/pd.go
+++ b/oracle/oracles/pd.go
@@ -473,6 +473,8 @@ func (o *pdOracle) updateTS(ctx context.Context) {
 	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 
+	// Note that as `doUpdate` updates last tick time while `nextUpdateInterval` may perform calculation depending on the
+	// last tick time, `doUpdate` should be called after finishing calculating the next interval.
 	doUpdate := func(now time.Time) {
 		// Update the timestamp for each txnScope
 		o.lastTSMap.Range(func(key, _ interface{}) bool {
@@ -492,9 +494,12 @@ func (o *pdOracle) updateTS(ctx context.Context) {
 	for {
 		select {
 		case now := <-ticker.C:
+			// nextUpdateInterval has calculation that depends on the time of the last tick. Calculate next interval
+			// before `doUpdate` as `doUpdate` is responsible for updating the time of the last tick.
+			newInterval := o.nextUpdateInterval(now, 0)
+
 			doUpdate(now)
 
-			newInterval := o.nextUpdateInterval(now, 0)
 			if newInterval != currentInterval {
 				currentInterval = newInterval
 				ticker.Reset(currentInterval)
@@ -556,6 +561,11 @@ func (o *pdOracle) SetLowResolutionTimestampUpdateInterval(newUpdateInterval tim
 
 	prevConfigured := o.lastTSUpdateInterval.Swap(int64(newUpdateInterval))
 	adaptiveUpdateInterval := o.adaptiveLastTSUpdateInterval.Load()
+
+	if newUpdateInterval == time.Duration(prevConfigured) {
+		// The config is unchanged. Do nothing.
+		return nil
+	}
 
 	var adaptiveUpdateIntervalUpdated bool
 


### PR DESCRIPTION
Found and fixed these problems:

1. As updating last tick time is  moved into the `doUpdate` closure, and `nextUpdateInterval` calculates the value of recovering based on the last tick time, it causes the update interval unable to recover back.
2. TiDB calls `SetLowResolutionTimestampUpdateInterval` [every 30 seconds no matter whether the user changes it](https://github.com/pingcap/tidb/blob/153d5aaa3859a2a7c10150e2724e7edba1096b14/pkg/domain/domain.go#L1867). After adding the log about changing the update interval, then there becomes too many logs.