### PR TITLE
Handle error invalid_max_ts_update

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1742,6 +1742,12 @@ func (s *RegionRequestSender) onRegionError(
 	}
 
 	if isInvalidMaxTsUpdate(regionErr) {
+		logutil.Logger(bo.GetCtx()).Error(
+			"tikv reports `InvalidMaxTsUpdate`",
+			zap.String("message", regionErr.GetMessage()),
+			zap.Stringer("req", req),
+			zap.Stringer("ctx", ctx),
+		)
 		return false, errors.New(regionErr.String())
 	}
 


### PR DESCRIPTION
Ref https://github.com/tikv/tikv/issues/17916

The error will directly propagate to user and abort current stmt.

The string match is more suitable for cherry-picking to older versions, we may consider introducing a new error type in master branch.