### PR TITLE
Refine pessimistic lock related metrics and stats

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -61,9 +61,6 @@ type LockCtx struct {
 	ForUpdateTS             uint64
 	lockWaitTime            *lockWaitTimeInMs
 	WaitStartTime           time.Time
-	PessimisticLockWaited   *int32
-	LockKeysDuration        *int64
-	LockKeysCount           *int32
 	ReturnValues            bool
 	CheckExistence          bool
 	LockOnlyIfExists        bool

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -517,16 +517,6 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Buckets:     prometheus.ExponentialBuckets(1, 2, 20), // 1s ~ 524288s
 		})
 
-	TiKVPessimisticLockKeysDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace:   namespace,
-			Subsystem:   subsystem,
-			Name:        "pessimistic_lock_keys_duration",
-			Buckets:     prometheus.ExponentialBuckets(0.001, 2, 24), // 1ms ~ 8389s
-			Help:        "tidb txn pessimistic lock keys duration",
-			ConstLabels: constLabels,
-		})
-
 	TiKVTTLLifeTimeReachCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace:   namespace,
@@ -907,7 +897,6 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVTokenWaitDuration)
 	prometheus.MustRegister(TiKVTxnHeartBeatHistogram)
 	prometheus.MustRegister(TiKVTTLManagerHistogram)
-	prometheus.MustRegister(TiKVPessimisticLockKeysDuration)
 	prometheus.MustRegister(TiKVTTLLifeTimeReachCounter)
 	prometheus.MustRegister(TiKVNoAvailableConnectionCounter)
 	prometheus.MustRegister(TiKVTwoPCTxnCounter)

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -381,9 +381,6 @@ func (action actionPessimisticLock) handlePessimisticLockResponseNormalMode(
 				return true, errors.WithStack(tikverr.ErrLockWaitTimeout)
 			}
 		}
-		if action.LockCtx.PessimisticLockWaited != nil {
-			atomic.StoreInt32(action.LockCtx.PessimisticLockWaited, 1)
-		}
 	}
 
 	return false, nil
@@ -509,9 +506,6 @@ func (action actionPessimisticLock) handlePessimisticLockResponseForceLockMode(
 					if time.Since(action.WaitStartTime).Milliseconds() >= action.LockWaitTime() {
 						return true, errors.WithStack(tikverr.ErrLockWaitTimeout)
 					}
-				}
-				if action.LockCtx.PessimisticLockWaited != nil {
-					atomic.StoreInt32(action.LockCtx.PessimisticLockWaited, 1)
 				}
 			}
 			return false, nil

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1360,18 +1360,6 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 		} else {
 			metrics.TxnCmdHistogramWithLockKeysGeneral.Observe(time.Since(startTime).Seconds())
 		}
-		if err == nil {
-			if lockCtx.PessimisticLockWaited != nil {
-				if atomic.LoadInt32(lockCtx.PessimisticLockWaited) > 0 {
-					timeWaited := time.Since(lockCtx.WaitStartTime)
-					atomic.StoreInt64(lockCtx.LockKeysDuration, int64(timeWaited))
-					metrics.TiKVPessimisticLockKeysDuration.Observe(timeWaited.Seconds())
-				}
-			}
-		}
-		if lockCtx.LockKeysCount != nil {
-			*lockCtx.LockKeysCount += int32(len(keys))
-		}
 		if lockCtx.Stats != nil {
 			lockCtx.Stats.TotalTime = time.Since(startTime)
 			ctxValue := ctx.Value(util.LockKeysDetailCtxKey)


### PR DESCRIPTION
This PR mainly forcus to replace some existing perssimistic stats with lockCtx.Stats struct, and move the TiKVPessimisticLockKeysDuration metric to tidb side, since the final merged lockCtx.Stats will be ready in tidb side.
Using lockCtx.Stats to replace existing LockKeys_Duration stats have several advantages:

1. Won't miss any lock time when the lock is not successfully accquired at last.
2. Don't rely on the Waited flag to record lock time
3. No need to keep similar stats in lockCtx and lockCtx.Stats