### PR TITLE
integrate circuitbreaker for region calls

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -100,6 +100,8 @@ type TiKVClient struct {
 	// If a Region has not been accessed for more than the given duration (in seconds), it
 	// will be reloaded from the PD.
 	RegionCacheTTL uint `toml:"region-cache-ttl" json:"region-cache-ttl"`
+	// CircuitBreakerSettingsList is the config for default circuit breaker settings
+	CircuitBreakerSettingsList CircuitBreakerSettingsList `toml:"circuit-breaker" json:"circuit-breaker"`
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
@@ -149,6 +151,23 @@ type CoprocessorCache struct {
 	AdmissionMinProcessMs uint64 `toml:"admission-min-process-ms" json:"-"`
 }
 
+// CircuitBreakerSettings is the config for default circuit breaker settings excluding the error rate
+type CircuitBreakerSettings struct {
+	// ErrorRateEvaluationWindowSeconds defines how long to track errors before evaluating error rate threshold.
+	ErrorRateEvaluationWindowSeconds uint `toml:"error-rate-evaluation-window-seconds" json:"error-rate-evaluation-window-seconds"`
+	// MinQPSToOpen defines the average qps over the error-rate-evaluation-window-seconds that must be met before evaluating the error rate threshold.
+	MinQPSToOpen uint `toml:"min-qps-to-open" json:"min-qps-to-open"`
+	// CooldownIntervalSeconds defines how long to wait after circuit breaker is open before go to half-open state to send a probe request.
+	CooldownIntervalSeconds uint `toml:"cooldown-interval-seconds" json:"cooldown-interval-seconds"`
+	// HalfOpenSuccessCount defines how many subsequent requests to test after cooldown period before fully close the circuit. All request in excess of this count will be errored till the circuit is fully closed pending results of the firsts HalfOpenSuccessCount requests.
+	HalfOpenSuccessCount uint `toml:"half_open_success_count" json:"half_open_success_count"`
+}
+
+// CircuitBreakerSettingsList is a container to configure all circuit breakers
+type CircuitBreakerSettingsList struct {
+	PDRegionsMetadata CircuitBreakerSettings `toml:"pd-regions-metadata" json:"pd-regions-metadata"`
+}
+
 // DefaultTiKVClient returns default config for TiKVClient.
 func DefaultTiKVClient() TiKVClient {
 	return TiKVClient{
@@ -176,7 +195,16 @@ func DefaultTiKVClient() TiKVClient {
 
 		EnableChunkRPC: true,
 
-		RegionCacheTTL:       600,
+		RegionCacheTTL: 600,
+		CircuitBreakerSettingsList: CircuitBreakerSettingsList{
+			PDRegionsMetadata: CircuitBreakerSettings{
+				ErrorRateEvaluationWindowSeconds: 30,
+				MinQPSToOpen:                     10,
+				CooldownIntervalSeconds:          10,
+				HalfOpenSuccessCount:             1,
+			},
+		},
+
 		StoreLimit:           0,
 		StoreLivenessTimeout: DefStoreLivenessTimeout,
 

--- a/config/client.go
+++ b/config/client.go
@@ -160,12 +160,12 @@ type CircuitBreakerSettings struct {
 	// CooldownIntervalSeconds defines how long to wait after circuit breaker is open before go to half-open state to send a probe request.
 	CooldownIntervalSeconds uint `toml:"cooldown-interval-seconds" json:"cooldown-interval-seconds"`
 	// HalfOpenSuccessCount defines how many subsequent requests to test after cooldown period before fully close the circuit. All request in excess of this count will be errored till the circuit is fully closed pending results of the firsts HalfOpenSuccessCount requests.
-	HalfOpenSuccessCount uint `toml:"half_open_success_count" json:"half_open_success_count"`
+	HalfOpenSuccessCount uint `toml:"half-open-success-count" json:"half-open-success-count"`
 }
 
 // CircuitBreakerSettingsList is a container to configure all circuit breakers
 type CircuitBreakerSettingsList struct {
-	PDRegionsMetadata CircuitBreakerSettings `toml:"pd-regions-metadata" json:"pd-regions-metadata"`
+	PDRegionsMetadata CircuitBreakerSettings `toml:"pd-region-metadata" json:"pd-region-metadata"`
 }
 
 // DefaultTiKVClient returns default config for TiKVClient.

--- a/config/client.go
+++ b/config/client.go
@@ -100,8 +100,6 @@ type TiKVClient struct {
 	// If a Region has not been accessed for more than the given duration (in seconds), it
 	// will be reloaded from the PD.
 	RegionCacheTTL uint `toml:"region-cache-ttl" json:"region-cache-ttl"`
-	// CircuitBreakerSettingsList is the config for default circuit breaker settings
-	CircuitBreakerSettingsList CircuitBreakerSettingsList `toml:"circuit-breaker" json:"circuit-breaker"`
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
@@ -151,23 +149,6 @@ type CoprocessorCache struct {
 	AdmissionMinProcessMs uint64 `toml:"admission-min-process-ms" json:"-"`
 }
 
-// CircuitBreakerSettings is the config for default circuit breaker settings excluding the error rate
-type CircuitBreakerSettings struct {
-	// ErrorRateEvaluationWindowSeconds defines how long to track errors before evaluating error rate threshold.
-	ErrorRateEvaluationWindowSeconds uint `toml:"error-rate-evaluation-window-seconds" json:"error-rate-evaluation-window-seconds"`
-	// MinQPSToOpen defines the average qps over the error-rate-evaluation-window-seconds that must be met before evaluating the error rate threshold.
-	MinQPSToOpen uint `toml:"min-qps-to-open" json:"min-qps-to-open"`
-	// CooldownIntervalSeconds defines how long to wait after circuit breaker is open before go to half-open state to send a probe request.
-	CooldownIntervalSeconds uint `toml:"cooldown-interval-seconds" json:"cooldown-interval-seconds"`
-	// HalfOpenSuccessCount defines how many subsequent requests to test after cooldown period before fully close the circuit. All request in excess of this count will be errored till the circuit is fully closed pending results of the firsts HalfOpenSuccessCount requests.
-	HalfOpenSuccessCount uint `toml:"half-open-success-count" json:"half-open-success-count"`
-}
-
-// CircuitBreakerSettingsList is a container to configure all circuit breakers
-type CircuitBreakerSettingsList struct {
-	PDRegionsMetadata CircuitBreakerSettings `toml:"pd-region-metadata" json:"pd-region-metadata"`
-}
-
 // DefaultTiKVClient returns default config for TiKVClient.
 func DefaultTiKVClient() TiKVClient {
 	return TiKVClient{
@@ -195,16 +176,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		EnableChunkRPC: true,
 
-		RegionCacheTTL: 600,
-		CircuitBreakerSettingsList: CircuitBreakerSettingsList{
-			PDRegionsMetadata: CircuitBreakerSettings{
-				ErrorRateEvaluationWindowSeconds: 30,
-				MinQPSToOpen:                     10,
-				CooldownIntervalSeconds:          10,
-				HalfOpenSuccessCount:             1,
-			},
-		},
-
+		RegionCacheTTL:       600,
 		StoreLimit:           0,
 		StoreLivenessTimeout: DefStoreLivenessTimeout,
 

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -142,6 +142,7 @@ var pdRegionMetaCircuitBreaker = circuitbreaker.NewCircuitBreaker("region-meta",
 		HalfOpenSuccessCount: 1,
 	})
 
+// wrap context with circuit breaker for PD region metadata calls
 func withPDCircuitBreaker(ctx context.Context) context.Context {
 	return circuitbreaker.WithCircuitBreaker(ctx, pdRegionMetaCircuitBreaker)
 }

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -146,8 +146,8 @@ func withPDCircuitBreaker(ctx context.Context) context.Context {
 	return circuitbreaker.WithCircuitBreaker(ctx, pdRegionMetaCircuitBreaker)
 }
 
-// ChangePdRegionMetaCircuitBreakerSettings changes circuit breaker changes for region metadata calls
-func ChangePdRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {
+// ChangePDRegionMetaCircuitBreakerSettings changes circuit breaker changes for region metadata calls
+func ChangePDRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {
 	pdRegionMetaCircuitBreaker.ChangeSettings(apply)
 }
 

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -134,14 +134,7 @@ func nextTTL(ts int64) int64 {
 	return ts + regionCacheTTLSec + jitter
 }
 
-var pdRegionMetaCircuitBreaker = circuitbreaker.NewCircuitBreaker(
-	"region-meta",
-	circuitbreaker.Settings{
-		ErrorRateThresholdPct: 0,
-		MinQPSForOpen:         100,
-		ErrorRateWindow:       time.Second * 30,
-		CoolDownInterval:      time.Second * 10,
-		HalfOpenSuccessCount:  1})
+var pdRegionMetaCircuitBreaker = circuitbreaker.NewCircuitBreaker("region-meta", circuitbreaker.AlwaysClosedSettings)
 
 // ChangePdRegionMetaCircuitBreakerSettings changes circuit breaker changes for region metadata calls
 func ChangePdRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {

--- a/internal/mockstore/mocktikv/pd.go
+++ b/internal/mockstore/mocktikv/pd.go
@@ -261,11 +261,13 @@ func (c *pdClient) GetRegionByID(ctx context.Context, regionID uint64, opts ...o
 }
 
 func (c *pdClient) ScanRegions(ctx context.Context, startKey []byte, endKey []byte, limit int, opts ...opt.GetRegionOption) ([]*router.Region, error) {
+	enforceCircuitBreakerFor("ScanRegions", ctx)
 	regions := c.cluster.ScanRegions(startKey, endKey, limit, opts...)
 	return regions, nil
 }
 
 func (c *pdClient) BatchScanRegions(ctx context.Context, keyRanges []router.KeyRange, limit int, opts ...opt.GetRegionOption) ([]*router.Region, error) {
+	enforceCircuitBreakerFor("BatchScanRegions", ctx)
 	if _, err := util.EvalFailpoint("mockBatchScanRegionsUnimplemented"); err == nil {
 		return nil, status.Errorf(codes.Unimplemented, "mock BatchScanRegions is not implemented")
 	}

--- a/internal/mockstore/mocktikv/pd.go
+++ b/internal/mockstore/mocktikv/pd.go
@@ -56,7 +56,7 @@ import (
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
 	"github.com/tikv/pd/client/pkg/circuitbreaker"
-sd "github.com/tikv/pd/client/servicediscovery"
+	sd "github.com/tikv/pd/client/servicediscovery"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -472,6 +472,6 @@ func (m *pdClient) WithCallerComponent(caller.Component) pd.Client { return m }
 
 func enforceCircuitBreakerFor(name string, ctx context.Context) {
 	if circuitbreaker.FromContext(ctx) == nil {
-    	panic(fmt.Errorf("CircuitBreaker must be configured for %s", name))
+		panic(fmt.Errorf("CircuitBreaker must be configured for %s", name))
 	}
 }

--- a/internal/mockstore/mocktikv/pd.go
+++ b/internal/mockstore/mocktikv/pd.go
@@ -55,7 +55,8 @@ import (
 	"github.com/tikv/pd/client/clients/tso"
 	"github.com/tikv/pd/client/opt"
 	"github.com/tikv/pd/client/pkg/caller"
-	sd "github.com/tikv/pd/client/servicediscovery"
+	"github.com/tikv/pd/client/pkg/circuitbreaker"
+sd "github.com/tikv/pd/client/servicediscovery"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -226,6 +227,7 @@ func (m *mockTSFuture) Wait() (int64, int64, error) {
 }
 
 func (c *pdClient) GetRegion(ctx context.Context, key []byte, opts ...opt.GetRegionOption) (*router.Region, error) {
+	enforceCircuitBreakerFor("GetRegion", ctx)
 	region, peer, buckets, downPeers := c.cluster.GetRegionByKey(key)
 	if len(opts) == 0 {
 		buckets = nil
@@ -244,6 +246,7 @@ func (c *pdClient) GetRegionFromMember(ctx context.Context, key []byte, memberUR
 }
 
 func (c *pdClient) GetPrevRegion(ctx context.Context, key []byte, opts ...opt.GetRegionOption) (*router.Region, error) {
+	enforceCircuitBreakerFor("GetPrevRegion", ctx)
 	region, peer, buckets, downPeers := c.cluster.GetPrevRegionByKey(key)
 	if len(opts) == 0 {
 		buckets = nil
@@ -252,6 +255,7 @@ func (c *pdClient) GetPrevRegion(ctx context.Context, key []byte, opts ...opt.Ge
 }
 
 func (c *pdClient) GetRegionByID(ctx context.Context, regionID uint64, opts ...opt.GetRegionOption) (*router.Region, error) {
+	enforceCircuitBreakerFor("GetRegionByID", ctx)
 	region, peer, buckets, downPeers := c.cluster.GetRegionByID(regionID)
 	return &router.Region{Meta: region, Leader: peer, Buckets: buckets, DownPeers: downPeers}, nil
 }
@@ -465,3 +469,9 @@ func (m *pdClient) LoadResourceGroups(ctx context.Context) ([]*rmpb.ResourceGrou
 func (m *pdClient) GetServiceDiscovery() sd.ServiceDiscovery { return nil }
 
 func (m *pdClient) WithCallerComponent(caller.Component) pd.Client { return m }
+
+func enforceCircuitBreakerFor(name string, ctx context.Context) {
+	if circuitbreaker.FromContext(ctx) == nil {
+    	panic(fmt.Errorf("CircuitBreaker must be configured for %s", name))
+	}
+}

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/pkg/circuitbreaker"
 )
 
 // RPCContext contains data that is needed to send RPC to a region.
@@ -195,6 +196,11 @@ func NewRegionRequestRuntimeStats() *RegionRequestRuntimeStats {
 // Deprecated: use SetRegionCacheTTLWithJitter instead.
 func SetRegionCacheTTLSec(t int64) {
 	locate.SetRegionCacheTTLSec(t)
+}
+
+// ChangePdRegionMetaCircuitBreakerSettings changes circuit breaker settings for region metadata calls
+func ChangePdRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {
+	locate.ChangePdRegionMetaCircuitBreakerSettings(apply)
 }
 
 // SetRegionCacheTTLWithJitter sets region cache TTL with jitter. The real TTL is in range of [base, base+jitter).

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -198,9 +198,9 @@ func SetRegionCacheTTLSec(t int64) {
 	locate.SetRegionCacheTTLSec(t)
 }
 
-// ChangePdRegionMetaCircuitBreakerSettings changes circuit breaker settings for region metadata calls
-func ChangePdRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {
-	locate.ChangePdRegionMetaCircuitBreakerSettings(apply)
+// ChangePDRegionMetaCircuitBreakerSettings changes circuit breaker settings for region metadata calls
+func ChangePDRegionMetaCircuitBreakerSettings(apply func(config *circuitbreaker.Settings)) {
+	locate.ChangePDRegionMetaCircuitBreakerSettings(apply)
 }
 
 // SetRegionCacheTTLWithJitter sets region cache TTL with jitter. The real TTL is in range of [base, base+jitter).


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref https://github.com/tikv/pd/issues/8678

### What is changed and how does it work?
Add a global circuit breaker to the context of each call to get region data from PD.  
The default circuit breaker is in the disabled state and has no effect. 
This PR also exposes a method to tweak circuit breaker settings which can be used from TiDB layer to enable and configure it.
