### PR TITLE
region_cache: fix a potential data race on store.addr

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -3078,7 +3078,7 @@ func (c *RegionCache) checkAndUpdateStoreHealthStatus(ctx context.Context, now t
 func (c *RegionCache) reportStoreReplicaFlows() {
 	c.stores.forEach(func(store *Store) {
 		for destType := toLeader; destType < numReplicaFlowsType; destType++ {
-			metrics.TiKVPreferLeaderFlowsGauge.WithLabelValues(destType.String(), store.addr).Set(float64(store.getReplicaFlowsStats(destType)))
+			metrics.TiKVPreferLeaderFlowsGauge.WithLabelValues(destType.String(), strconv.FormatUint(store.storeID, 10)).Set(float64(store.getReplicaFlowsStats(destType)))
 			store.resetReplicaFlowsStats(destType)
 		}
 	})


### PR DESCRIPTION
close #1544

`store.addr` is mutable, it gets updated when: 1. `initResolve` 2. `refreshFullStoreList` , to avoid data race, we use storeID (which is immutable) as the value of the metric label.