### PR TITLE
avoid copy stack in batch-get

### DIFF
--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -326,7 +326,7 @@ func appendBatchKeysBySize(b []batchKeys, region locate.RegionVerID, keys [][]by
 func growStackForBatchGetWorker() {
 	// A batch get worker typically needs 8KB stack space. So we pre-allocate 4KB here to let the stack grow to 8KB
 	// directly (instead of 2KB to 4KB to 8KB).
-	var ballast [4096]byte
+	var ballast [8192]byte
 	runtime.KeepAlive(ballast[:])
 }
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -324,8 +324,8 @@ func appendBatchKeysBySize(b []batchKeys, region locate.RegionVerID, keys [][]by
 
 //go:noinline
 func growStackForBatchGetWorker() {
-	// A batch get worker typically needs 8KB stack space. So we pre-allocate 4KB here to let the stack grow to 8KB
-	// directly (instead of 2KB to 4KB to 8KB).
+	// A batch get worker typically needs 16KB stack space. So we pre-allocate 8KB here to let the stack grow to 16KB
+	// directly (instead of 2KB to 4KB to 8KB to 16KB).
 	var ballast [8192]byte
 	runtime.KeepAlive(ballast[:])
 }


### PR DESCRIPTION
When build TiDB with PGO, batch-get may still has `copystack` operation, this pr will avoid copy stack in batch-get.

Related PR:
  - https://github.com/tikv/client-go/pull/1535
  - https://github.com/pingcap/tidb/pull/58630


Benchmark

<img width="614" alt="image" src="https://github.com/user-attachments/assets/fd1dbdeb-0c63-404c-be67-5d1a90cad497" />


<img width="2995" alt="image" src="https://github.com/user-attachments/assets/1c74e32a-b3b1-41a5-8d72-f0507e1517b5" />
