### PR TITLE
Add a switch in cfg to enable the read ts validator

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,8 @@ type Config struct {
 	// RegionsRefreshInterval indicates the interval of loading regions info, the unit is second, if RegionsRefreshInterval == 0, it will be disabled.
 	RegionsRefreshInterval uint64
 	// EnablePreload indicates whether to preload region info when initializing the client.
-	EnablePreload bool
+	EnablePreload         bool
+	EnableReadTSValidator bool
 }
 
 // DefaultConfig returns the default configuration.
@@ -99,6 +100,7 @@ func DefaultConfig() Config {
 		TxnScope:              "",
 		EnableAsyncCommit:     false,
 		Enable1PC:             false,
+		EnableReadTSValidator: true,
 	}
 }
 

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -45,6 +45,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/tikv/client-go/v2/config"
+
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -402,6 +404,9 @@ func (s *ReplicaAccessStats) String() string {
 
 // NewRegionRequestSender creates a new sender.
 func NewRegionRequestSender(regionCache *RegionCache, client client.Client, readTSValidator oracle.ReadTSValidator) *RegionRequestSender {
+	if !config.GetGlobalConfig().EnableReadTSValidator {
+		readTSValidator = oracle.NoopReadTSValidator{}
+	}
 	return &RegionRequestSender{
 		regionCache:     regionCache,
 		apiVersion:      regionCache.codec.GetAPIVersion(),

--- a/oracle/oracles/pd.go
+++ b/oracle/oracles/pd.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/util"
 	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/clients/tso"
 	"go.uber.org/zap"
@@ -661,6 +662,10 @@ func (o *pdOracle) getCurrentTSForValidation(ctx context.Context, opt *oracle.Op
 }
 
 func (o *pdOracle) ValidateReadTS(ctx context.Context, readTS uint64, isStaleRead bool, opt *oracle.Option) (errRet error) {
+	if val, err := util.EvalFailpoint("failOnValidateReadTS"); err == nil {
+		return errors.New(val.(string))
+	}
+
 	if readTS == math.MaxUint64 {
 		if isStaleRead {
 			return oracle.ErrLatestStaleRead{}
@@ -695,6 +700,7 @@ func (o *pdOracle) ValidateReadTS(ctx context.Context, readTS uint64, isStaleRea
 			o.adjustUpdateLowResolutionTSIntervalWithRequestedStaleness(readTS, estimatedCurrentTS, time.Now())
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Ref https://github.com/pingcap/tidb/issues/57786

The read ts validator doesn't come with any config items. The PR adds a switch to it to allow disabling it in production if any issues arise.