### PR TITLE
*: fix two minor bugs

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -860,7 +860,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		if req.InputRequestSource != "" && s.replicaSelector != nil {
 			patchRequestSource(req, s.replicaSelector.replicaType())
 		}
-		if e := tikvrpc.SetContext(req, rpcCtx.Meta, rpcCtx.Peer); e != nil {
+		if err := tikvrpc.SetContext(req, rpcCtx.Meta, rpcCtx.Peer); err != nil {
 			return nil, nil, retryTimes, err
 		}
 		if s.replicaSelector != nil {

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -436,6 +436,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 		s.mu.RLock()
 		req, err := s.buildBatchGetRequest(pending, busyThresholdMs, readTier)
 		if err != nil {
+			s.mu.RUnlock()
 			return err
 		}
 		req.InputRequestSource = s.GetRequestSource()


### PR DESCRIPTION
Fix the following two minor bugs found by code review:
1. [here](https://github.com/tikv/client-go/blob/2eba2f614b38e2905cc46ea8f0fc6d40ed6a0ccf/internal/locate/region_request.go#L864) the func may `return nil, nil, retryTimes, nil`
2. [here](https://github.com/tikv/client-go/blob/2eba2f614b38e2905cc46ea8f0fc6d40ed6a0ccf/txnkv/txnsnapshot/snapshot.go#L439) the func may return without unlock