### PR TITLE
(tidb-7.5) Do not set txn scope in snapshot

### DIFF
--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -419,7 +419,6 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 		matchStoreLabels := s.mu.matchStoreLabels
 		replicaAdjuster := s.mu.replicaReadAdjuster
 		s.mu.RUnlock()
-		req.TxnScope = scope
 		req.ReadReplicaScope = scope
 		if isStaleness {
 			req.EnableStaleWithMixedReplicaRead()
@@ -647,7 +646,6 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]
 	scope := s.mu.readReplicaScope
 	replicaAdjuster := s.mu.replicaReadAdjuster
 	s.mu.RUnlock()
-	req.TxnScope = scope
 	req.ReadReplicaScope = scope
 	var ops []locate.StoreSelectorOption
 	if isStaleness {


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/59402

`TxnScope` should not be set to `ReadReplicaScope`.