### PR TITLE
sync etcd endpoints immediately after initializing the client

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -103,6 +103,12 @@ func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, erro
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+	if err := cli.Sync(ctx); err != nil {
+		_ = cli.Close()
+		return nil, errors.WithStack(err)
+	}
 	return cli, nil
 }
 


### PR DESCRIPTION
**Problem Statement**

etcd client would only run `Sync` after `AutoSyncInterval` (30 seconds), which makes tikv client vulnerable to the failure of endpoints provided in `addrs` before the first sync happens. Specific failure scenario:

1. tidb is initialized with a `--path=endpoint`
2. tidb successfully established connection to the `endpoint`
3. n < 30 seconds after, endpoint fails (e.g. k8s control plane is upgrading the pod)
4. etcd client is no longer connected
5. Safe checkpoint expires and `CheckVisibility` in `KVStore` start to error out

**Fix**

We explicitly synchronize client endpoints with endpoints from etcd membership during client initialization phase. etcd client would continue to do periodic sync, we just force first sync to happen in the init phase.
