### PR TITLE
CI: disable tidb compatible test in merge CI

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -3,8 +3,6 @@ name: Compatibility Test
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
 


### PR DESCRIPTION
The TiDB compatibility tests in client-go can be disabled in the merge ci. These tests make modifying client-go very cumbersome after the repository split. In practice, updating the client-go dependency in TiDB already serves as a compatibility test.