### PR TITLE
(tidb-6.5) Do not set txn scope in snapshot

### DIFF
--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -396,7 +396,6 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 		matchStoreLabels := s.mu.matchStoreLabels
 		replicaAdjuster := s.mu.replicaReadAdjuster
 		s.mu.RUnlock()
-		req.TxnScope = scope
 		req.ReadReplicaScope = scope
 		if isStaleness {
 			req.EnableStaleRead()
@@ -604,7 +603,6 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]
 	scope := s.mu.readReplicaScope
 	replicaAdjuster := s.mu.replicaReadAdjuster
 	s.mu.RUnlock()
-	req.TxnScope = scope
 	req.ReadReplicaScope = scope
 	var ops []locate.StoreSelectorOption
 	if isStaleness {


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/59402

`TxnScope` should not be set to `ReadReplicaScope`.