### PR TITLE
(tidb-6.5) Use global txn scope when validating ts

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1913,7 +1913,7 @@ func (s *RegionRequestSender) validateReadTS(ctx context.Context, req *tikvrpc.R
 	default:
 		return nil
 	}
-	return s.readTSValidator.ValidateReadTS(ctx, readTS, req.StaleRead, &oracle.Option{TxnScope: req.TxnScope})
+	return s.readTSValidator.ValidateReadTS(ctx, readTS, req.StaleRead, &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 }
 
 type staleReadMetricsCollector struct {


### PR DESCRIPTION
This is to reduce the risk of txn-scope related bugs.