### PR TITLE
Fix backoff lose info when forked

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -297,17 +297,16 @@ func (b *Backoffer) UpdateUsingForked(forked *Backoffer) {
 	if forked == nil {
 		return
 	}
-	forkedParent := forked.parent
-	// We should check forkedParent == b here to only update bo with bo's child. However, in our existing code,
-	// we sometimes fork a already forked backoffer, so we need to update using the grand child backoffer.
-	if forkedParent == nil || (forkedParent != b && forkedParent.parent != b) {
-		return
+	for bo := forked.parent; bo != nil; bo = bo.parent {
+		if bo == b {
+			b.totalSleep = forked.totalSleep
+			b.excludedSleep = forked.excludedSleep
+			b.errors = forked.errors
+			b.backoffSleepMS = forked.backoffSleepMS
+			b.backoffTimes = forked.backoffTimes
+			break
+		}
 	}
-	b.totalSleep = forked.totalSleep
-	b.excludedSleep = forked.excludedSleep
-	b.errors = forked.errors
-	b.backoffSleepMS = forked.backoffSleepMS
-	b.backoffTimes = forked.backoffTimes
 }
 
 // GetVars returns the binded vars.

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -300,7 +300,7 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 // MergeForked merged back forked Backoffer's status
 // Note: Make sure forked is no longer used after this, because b reuses forked's errors/backoffSleepMS/backoffTimes fields
 func (b *Backoffer) MergeForked(forked *Backoffer) {
-	if forked == nil || forked.parent != b {
+	if forked == nil {
 		return
 	}
 	b.totalSleep = forked.totalSleep

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -297,10 +297,16 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 	}, cancel
 }
 
-// MergeForked merged back forked Backoffer's status
+// UpdateUsingForked updates Backoffer's status using forked one's
 // Note: Make sure forked is no longer used after this, because b reuses forked's errors/backoffSleepMS/backoffTimes fields
-func (b *Backoffer) MergeForked(forked *Backoffer) {
+func (b *Backoffer) UpdateUsingForked(forked *Backoffer) {
 	if forked == nil {
+		return
+	}
+	forkedParent := forked.parent
+	// We should check forkedParent == b here to only update bo with bo's child. However, in our existing code,
+	// we sometimes fork a already forked backoffer, so we need to update using the grand child backoffer.
+	if forkedParent == nil || (forkedParent != b && forkedParent.parent != b) {
 		return
 	}
 	b.totalSleep = forked.totalSleep

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -74,12 +74,6 @@ type Backoffer struct {
 	parent         *Backoffer
 }
 
-// ErrWithBo wraps err with Backoffer pointer
-type ErrWithBo struct {
-	Error error
-	Bo    *Backoffer
-}
-
 type txnStartCtxKeyType struct{}
 
 // TxnStartKey is a key for transaction start_ts info in context.Context.

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -74,6 +74,12 @@ type Backoffer struct {
 	parent         *Backoffer
 }
 
+// ErrWithBo wraps err with Backoffer pointer
+type ErrWithBo struct {
+	Error error
+	Bo    *Backoffer
+}
+
 type txnStartCtxKeyType struct{}
 
 // TxnStartKey is a key for transaction start_ts info in context.Context.
@@ -289,6 +295,16 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 		vars:           b.vars,
 		parent:         b,
 	}, cancel
+}
+
+// MergeForked merged back forked Backoffer's status
+// Note: Make sure forked is no longer used after this, because b reuses forked's errors/backoffSleepMS/backoffTimes fields
+func (b *Backoffer) MergeForked(forked *Backoffer) {
+	b.totalSleep = forked.totalSleep
+	b.excludedSleep = forked.excludedSleep
+	b.errors = forked.errors
+	b.backoffSleepMS = forked.backoffSleepMS
+	b.backoffTimes = forked.backoffTimes
 }
 
 // GetVars returns the binded vars.

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -300,6 +300,9 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 // MergeForked merged back forked Backoffer's status
 // Note: Make sure forked is no longer used after this, because b reuses forked's errors/backoffSleepMS/backoffTimes fields
 func (b *Backoffer) MergeForked(forked *Backoffer) {
+	if forked == nil || forked.parent != b {
+		return
+	}
 	b.totalSleep = forked.totalSleep
 	b.excludedSleep = forked.excludedSleep
 	b.errors = forked.errors

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -100,7 +100,7 @@ func TestBackoffDeepCopy(t *testing.T) {
 	}
 }
 
-func TestBackoffMergeFork(t *testing.T) {
+func TestBackoffUpdateUsingFork(t *testing.T) {
 	var err error
 	b := NewBackofferWithVars(context.TODO(), 4, nil)
 	// 700 ms sleep in total and the backoffer will return an error next time.

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -112,7 +112,7 @@ func TestBackoffMergeFork(t *testing.T) {
 	defer cancel()
 	bForked.Backoff(BoTiKVRPC, errors.New("tikv rpc"))
 	bCloneForked := bForked.Clone()
-	b.MergeForked(bForked)
+	b.UpdateUsingForked(bForked)
 	assert.Equal(t, b.errors, bCloneForked.errors)
 	assert.Equal(t, b.backoffSleepMS, bCloneForked.backoffSleepMS)
 	assert.Equal(t, b.backoffTimes, bCloneForked.backoffTimes)

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -100,6 +100,27 @@ func TestBackoffDeepCopy(t *testing.T) {
 	}
 }
 
+func TestBackoffMergeFork(t *testing.T) {
+	var err error
+	b := NewBackofferWithVars(context.TODO(), 4, nil)
+	// 700 ms sleep in total and the backoffer will return an error next time.
+	for i := 0; i < 3; i++ {
+		err = b.Backoff(BoMaxRegionNotInitialized, errors.New("region not initialized"))
+		assert.Nil(t, err)
+	}
+	bForked, cancel := b.Fork()
+	defer cancel()
+	bForked.Backoff(BoTiKVRPC, errors.New("tikv rpc"))
+	bCloneForked := bForked.Clone()
+	b.MergeForked(bForked)
+	assert.Equal(t, b.errors, bCloneForked.errors)
+	assert.Equal(t, b.backoffSleepMS, bCloneForked.backoffSleepMS)
+	assert.Equal(t, b.backoffTimes, bCloneForked.backoffTimes)
+	assert.Equal(t, b.excludedSleep, bCloneForked.excludedSleep)
+	assert.Equal(t, b.totalSleep, bCloneForked.totalSleep)
+	assert.Nil(t, b.parent)
+}
+
 func TestBackoffWithMaxExcludedExceed(t *testing.T) {
 	setBackoffExcluded(BoTiKVServerBusy.name, 1)
 	b := NewBackofferWithVars(context.TODO(), 1, nil)

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -921,18 +921,17 @@ func (c *Client) sendBatchPut(bo *retry.Backoffer, keys, values [][]byte, ttls [
 	}
 
 	for i := range batches {
-		if ewb, ok := <-ch; ok {
-			if ewb.Error != nil {
-				// catch the first error
-				if err == nil {
-					err = errors.WithStack(ewb.Error)
-					cancel()
-				}
+		ewb := <-ch
+		if ewb.Error != nil {
+			// catch the first error
+			if err == nil {
+				err = errors.WithStack(ewb.Error)
+				cancel()
 			}
-			// Use the slowest execution's bo to replace the original bo
-			if i+1 == len(batches) {
-				bo.UpdateUsingForked(ewb.Bo)
-			}
+		}
+		// Use the slowest execution's bo to replace the original bo
+		if i+1 == len(batches) {
+			bo.UpdateUsingForked(ewb.Bo)
 		}
 	}
 

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -773,7 +773,7 @@ func (c *Client) sendBatchReq(bo *retry.Backoffer, keys [][]byte, options *rawOp
 			}
 			// Use the slowest execution's bo to replace the original bo
 			if i+1 == len(batches) {
-				bo.MergeForked(singleResp.bo)
+				bo.UpdateUsingForked(singleResp.bo)
 			}
 		}
 	}
@@ -931,7 +931,7 @@ func (c *Client) sendBatchPut(bo *retry.Backoffer, keys, values [][]byte, ttls [
 			}
 			// Use the slowest execution's bo to replace the original bo
 			if i+1 == len(batches) {
-				bo.MergeForked(ewb.Bo)
+				bo.UpdateUsingForked(ewb.Bo)
 			}
 		}
 	}

--- a/rawkv/rawkv.go
+++ b/rawkv/rawkv.go
@@ -906,9 +906,9 @@ func (c *Client) sendBatchPut(bo *retry.Backoffer, keys, values [][]byte, ttls [
 		go func() {
 			singleBatchBackoffer, singleBatchCancel := newBo.Fork()
 			defer singleBatchCancel()
-			err := c.doBatchPut(singleBatchBackoffer, batch1, opts)
+			e := c.doBatchPut(singleBatchBackoffer, batch1, opts)
 			lastForkedBo.Store(singleBatchBackoffer)
-			ch <- err
+			ch <- e
 		}()
 	}
 

--- a/tikv/split_region.go
+++ b/tikv/split_region.go
@@ -147,7 +147,7 @@ func (s *KVStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter boo
 
 		// Use the slowest execution's bo to replace the original bo
 		if i+1 == len(batches) && wrappedBatchResp.boValid {
-			bo.MergeForked(wrappedBatchResp.bo)
+			bo.UpdateUsingForked(wrappedBatchResp.bo)
 		}
 	}
 	return &tikvrpc.Response{Resp: srResp}, err

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -971,7 +971,7 @@ func (lr *LockResolver) resolveAsyncResolveData(bo *retry.Backoffer, l *Lock, st
 	if err != nil {
 		return err
 	}
-	errChan := make(chan error, len(keysByRegion))
+	errChan := make(chan retry.ErrWithBo, len(keysByRegion))
 	// Resolve every lock in the transaction.
 	for region, locks := range keysByRegion {
 		curLocks := locks
@@ -980,15 +980,23 @@ func (lr *LockResolver) resolveAsyncResolveData(bo *retry.Backoffer, l *Lock, st
 		defer cancel()
 
 		go func() {
-			errChan <- lr.resolveRegionLocks(resolveBo, l, curRegion, curLocks, status)
+			var ewb retry.ErrWithBo
+			ewb.Error = lr.resolveRegionLocks(resolveBo, l, curRegion, curLocks, status)
+			ewb.Bo = resolveBo
+			errChan <- ewb
 		}()
 	}
 
 	var errs []string
-	for range keysByRegion {
-		err1 := <-errChan
-		if err1 != nil {
-			errs = append(errs, err1.Error())
+	for i := range len(keysByRegion) {
+		if ewb, ok := <-errChan; ok {
+			if ewb.Error != nil {
+				errs = append(errs, ewb.Error.Error())
+			}
+			// Use the slowest execution's bo to replace the original bo
+			if i+1 == len(keysByRegion) {
+				bo.MergeForked(ewb.Bo)
+			}
 		}
 	}
 
@@ -1045,7 +1053,7 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 		missingLock: false,
 	}
 
-	errChan := make(chan error, len(regions))
+	errChan := make(chan retry.ErrWithBo, len(regions))
 	for regionID, keys := range regions {
 		curRegionID := regionID
 		curKeys := keys
@@ -1053,14 +1061,22 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 		defer cancel()
 
 		go func() {
-			errChan <- lr.checkSecondaries(checkBo, l.TxnID, curKeys, curRegionID, &shared)
+			var ewb retry.ErrWithBo
+			ewb.Error = lr.checkSecondaries(checkBo, l.TxnID, curKeys, curRegionID, &shared)
+			ewb.Bo = checkBo
+			errChan <- ewb
 		}()
 	}
 
-	for range regions {
-		err := <-errChan
-		if err != nil {
-			return nil, err
+	for i := range len(regions) {
+		if ewb, ok := <-errChan; ok {
+			// Use the slowest execution's bo to replace the original bo
+			if i+1 == len(regions) {
+				bo.MergeForked(ewb.Bo)
+			}
+			if ewb.Error != nil {
+				return nil, ewb.Error
+			}
 		}
 	}
 

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -995,7 +995,7 @@ func (lr *LockResolver) resolveAsyncResolveData(bo *retry.Backoffer, l *Lock, st
 			}
 			// Use the slowest execution's bo to replace the original bo
 			if i+1 == len(keysByRegion) {
-				bo.MergeForked(ewb.Bo)
+				bo.UpdateUsingForked(ewb.Bo)
 			}
 		}
 	}
@@ -1072,7 +1072,7 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 		if ewb, ok := <-errChan; ok {
 			// Use the slowest execution's bo to replace the original bo
 			if i+1 == len(regions) {
-				bo.MergeForked(ewb.Bo)
+				bo.UpdateUsingForked(ewb.Bo)
 			}
 			if ewb.Error != nil {
 				return nil, ewb.Error

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -361,28 +361,37 @@ func (s *KVSnapshot) batchGetKeysByRegions(bo *retry.Backoffer, keys [][]byte, r
 	if len(batches) == 1 {
 		return s.batchGetSingleRegion(bo, batches[0], readTier, collectF)
 	}
-	ch := make(chan error, len(batches))
-	bo, cancel := bo.Fork()
+	ch := make(chan retry.ErrWithBo, len(batches))
+	forkedBo, cancel := bo.Fork()
 	defer cancel()
 	for i, batch1 := range batches {
 		var backoffer *retry.Backoffer
 		if i == 0 {
-			backoffer = bo
+			backoffer = forkedBo
 		} else {
-			backoffer = bo.Clone()
+			backoffer = forkedBo.Clone()
 		}
 		batch := batch1
 		go func() {
 			growStackForBatchGetWorker()
-			ch <- s.batchGetSingleRegion(backoffer, batch, readTier, collectF)
+			var ewb retry.ErrWithBo
+			ewb.Error = s.batchGetSingleRegion(backoffer, batch, readTier, collectF)
+			ewb.Bo = backoffer
+			ch <- ewb
 		}()
 	}
-	for i := 0; i < len(batches); i++ {
-		if e := <-ch; e != nil {
-			logutil.BgLogger().Debug("snapshot BatchGetWithTier failed",
-				zap.Error(e),
-				zap.Uint64("txnStartTS", s.version))
-			err = errors.WithStack(e)
+	for i := range batches {
+		if ewb, ok := <-ch; ok {
+			if ewb.Error != nil {
+				logutil.BgLogger().Debug("snapshot BatchGetWithTier failed",
+					zap.Error(ewb.Error),
+					zap.Uint64("txnStartTS", s.version))
+				err = errors.WithStack(ewb.Error)
+			}
+			// Use the slowest execution's bo to replace the original bo
+			if i+1 == len(batches) {
+				bo.MergeForked(ewb.Bo)
+			}
 		}
 	}
 	return err

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -390,7 +390,7 @@ func (s *KVSnapshot) batchGetKeysByRegions(bo *retry.Backoffer, keys [][]byte, r
 			}
 			// Use the slowest execution's bo to replace the original bo
 			if i+1 == len(batches) {
-				bo.MergeForked(ewb.Bo)
+				bo.UpdateUsingForked(ewb.Bo)
 			}
 		}
 	}


### PR DESCRIPTION
ref https://github.com/pingcap/tidb/issues/60271
For current Backoffer code, when we send rpc concurrently for multiple regions, the Backoffer object will be forked multiple times to keep isolated. However, the forked Backoffer's info is never merged into its parent, causing Backoffer info lose. In this PR, we use the slowest execution path to merge back Backoffer info.
Two Backoffer fork in 2pc.go keeps unchanged, because I have no confidence to ensure funcitonality correctness:
https://github.com/tikv/client-go/blob/2b8c6a77616c9b43ccdc5c115e122276423db477/txnkv/transaction/2pc.go#L2258
https://github.com/tikv/client-go/blob/2b8c6a77616c9b43ccdc5c115e122276423db477/txnkv/transaction/2pc.go#L2303