### PR TITLE
p-dml: resolve locks concurrently (#1584)

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -45,7 +45,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -62,6 +61,7 @@ import (
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/metrics"
+	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util"
 	"github.com/tikv/pd/client/errs"

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -485,6 +485,7 @@ func (c *twoPhaseCommitter) resolveFlushedLocks(bo *retry.Backoffer, start, end 
 		handler,
 	)
 	runner.SetStatLogInterval(30 * time.Second)
+	runner.SetRegionsPerTask(1)
 
 	c.txn.spawnWithStorePool(func() {
 		if err = runner.RunOnRange(bo.GetCtx(), start, end); err != nil {


### PR DESCRIPTION
Cherry pick #1584 to `tidb-8.5` branch.

---

close #1577

The default range task size is too large for p-dml, which makes the concurrent resolve works bad, e.g., all the regions are pending in one worker and other workers are just waiting. Meanwhile, the utilization of TiKV CPU is low, and the resolve progress can take a long time.

https://github.com/tikv/client-go/blob/279dcd5b29a2df8797237bb09e41924d52a73fe0/txnkv/rangetask/range_task.go#L54

This PR set the task size to 1 for p-dml, so that the resolve progress can run at the concurrency given by user.

The resolve lock speed:

- nightly: 44m21s
- this PR: 14m19s

![image](https://github.com/user-attachments/assets/07bfb2ea-8e60-4450-b61f-7df9a080ba3d)

The progress logs work well with this change:

```log
[2025/02/18 03:27:35.952 +00:00] [INFO] [range_task.go:167] ["range task started"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8]
[2025/02/18 03:28:15.879 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=39.926761609s] ["completed regions"=8]
[2025/02/18 03:28:36.076 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=1m0.123584892s] ["completed regions"=14]
[2025/02/18 03:29:11.505 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=1m35.552227637s] ["completed regions"=25]
[2025/02/18 03:29:39.692 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=2m3.740022981s] ["completed regions"=35]
[2025/02/18 03:30:08.130 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=2m32.178047735s] ["completed regions"=44]
[2025/02/18 03:30:39.419 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=3m3.466146672s] ["completed regions"=55]
[2025/02/18 03:31:06.458 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=3m30.505386121s] ["completed regions"=64]
[2025/02/18 03:31:36.061 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=4m0.108660945s] ["completed regions"=74]
[2025/02/18 03:32:07.166 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=4m31.213248541s] ["completed regions"=84]
[2025/02/18 03:32:36.056 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=5m0.10354548s] ["completed regions"=96]
[2025/02/18 03:33:11.113 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=5m35.160928996s] ["completed regions"=102]
[2025/02/18 03:33:55.655 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=6m19.702216102s] ["completed regions"=110]
[2025/02/18 03:34:11.974 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=6m36.021730836s] ["completed regions"=114]
[2025/02/18 03:34:38.090 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=7m2.137833732s] ["completed regions"=118]
[2025/02/18 03:35:21.752 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=7m45.799917767s] ["completed regions"=126]
[2025/02/18 03:35:36.277 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=8m0.324446238s] ["completed regions"=130]
[2025/02/18 03:36:08.257 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=8m32.304513943s] ["completed regions"=135]
[2025/02/18 03:36:48.223 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=9m12.271027942s] ["completed regions"=142]
[2025/02/18 03:37:07.483 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=9m31.530321068s] ["completed regions"=149]
[2025/02/18 03:37:36.326 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=10m0.373384077s] ["completed regions"=151]
[2025/02/18 03:38:15.821 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=10m39.868249005s] ["completed regions"=158]
[2025/02/18 03:38:36.741 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=11m0.788590563s] ["completed regions"=165]
[2025/02/18 03:39:07.063 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=11m31.110917818s] ["completed regions"=169]
[2025/02/18 03:39:44.121 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=12m8.168255209s] ["completed regions"=174]
[2025/02/18 03:40:25.723 +00:00] [INFO] [range_task.go:209] ["range task in progress"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] [concurrency=8] ["cost time"=12m49.770345125s] ["completed regions"=182]
[2025/02/18 03:41:55.183 +00:00] [INFO] [range_task.go:276] ["range task finished"] [name=pipelined-dml-commit-456090845481533442] [startKey=7480000000000000815f69800000000000000103800000000000000103800000000185fa98] [endKey=7480000000000000815f728000000005f5e100] ["cost time"=14m19.230530045s] ["completed regions"=201]
```

