### PR TITLE
[WIP] add tidwall/btree support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/tidwall/btree v1.7.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230711005742-c3f37128e5a4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_model v0.5.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a
+	github.com/tidwall/btree v1.7.0
 	github.com/tikv/pd/client v0.0.0-20241111073742-238d4d79ea31
 	github.com/twmb/murmur3 v1.1.3
 	go.etcd.io/etcd/api/v3 v3.5.10
@@ -46,7 +47,6 @@ require (
 	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
-	github.com/tidwall/btree v1.7.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230711005742-c3f37128e5a4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
+github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
+github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tikv/pd/client v0.0.0-20241111073742-238d4d79ea31 h1:oAYc4m5Eu1OY9ogJ103VO47AYPHvhtzbUPD8L8B67Qk=
 github.com/tikv/pd/client v0.0.0-20241111073742-238d4d79ea31/go.mod h1:W5a0sDadwUpI9k8p7M77d3jo253ZHdmua+u4Ho4Xw8U=
 github.com/twmb/murmur3 v1.1.3 h1:D83U0XYKcHRYwYIpBKf3Pks91Z0Byda/9SJ8B6EMRcA=

--- a/internal/locate/sorted_btree_test.go
+++ b/internal/locate/sorted_btree_test.go
@@ -1,0 +1,248 @@
+// Copyright 2022 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locate
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function to create test regions
+func createTestRegion(id uint64, startKey, endKey []byte) *Region {
+	return &Region{
+		meta: &metapb.Region{
+			Id:          id,
+			StartKey:    startKey,
+			EndKey:      endKey,
+			RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVer: 1},
+		},
+		ttl: time.Now().Unix() + 600, // 10 minutes TTL
+	}
+}
+
+func TestSortedRegionsComparison(t *testing.T) {
+	btree := NewSortedRegions(32)
+	btreeV2 := NewSortedRegionsV2(32)
+
+	t.Run("ReplaceOrInsert", func(t *testing.T) {
+		regions := []*Region{
+			createTestRegion(1, []byte("a"), []byte("b")),
+			createTestRegion(2, []byte("b"), []byte("c")),
+			createTestRegion(3, []byte("c"), []byte("d")),
+		}
+
+		for _, r := range regions {
+			old1 := btree.ReplaceOrInsert(r)
+			old2 := btreeV2.ReplaceOrInsert(r)
+			require.Equal(t, old1, old2, "ReplaceOrInsert should return same result")
+		}
+
+		// Test replacing existing region
+		updatedRegion := createTestRegion(1, []byte("a"), []byte("b"))
+		old1 := btree.ReplaceOrInsert(updatedRegion)
+		old2 := btreeV2.ReplaceOrInsert(updatedRegion)
+		require.Equal(t, old1, old2, "ReplaceOrInsert should return same result for updates")
+	})
+
+	t.Run("SearchByKey", func(t *testing.T) {
+		testCases := []struct {
+			key      []byte
+			isEndKey bool
+		}{
+			{[]byte("a"), false},
+			{[]byte("b"), false},
+			{[]byte("b"), true},
+			{[]byte("c"), false},
+			{[]byte("d"), false},
+			{[]byte("e"), false}, // non-existent key
+		}
+
+		for _, tc := range testCases {
+			r1 := btree.SearchByKey(tc.key, tc.isEndKey)
+			r2 := btreeV2.SearchByKey(tc.key, tc.isEndKey)
+
+			if r1 == nil {
+				require.Nil(t, r2, "Both implementations should return nil for key %s", tc.key)
+			} else {
+				require.NotNil(t, r2, "Both implementations should return non-nil for key %s", tc.key)
+				require.True(t, bytes.Equal(r1.StartKey(), r2.StartKey()),
+					"Start keys should match for key %s", tc.key)
+				require.True(t, bytes.Equal(r1.EndKey(), r2.EndKey()),
+					"End keys should match for key %s", tc.key)
+			}
+		}
+	})
+
+	t.Run("AscendGreaterOrEqual", func(t *testing.T) {
+		testCases := []struct {
+			startKey []byte
+			endKey   []byte
+			limit    int
+		}{
+			{[]byte("a"), []byte("c"), 2},
+			{[]byte("b"), []byte("d"), 2},
+			{[]byte("a"), []byte("d"), 3},
+			{[]byte("d"), []byte("e"), 1}, // beyond existing regions
+		}
+
+		for _, tc := range testCases {
+			regions1 := btree.AscendGreaterOrEqual(tc.startKey, tc.endKey, tc.limit)
+			regions2 := btreeV2.AscendGreaterOrEqual(tc.startKey, tc.endKey, tc.limit)
+
+			require.Equal(t, len(regions1), len(regions2),
+				"Should return same number of regions for range [%s, %s]", tc.startKey, tc.endKey)
+
+			for i := range regions1 {
+				require.True(t, bytes.Equal(regions1[i].StartKey(), regions2[i].StartKey()),
+					"Start keys should match for range [%s, %s]", tc.startKey, tc.endKey)
+				require.True(t, bytes.Equal(regions1[i].EndKey(), regions2[i].EndKey()),
+					"End keys should match for range [%s, %s]", tc.startKey, tc.endKey)
+			}
+		}
+	})
+
+	t.Run("RemoveIntersecting", func(t *testing.T) {
+		region := createTestRegion(4, []byte("b"), []byte("c"))
+		verID := RegionVerID{id: 4, ver: 1, confVer: 1}
+
+		deleted1, stale1 := btree.removeIntersecting(region, verID)
+		deleted2, stale2 := btreeV2.removeIntersecting(region, verID)
+
+		require.Equal(t, stale1, stale2, "Stale flag should match")
+		require.Equal(t, len(deleted1), len(deleted2), "Should delete same number of items")
+	})
+
+	t.Run("ValidRegionsInBtree", func(t *testing.T) {
+		now := time.Now().Unix()
+		count1 := btree.ValidRegionsInBtree(now)
+		count2 := btreeV2.ValidRegionsInBtree(now)
+		require.Equal(t, count1, count2, "Should have same number of valid regions")
+	})
+
+	t.Run("Clear", func(t *testing.T) {
+		btree.Clear()
+		btreeV2.Clear()
+
+		now := time.Now().Unix()
+		require.Equal(t, 0, btree.ValidRegionsInBtree(now), "Btree should be empty after clear")
+		require.Equal(t, 0, btreeV2.ValidRegionsInBtree(now), "BtreeV2 should be empty after clear")
+	})
+}
+
+func BenchmarkSortedRegions_SearchByKey(b *testing.B) {
+	btree := NewSortedRegions(32)
+	btreeV2 := NewSortedRegionsV2(32)
+
+	// Create 10000 regions with sequential keys
+	for i := 0; i < 10000; i++ {
+		start := []byte(fmt.Sprintf("key%09d", i)) // key000000001, key000000002, etc.
+		end := []byte(fmt.Sprintf("key%09d", i+1))
+		region := createTestRegion(uint64(i+1), start, end)
+		btree.ReplaceOrInsert(region)
+		btreeV2.ReplaceOrInsert(region)
+	}
+
+	// Create some test keys for searching
+	testKey := []byte("key000005000") // Middle of the range
+
+	b.Run("SearchByKey/Original", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btree.SearchByKey(testKey, false)
+		}
+	})
+
+	b.Run("SearchByKey/V2", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btreeV2.SearchByKey(testKey, false)
+		}
+	})
+}
+
+func BenchmarkSortedRegions_ReplaceOrInsert(b *testing.B) {
+	btree := NewSortedRegions(32)
+	btreeV2 := NewSortedRegionsV2(32)
+
+	// Create 10000 regions with random keys
+	regions := make([]*Region, 10000)
+	for i := 0; i < 10000; i++ {
+		// Generate random key with prefix to ensure good distribution
+		start := []byte(fmt.Sprintf("key%09d", rand.Intn(1000000)))
+		end := []byte(fmt.Sprintf("key%09d", rand.Intn(1000000)))
+		if bytes.Compare(start, end) > 0 {
+			// Ensure start key is less than end key
+			start, end = end, start
+		}
+		regions[i] = createTestRegion(uint64(i+1), start, end)
+	}
+
+	b.Run("ReplaceOrInsert/Original", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btree.ReplaceOrInsert(regions[i%10000])
+		}
+	})
+
+	b.Run("ReplaceOrInsert/V2", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btreeV2.ReplaceOrInsert(regions[i%10000])
+		}
+	})
+}
+
+func BenchmarkSortedRegions_AscendGreaterOrEqual(b *testing.B) {
+	btree := NewSortedRegions(32)
+	btreeV2 := NewSortedRegionsV2(32)
+
+	// Create 10000 regions with sequential keys
+	regions := make([]*Region, 10000)
+	for i := 0; i < 10000; i++ {
+		start := []byte(fmt.Sprintf("key%09d", i))
+		end := []byte(fmt.Sprintf("key%09d", i+1))
+		regions[i] = createTestRegion(uint64(i+1), start, end)
+	}
+
+	// Insert all regions into both trees
+	for i := 0; i < 10000; i++ {
+		btree.ReplaceOrInsert(regions[i])
+		btreeV2.ReplaceOrInsert(regions[i])
+	}
+
+	// Pick a random start key for benchmarking
+	testKey := []byte(fmt.Sprintf("key%09d", 5000))
+	endKey := []byte(fmt.Sprintf("key%09d", 6000))
+
+	b.Run("AscendGreaterOrEqual/Original", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btree.AscendGreaterOrEqual(testKey, endKey, 100)
+		}
+	})
+
+	b.Run("AscendGreaterOrEqual/V2", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			btreeV2.AscendGreaterOrEqual(testKey, endKey, 100)
+		}
+	})
+}

--- a/internal/locate/sorted_btreev2.go
+++ b/internal/locate/sorted_btreev2.go
@@ -1,0 +1,133 @@
+// Copyright 2022 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locate
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/tidwall/btree"
+	"github.com/tikv/client-go/v2/internal/logutil"
+	"go.uber.org/zap"
+)
+
+// SortedRegionsV2 is a sorted btree.
+type SortedRegionsV2 struct {
+	b *btree.BTreeG[*btreeItem]
+}
+
+// NewSortedRegions returns a new SortedRegions.
+func NewSortedRegionsV2(_ int) *SortedRegionsV2 {
+	return &SortedRegionsV2{
+		b: btree.NewBTreeG(
+			func(a, b *btreeItem) bool { return a.Less(b) }),
+	}
+}
+
+// ReplaceOrInsert inserts a new item into the btree.
+func (s *SortedRegionsV2) ReplaceOrInsert(cachedRegion *Region) *Region {
+	old, ok := s.b.Set(newBtreeItem(cachedRegion))
+	if !ok {
+		return nil
+	}
+
+	return old.cachedRegion
+}
+
+// SearchByKey returns the region which contains the key. Note that the region might be expired and it's caller's duty to check the region TTL.
+func (s *SortedRegionsV2) SearchByKey(key []byte, isEndKey bool) (r *Region) {
+	s.b.Descend(newBtreeSearchItem(key), func(item *btreeItem) bool {
+		region := item.cachedRegion
+		if isEndKey && bytes.Equal(region.StartKey(), key) {
+			return true // iterate next item
+		}
+		if !isEndKey && region.Contains(key) || isEndKey && region.ContainsByEnd(key) {
+			r = region
+		}
+		return false
+	})
+	return
+}
+
+// AscendGreaterOrEqual returns all items that are greater than or equal to the key.
+// It is the caller's responsibility to make sure that startKey is a node in the B-tree, otherwise, the startKey will not be included in the return regions.
+func (s *SortedRegionsV2) AscendGreaterOrEqual(startKey, endKey []byte, limit int) (regions []*Region) {
+	now := time.Now().Unix()
+	lastStartKey := startKey
+
+	s.b.Ascend(newBtreeSearchItem(startKey), func(item *btreeItem) bool {
+		region := item.cachedRegion
+		if len(endKey) > 0 && bytes.Compare(region.StartKey(), endKey) >= 0 {
+			return false
+		}
+		if !region.checkRegionCacheTTL(now) {
+			return false
+		}
+		if !region.Contains(lastStartKey) { // uncached hole
+			return false
+		}
+		lastStartKey = region.EndKey()
+		regions = append(regions, region)
+		return len(regions) < limit
+	})
+	return regions
+}
+
+// removeIntersecting removes all items that have intersection with the key range of given region.
+// If the region itself is in the cache, it's not removed.
+func (s *SortedRegionsV2) removeIntersecting(r *Region, verID RegionVerID) ([]*btreeItem, bool) {
+	var deleted []*btreeItem
+	var stale bool
+
+	s.b.Ascend(newBtreeSearchItem(r.StartKey()), func(item *btreeItem) bool {
+		if len(r.EndKey()) > 0 && bytes.Compare(item.cachedRegion.StartKey(), r.EndKey()) >= 0 {
+			return false
+		}
+		if item.cachedRegion.meta.GetRegionEpoch().GetVersion() > verID.ver {
+			logutil.BgLogger().Debug("get stale region",
+				zap.Uint64("region", verID.GetID()), zap.Uint64("ver", verID.GetVer()), zap.Uint64("conf", verID.GetConfVer()),
+				zap.Uint64("intersecting-ver", item.cachedRegion.meta.GetRegionEpoch().GetVersion()))
+			stale = true
+			return false
+		}
+		deleted = append(deleted, item)
+		return true
+	})
+	if stale {
+		return nil, true
+	}
+	for _, item := range deleted {
+		s.b.Delete(item)
+	}
+	return deleted, false
+}
+
+// Clear removes all items from the btree.
+func (s *SortedRegionsV2) Clear() {
+	s.b.Clear()
+}
+
+// ValidRegionsInBtree returns the number of valid regions in the btree.
+func (s *SortedRegionsV2) ValidRegionsInBtree(ts int64) (len int) {
+	s.b.Reverse(func(item *btreeItem) bool {
+		r := item.cachedRegion
+		if !r.checkRegionCacheTTL(ts) {
+			return true
+		}
+		len++
+		return true
+	})
+	return
+}


### PR DESCRIPTION
Just an experiment. I tried to use tidwall/btree instead of origin google's, you can see that the perf result is promising. we can consider it in the near future. 

```
go test -run=^$ -bench ^BenchmarkSortedRegions_
goos: darwin
goarch: amd64
pkg: github.com/tikv/client-go/v2/internal/locate
cpu: VirtualApple @ 2.50GHz

BenchmarkSortedRegions_SearchByKey/SearchByKey/Original-8         	 6363214	       189.0 ns/op
BenchmarkSortedRegions_SearchByKey/SearchByKey/V2-8               	 9601129	       124.4 ns/op
BenchmarkSortedRegions_ReplaceOrInsert/ReplaceOrInsert/Original-8 	 5168029	       230.7 ns/op
BenchmarkSortedRegions_ReplaceOrInsert/ReplaceOrInsert/V2-8       	 5801372	       207.6 ns/op
BenchmarkSortedRegions_AscendGreaterOrEqual/AscendGreaterOrEqual/Original-8         	  280526	      4251 ns/op
BenchmarkSortedRegions_AscendGreaterOrEqual/AscendGreaterOrEqual/V2-8               	  277137	      4249 ns/op
```