### PR TITLE
oracle: `setLastTS` always push tso to higher value

### DIFF
--- a/oracle/oracles/pd.go
+++ b/oracle/oracles/pd.go
@@ -694,12 +694,6 @@ func (o *pdOracle) ValidateReadTS(ctx context.Context, readTS uint64, isStaleRea
 			o.adjustUpdateLowResolutionTSIntervalWithRequestedStaleness(readTS, currentTS, time.Now())
 		}
 		if readTS > currentTS {
-			logutil.Logger(ctx).Warn("DBG",
-				zap.Uint64("readTS", readTS),
-				zap.Uint64("currentTS", currentTS),
-				zap.Uint64("latestTS", latestTSInfo.tso),
-				zap.Time("latest arrive", latestTSInfo.arrival),
-			)
 			return oracle.ErrFutureTSRead{
 				ReadTS:    readTS,
 				CurrentTS: currentTS,


### PR DESCRIPTION
The `setLastTS` can be called concurrently, so that the `tso` and `arrival` may have different order, `lastTSO1.tso < lastTSO2.tso` meanwhile `lastTSO1.arrival > lastTSO2.arrival`. In this case, when `lastTS` is set to `lastTSO1`, the update of `lastTSO2` will fail and later when we check `lastTS`, it's not true last.

This PR changes the `setLastTS` that it'll always push the `lastTS` to the max TSO we received.