### PR TITLE
(tidb-8.1) Do not set txn scope in snapshot

### DIFF
--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -440,7 +440,6 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 		matchStoreLabels := s.mu.matchStoreLabels
 		replicaAdjuster := s.mu.replicaReadAdjuster
 		s.mu.RUnlock()
-		req.TxnScope = scope
 		req.ReadReplicaScope = scope
 		if isStaleness {
 			req.EnableStaleWithMixedReplicaRead()
@@ -686,7 +685,6 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]
 	scope := s.mu.readReplicaScope
 	replicaAdjuster := s.mu.replicaReadAdjuster
 	s.mu.RUnlock()
-	req.TxnScope = scope
 	req.ReadReplicaScope = scope
 	var ops []locate.StoreSelectorOption
 	if isStaleness {


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/59402

`TxnScope` should not be set to `ReadReplicaScope`.