### PR TITLE
Support updating progress of pipelined DML

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20250117122752-2b87602a94a1 // indirect
+	github.com/pingcap/kvproto v0.0.0-20250224053625-b6a98c6bf02d // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250213082949-e8930327be42 // indirect
+	github.com/tikv/pd/client v0.0.0-20250305170641-bdd857e5503b // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1806,6 +1806,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			return errors.Errorf("unexpected empty pipelinedStart(%s) or pipelinedEnd(%s)",
 				c.pipelinedCommitInfo.pipelinedStart, c.pipelinedCommitInfo.pipelinedEnd)
 		}
+		util.EvalFailpoint("beforePipelinedCommit")
 		return c.commitFlushedMutations(bo)
 	}
 

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -401,7 +401,7 @@ func (c *twoPhaseCommitter) buildPipelinedResolveHandler(commit bool, resolved *
 	// Use time-based callback control
 	lastCallback := atomic.Value{}
 	lastCallback.Store(time.Now().Add(-minProgressUpdateInterval))
-	
+
 	return func(ctx context.Context, r kv.KeyRange) (rangetask.TaskStat, error) {
 		start := r.StartKey
 		res := rangetask.TaskStat{}
@@ -450,7 +450,7 @@ func (c *twoPhaseCommitter) buildPipelinedResolveHandler(commit bool, resolved *
 			}
 			resolved.Add(1)
 			res.CompletedRegions++
-			
+
 			// Update progress periodically
 			if c.txn.pipelinedProgressCallback != nil {
 				now := time.Now()
@@ -459,8 +459,8 @@ func (c *twoPhaseCommitter) buildPipelinedResolveHandler(commit bool, resolved *
 				if timeSinceLastCallback < 0 {
 					timeSinceLastCallback = minProgressUpdateInterval
 				}
-				if timeSinceLastCallback >= minProgressUpdateInterval && 
-				   lastCallback.CompareAndSwap(last, now) {
+				if timeSinceLastCallback >= minProgressUpdateInterval &&
+					lastCallback.CompareAndSwap(last, now) {
 					resolvedCount := int64(resolved.Load())
 					c.txn.pipelinedProgressCallback(
 						c.startTS,
@@ -470,7 +470,7 @@ func (c *twoPhaseCommitter) buildPipelinedResolveHandler(commit bool, resolved *
 					)
 				}
 			}
-			
+
 			done := loc.EndKey == nil || bytes.Compare(loc.EndKey, r.EndKey) >= 0
 			if done {
 				return res, nil
@@ -544,7 +544,7 @@ func (c *twoPhaseCommitter) resolveFlushedLocks(bo *retry.Backoffer, start, end 
 					true,
 				)
 			}
-			
+
 			// wait a while before notifying txn_status_cache to evict the txn,
 			// which tolerates slow followers and avoids the situation that the
 			// txn is evicted before the follower catches up.

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -208,7 +208,7 @@ type KVTxn struct {
 	pipelinedResolveLockConcurrency int
 	writeThrottleRatio              float64
 	// flushBatchDurationEWMA is read before each flush, and written after each flush => no race
-	flushBatchDurationEWMA ewma.MovingAverage
+	flushBatchDurationEWMA    ewma.MovingAverage
 	pipelinedProgressCallback PipelinedProgressCallbackType
 	// progressRecordInitiated is only updated in the flush process, which is single-threaded. No need to use atomic.
 	progressRecordInitiated bool
@@ -1946,7 +1946,7 @@ type PipelinedDMLStatus int
 
 const (
 	// PipelinedDMLExecuting means the transaction is executing
-	PipelinedDMLExecuting PipelinedDMLStatus = iota	
+	PipelinedDMLExecuting PipelinedDMLStatus = iota
 	// PipelinedDMLRollingBack means the transaction is rolling back
 	PipelinedDMLRollingBack
 	// PipelinedDMLResolvingLocks means the transaction is resolving locks
@@ -1962,5 +1962,5 @@ type PipelinedProgressCallbackType func(startTS uint64, status PipelinedDMLStatu
 
 // SetPipelinedProgressCallback sets the callback function for pipelined DML resolve lock progress
 func (txn *KVTxn) SetPipelinedProgressCallback(callback PipelinedProgressCallbackType) {
-    txn.pipelinedProgressCallback = callback
+	txn.pipelinedProgressCallback = callback
 }


### PR DESCRIPTION
A callback is passed to client-go to update progress. The main motivation is to indicate the user whether there might be locks written by PDML that have not been resolved.
1. When first flush happens, update
2. When rollback, update
3. During resolve lock progress, periodically update