### PR TITLE
retry stale read as stale if leader is not accessible

### DIFF
--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1412,9 +1412,6 @@ func (s *testRegionRequestToThreeStoresSuite) TestDoNotTryUnreachableLeader() {
 	follower, _, _, _ := region.FollowerStorePeer(regionStore, 0, &storeSelectorOp{})
 
 	s.regionRequestSender.client = &fnClient{fn: func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (response *tikvrpc.Response, err error) {
-		if req.StaleRead && addr == follower.addr {
-			return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{DataIsNotReady: &errorpb.DataIsNotReady{}}}}, nil
-		}
 		return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{
 			Value: []byte(addr),
 		}}, nil

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -333,7 +333,7 @@ func TestRegionCacheStaleRead(t *testing.T) {
 			leaderRegionValid:       true,
 			leaderAsyncReload:       util.Some(true),
 			leaderSuccessReplica:    []string{"z2", "z3"},
-			leaderSuccessReadType:   SuccessFollowerRead,
+			leaderSuccessReadType:   SuccessStaleRead,
 			followerRegionValid:     true,
 			followerAsyncReload:     util.None[bool](),
 			followerSuccessReplica:  []string{"z2"},

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -307,8 +307,8 @@ func (s *ReplicaSelectMixedStrategy) next(selector *replicaSelector) *replica {
 func (s *ReplicaSelectMixedStrategy) canSendReplicaRead(selector *replicaSelector) bool {
 	replicas := selector.replicas
 	replica := replicas[s.leaderIdx]
-	if replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
-		// don't overwhelm the leader if it is busy
+	if replica.attempts == 0 || replica.hasFlag(deadlineErrUsingConfTimeoutFlag) || replica.hasFlag(serverIsBusyFlag) {
+		// don't do the replica read if leader is not exhausted or leader has timeout or server busy error.
 		return false
 	}
 	return true

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -2144,7 +2144,7 @@ func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
 			beforeRun: func() { /* don't resetStoreState */ },
 			expect: &accessPathResult{
 				accessPath: []string{
-					"{addr: store3, replica-read: true, stale-read: false}",
+					"{addr: store3, replica-read: false, stale-read: true}",
 				},
 				respErr:         "",
 				respRegionError: fakeEpochNotMatch,


### PR DESCRIPTION
issue number : https://github.com/tikv/tikv/issues/17422
It is the extension of the original PR https://github.com/tikv/client-go/pull/1509. I have observed that in case of hot regions, leaders are inaccessible and stale reads are retried as follower_follower. I have added a change if leader is not reachable or epoch doesn't mach than retry stale read as stale instead of follower.
<img width="1713" alt="github" src="https://github.com/user-attachments/assets/3af6dbab-5ead-4172-b5d7-f08b6f84065f" />
