### PR TITLE
retry stale read as stale if leader is not accessible

### DIFF
--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1412,9 +1412,6 @@ func (s *testRegionRequestToThreeStoresSuite) TestDoNotTryUnreachableLeader() {
 	follower, _, _, _ := region.FollowerStorePeer(regionStore, 0, &storeSelectorOp{})
 
 	s.regionRequestSender.client = &fnClient{fn: func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (response *tikvrpc.Response, err error) {
-		if req.StaleRead && addr == follower.addr {
-			return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{DataIsNotReady: &errorpb.DataIsNotReady{}}}}, nil
-		}
 		return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{
 			Value: []byte(addr),
 		}}, nil

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -324,7 +324,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessStaleRead,
+			leaderSuccessReadType:   SuccessFollowerRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(false),
 			followerSuccessReplica:  []string{"z2"},
@@ -346,7 +346,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessStaleRead,
+			leaderSuccessReadType:   SuccessFollowerRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.None[bool](),
 			followerSuccessReplica:  []string{"z2"},
@@ -434,11 +434,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessStaleRead,
+			leaderSuccessReadType:   SuccessFollowerRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z2", "z3"},
-			followerSuccessReadType: SuccessStaleRead,
+			followerSuccessReadType: SuccessFollowerRead,
 		},
 		{
 			do:                      leaderDown,
@@ -447,11 +447,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z3"},
-			leaderSuccessReadType:   SuccessStaleRead,
+			leaderSuccessReadType:   SuccessFollowerRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z3"},
-			followerSuccessReadType: SuccessStaleRead,
+			followerSuccessReadType: SuccessFollowerRead,
 		},
 		{
 			do:                      leaderDown,
@@ -460,11 +460,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z3"},
-			leaderSuccessReadType:   SuccessStaleRead,
+			leaderSuccessReadType:   SuccessFollowerRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z3"},
-			followerSuccessReadType: SuccessStaleRead,
+			followerSuccessReadType: SuccessFollowerRead,
 		},
 	}
 	tests := []func(*testRegionCacheStaleReadSuite, *RegionCacheTestCase){
@@ -556,6 +556,8 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 	_, successZone, successReadType := s.extractResp(resp)
 	find := false
 	if leaderZone {
+		funcName := runtime.FuncForPC(reflect.ValueOf(r.do).Pointer()).Name()
+		fmt.Printf("Function name of r.do(): %s\n", funcName)
 		s.Equal(r.leaderSuccessReadType, successReadType, msg)
 		for _, z := range r.leaderSuccessReplica {
 			if z == successZone {

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -554,8 +554,6 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 	_, successZone, successReadType := s.extractResp(resp)
 	find := false
 	if leaderZone {
-		funcName := runtime.FuncForPC(reflect.ValueOf(r.do).Pointer()).Name()
-		fmt.Printf("Function name of r.do(): %s\n", funcName)
 		s.Equal(r.leaderSuccessReadType, successReadType, msg)
 		for _, z := range r.leaderSuccessReplica {
 			if z == successZone {
@@ -564,8 +562,6 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 			}
 		}
 	} else {
-		funcName := runtime.FuncForPC(reflect.ValueOf(r.do).Pointer()).Name()
-		fmt.Printf("Function name of r.do(): %s\n", funcName)
 		s.Equal(r.followerSuccessReadType, successReadType)
 		for _, z := range r.followerSuccessReplica {
 			if z == successZone {

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -17,6 +17,8 @@ package locate
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -322,7 +324,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(false),
 			followerSuccessReplica:  []string{"z2"},
@@ -333,7 +335,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.None[bool](),
 			followerSuccessReplica:  []string{"z2"},
@@ -344,7 +346,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.None[bool](),
 			followerSuccessReplica:  []string{"z2"},
@@ -432,11 +434,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z2", "z3"},
-			followerSuccessReadType: SuccessFollowerRead,
+			followerSuccessReadType: SuccessStaleRead,
 		},
 		{
 			do:                      leaderDown,
@@ -445,11 +447,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z3"},
-			followerSuccessReadType: SuccessFollowerRead,
+			followerSuccessReadType: SuccessStaleRead,
 		},
 		{
 			do:                      leaderDown,
@@ -458,11 +460,11 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.Some(true),
 			followerSuccessReplica:  []string{"z3"},
-			followerSuccessReadType: SuccessFollowerRead,
+			followerSuccessReadType: SuccessStaleRead,
 		},
 	}
 	tests := []func(*testRegionCacheStaleReadSuite, *RegionCacheTestCase){
@@ -562,6 +564,8 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 			}
 		}
 	} else {
+		funcName := runtime.FuncForPC(reflect.ValueOf(r.do).Pointer()).Name()
+		fmt.Printf("Function name of r.do(): %s\n", funcName)
 		s.Equal(r.followerSuccessReadType, successReadType)
 		for _, z := range r.followerSuccessReplica {
 			if z == successZone {

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -17,8 +17,6 @@ package locate
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -308,7 +308,7 @@ func (s *ReplicaSelectMixedStrategy) canSendReplicaRead(selector *replicaSelecto
 	replicas := selector.replicas
 	replica := replicas[s.leaderIdx]
 
-	if leader.attempts == 0 || replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
+	if replica.attempts == 0 || replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
 		// don't do the replica read if leader is not exhausted or leader has timeout or server busy error.
 		return false
 	}

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -308,8 +308,7 @@ func (s *ReplicaSelectMixedStrategy) canSendReplicaRead(selector *replicaSelecto
 	replicas := selector.replicas
 	replica := replicas[s.leaderIdx]
 
-	maxAttempt := 1
-	if !replica.isExhausted(maxAttempt, 0) || replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
+	if leader.attempts == 0 || replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
 		// don't do the replica read if leader is not exhausted or leader has timeout or server busy error.
 		return false
 	}

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -898,8 +898,8 @@ func TestReplicaReadAccessPathByCase2(t *testing.T) {
 		expect: &accessPathResult{
 			accessPath: []string{
 				"{addr: store1, replica-read: false, stale-read: true}",
-				"{addr: store2, replica-read: false, stale-read: true}",
-				"{addr: store3, replica-read: false, stale-read: true}"},
+				"{addr: store2, replica-read: true, stale-read: false}",
+				"{addr: store3, replica-read: true, stale-read: false}"},
 			respErr:         "",
 			respRegionError: fakeEpochNotMatch,
 			backoffCnt:      3,
@@ -2125,7 +2125,7 @@ func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
 				accessPath: []string{
 					"{addr: store2, replica-read: false, stale-read: true}",
 					"{addr: store1, replica-read: false, stale-read: false}",
-					"{addr: store3, replica-read: false, stale-read: true}",
+					"{addr: store3, replica-read: true, stale-read: false}",
 				},
 				respErr:         "",
 				respRegionError: nil,

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -898,8 +898,8 @@ func TestReplicaReadAccessPathByCase2(t *testing.T) {
 		expect: &accessPathResult{
 			accessPath: []string{
 				"{addr: store1, replica-read: false, stale-read: true}",
-				"{addr: store2, replica-read: true, stale-read: false}",
-				"{addr: store3, replica-read: true, stale-read: false}"},
+				"{addr: store2, replica-read: false, stale-read: true}",
+				"{addr: store3, replica-read: false, stale-read: true}"},
 			respErr:         "",
 			respRegionError: fakeEpochNotMatch,
 			backoffCnt:      3,
@@ -2125,7 +2125,7 @@ func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
 				accessPath: []string{
 					"{addr: store2, replica-read: false, stale-read: true}",
 					"{addr: store1, replica-read: false, stale-read: false}",
-					"{addr: store3, replica-read: true, stale-read: false}",
+					"{addr: store3, replica-read: false, stale-read: true}",
 				},
 				respErr:         "",
 				respRegionError: nil,
@@ -2144,7 +2144,7 @@ func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
 			beforeRun: func() { /* don't resetStoreState */ },
 			expect: &accessPathResult{
 				accessPath: []string{
-					"{addr: store3, replica-read: true, stale-read: false}",
+					"{addr: store3, replica-read: false, stale-read: true}",
 				},
 				respErr:         "",
 				respRegionError: fakeEpochNotMatch,


### PR DESCRIPTION
issue number : https://github.com/tikv/tikv/issues/17422
It is the extension of the original PR https://github.com/tikv/client-go/pull/1509. I have observed that in case of hot regions, leaders are inaccessible and stale reads are retried as follower_follower. I have added a change if leader is not reachable or epoch doesn't mach than retry stale read as stale instead of follower. 
<img width="1713" alt="Screenshot 2024-12-20 at 1 35 37 PM" src="https://github.com/user-attachments/assets/b0c93015-2cfc-4abb-b4f2-6f86814ebb96" />
