### PR TITLE
region_request: tiny refactor - init function failpointSendReqResult

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -730,43 +730,8 @@ func (s *RegionRequestSender) SendReqCtx(
 		bo.SetCtx(opentracing.ContextWithSpan(bo.GetCtx(), span1))
 	}
 
-	if val, err := util.EvalFailpoint("tikvStoreSendReqResult"); err == nil {
-		if s, ok := val.(string); ok {
-			switch s {
-			case "timeout":
-				return nil, nil, 0, errors.New("timeout")
-			case "GCNotLeader":
-				if req.Type == tikvrpc.CmdGC {
-					return &tikvrpc.Response{
-						Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
-					}, nil, 0, nil
-				}
-			case "PessimisticLockNotLeader":
-				if req.Type == tikvrpc.CmdPessimisticLock {
-					return &tikvrpc.Response{
-						Resp: &kvrpcpb.PessimisticLockResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
-					}, nil, 0, nil
-				}
-			case "GCServerIsBusy":
-				if req.Type == tikvrpc.CmdGC {
-					return &tikvrpc.Response{
-						Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}},
-					}, nil, 0, nil
-				}
-			case "busy":
-				return &tikvrpc.Response{
-					Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}},
-				}, nil, 0, nil
-			case "requestTiDBStoreError":
-				if et == tikvrpc.TiDB {
-					return nil, nil, 0, errors.WithStack(tikverr.ErrTiKVServerTimeout)
-				}
-			case "requestTiFlashError":
-				if et == tikvrpc.TiFlash {
-					return nil, nil, 0, errors.WithStack(tikverr.ErrTiFlashServerTimeout)
-				}
-			}
-		}
+	if resp, err = failpointSendReqResult(req, et); err != nil || resp != nil {
+		return
 	}
 
 	if err = s.validateReadTS(bo.GetCtx(), req); err != nil {
@@ -1928,4 +1893,63 @@ func (s *baseReplicaSelector) backoffOnNoCandidate(bo *retry.Backoffer) error {
 		return nil
 	}
 	return bo.Backoff(args.cfg, args.err)
+}
+
+// failpointSendReqResult is used to process the failpoint For tikvStoreSendReqResult.
+func failpointSendReqResult(req *tikvrpc.Request, et tikvrpc.EndpointType) (
+	resp *tikvrpc.Response,
+	err error,
+) {
+	val, e := util.EvalFailpoint("tikvStoreSendReqResult")
+	if e != nil {
+		return
+	}
+	errMsg, ok := val.(string)
+	if !ok {
+		return
+	}
+	switch errMsg {
+	case "timeout":
+		{
+			err = errors.New("timeout")
+			return
+		}
+	case "GCNotLeader":
+		if req.Type == tikvrpc.CmdGC {
+			resp = &tikvrpc.Response{
+				Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
+			}
+			return
+		}
+	case "PessimisticLockNotLeader":
+		if req.Type == tikvrpc.CmdPessimisticLock {
+			resp = &tikvrpc.Response{
+				Resp: &kvrpcpb.PessimisticLockResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
+			}
+			return
+		}
+	case "GCServerIsBusy":
+		if req.Type == tikvrpc.CmdGC {
+			resp = &tikvrpc.Response{
+				Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}},
+			}
+			return
+		}
+	case "busy":
+		resp = &tikvrpc.Response{
+			Resp: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}},
+		}
+		return
+	case "requestTiDBStoreError":
+		if et == tikvrpc.TiDB {
+			err = errors.WithStack(tikverr.ErrTiKVServerTimeout)
+			return
+		}
+	case "requestTiFlashError":
+		if et == tikvrpc.TiFlash {
+			err = errors.WithStack(tikverr.ErrTiFlashServerTimeout)
+			return
+		}
+	}
+	return
 }

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1901,11 +1901,11 @@ func failpointSendReqResult(req *tikvrpc.Request, et tikvrpc.EndpointType) (
 	err error,
 ) {
 	if val, e := util.EvalFailpoint("tikvStoreSendReqResult"); e == nil {
-		errMsg, ok := val.(string)
+		failpointCfg, ok := val.(string)
 		if !ok {
 			return
 		}
-		switch errMsg {
+		switch failpointCfg {
 		case "timeout":
 			{
 				err = errors.New("timeout")


### PR DESCRIPTION
Wrap the logic of handling failpoint `tikvStoreSendReqResult` into a function to make the main logic of `SendReqCtx` function more concise and friendly to maintain.