### PR TITLE
locate: fix the default settings of circuit breaker

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -136,9 +136,9 @@ func nextTTL(ts int64) int64 {
 
 var pdRegionMetaCircuitBreaker = circuitbreaker.NewCircuitBreaker("region-meta",
 	circuitbreaker.Settings{
-		ErrorRateWindow:      30,
+		ErrorRateWindow:      30 * time.Second,
 		MinQPSForOpen:        10,
-		CoolDownInterval:     10,
+		CoolDownInterval:     10 * time.Second,
 		HalfOpenSuccessCount: 1,
 	})
 


### PR DESCRIPTION
ref https://github.com/tikv/pd/issues/8678
The default settings are wrong, the unit should be the second.