### PR TITLE
Replace etcd safe point with txn safe point for read safety check

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -246,12 +246,14 @@ func (e *ErrPDServerTimeout) Error() string {
 
 // ErrGCTooEarly is the error that GC life time is shorter than transaction duration
 type ErrGCTooEarly struct {
-	TxnStartTS  time.Time
-	GCSafePoint time.Time
+	TxnStartTS       uint64
+	TxnStartTSTime   time.Time
+	TxnSafePoint     uint64
+	TxnSafePointTime time.Time
 }
 
 func (e *ErrGCTooEarly) Error() string {
-	return fmt.Sprintf("GC life time is shorter than transaction duration, transaction starts at %v, GC safe point is %v", e.TxnStartTS, e.GCSafePoint)
+	return fmt.Sprintf("GC life time is shorter than transaction duration, transaction start ts is %v (%v), GC safe point is %v (%v)", e.TxnStartTS, e.TxnStartTSTime, e.TxnSafePoint, e.TxnSafePointTime)
 }
 
 // ErrTokenLimit is the error that token is up to the limit.

--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/pingcap/kvproto => github.com/MyonKeminta/kvproto v0.0.0-20250311094808-d79890a8c4af
+
+replace github.com/tikv/pd/client => github.com/MyonKeminta/pd/client v0.0.0-20250417085901-68c5cb78d5bb

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/MyonKeminta/kvproto v0.0.0-20250311094808-d79890a8c4af/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/MyonKeminta/pd/client v0.0.0-20250417085901-68c5cb78d5bb/go.mod h1:CFIxUay+Ru4j7F56fBCqCoThyjT6M+zKPIR6StdW8WM=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -116,3 +116,7 @@ replace (
 
 	github.com/tikv/client-go/v2 => ../
 )
+
+replace github.com/pingcap/kvproto => github.com/MyonKeminta/kvproto v0.0.0-20250311094808-d79890a8c4af
+
+replace github.com/tikv/pd/client => github.com/MyonKeminta/pd/client v0.0.0-20250417085901-68c5cb78d5bb

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -843,6 +843,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXY
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/MyonKeminta/kvproto v0.0.0-20250311094808-d79890a8c4af/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/MyonKeminta/pd/client v0.0.0-20250417085901-68c5cb78d5bb/go.mod h1:CFIxUay+Ru4j7F56fBCqCoThyjT6M+zKPIR6StdW8WM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=

--- a/integration_tests/safepoint_test.go
+++ b/integration_tests/safepoint_test.go
@@ -89,7 +89,7 @@ func (s *testSafePointSuite) waitUntilErrorPlugIn(t uint64) {
 		cachedTime := time.Now()
 		newSafePoint, err := s.store.LoadSafePoint()
 		if err == nil {
-			s.store.UpdateSPCache(newSafePoint, cachedTime)
+			s.store.UpdateTxnSafePointCache(newSafePoint, cachedTime)
 			break
 		}
 		time.Sleep(time.Second)

--- a/tikv/interface.go
+++ b/tikv/interface.go
@@ -58,8 +58,9 @@ type Storage interface {
 	// GetSafePointKV gets the SafePointKV.
 	GetSafePointKV() SafePointKV
 
-	// UpdateSPCache updates the cache of safe point.
-	UpdateSPCache(cachedSP uint64, cachedTime time.Time)
+	// UpdateTxnSafePointCache updates the cached txn safe point, which is used for safety check of data access
+	// operations to prevent accessing GC-ed inconsistent data.
+	UpdateTxnSafePointCache(txnSafePoint uint64, now time.Time)
 
 	// SetOracle sets the Oracle.
 	SetOracle(oracle oracle.Oracle)

--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -133,10 +133,13 @@ type KVStore struct {
 
 	mock bool
 
-	kv        SafePointKV
-	safePoint uint64
-	spTime    time.Time
-	spMutex   sync.RWMutex // this is used to update safePoint and spTime
+	kv SafePointKV
+
+	gcStateCacheMu struct {
+		sync.RWMutex
+		cachedTxnSafePoint uint64
+		lastCacheTime      time.Time
+	}
 
 	// storeID -> safeTS, stored as map[uint64]uint64
 	// safeTS here will be used during the Stale Read process,
@@ -162,32 +165,36 @@ func (s *KVStore) Go(f func()) error {
 	return s.gP.Run(f)
 }
 
-// UpdateSPCache updates cached safepoint.
-func (s *KVStore) UpdateSPCache(cachedSP uint64, cachedTime time.Time) {
-	s.spMutex.Lock()
-	s.safePoint = cachedSP
-	s.spTime = cachedTime
-	s.spMutex.Unlock()
+// UpdateTxnSafePointCache updates the cached txn safe point, which is used for safety check of data access
+// operations to prevent accessing GC-ed inconsistent data.
+func (s *KVStore) UpdateTxnSafePointCache(txnSafePoint uint64, now time.Time) {
+	s.gcStateCacheMu.Lock()
+	defer s.gcStateCacheMu.Unlock()
+
+	s.gcStateCacheMu.lastCacheTime = now
+	s.gcStateCacheMu.cachedTxnSafePoint = txnSafePoint
 }
 
 // CheckVisibility checks if it is safe to read using given ts.
-func (s *KVStore) CheckVisibility(startTime uint64) error {
-	s.spMutex.RLock()
-	cachedSafePoint := s.safePoint
-	cachedTime := s.spTime
-	s.spMutex.RUnlock()
-	diff := time.Since(cachedTime)
+func (s *KVStore) CheckVisibility(startTS uint64) error {
+	s.gcStateCacheMu.RLock()
+	lastCacheTime := s.gcStateCacheMu.lastCacheTime
+	cachedTxnSafePoint := s.gcStateCacheMu.cachedTxnSafePoint
+	s.gcStateCacheMu.RUnlock()
+	diff := time.Since(lastCacheTime)
 
 	if diff > (GcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
 		return tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point")
 	}
 
-	if startTime < cachedSafePoint {
-		t1 := oracle.GetTimeFromTS(startTime)
-		t2 := oracle.GetTimeFromTS(cachedSafePoint)
+	if startTS < cachedTxnSafePoint {
+		t1 := oracle.GetTimeFromTS(startTS)
+		t2 := oracle.GetTimeFromTS(cachedTxnSafePoint)
 		return &tikverr.ErrGCTooEarly{
-			TxnStartTS:  t1,
-			GCSafePoint: t2,
+			TxnStartTS:       startTS,
+			TxnStartTSTime:   t1,
+			TxnSafePoint:     cachedTxnSafePoint,
+			TxnSafePointTime: t2,
 		}
 	}
 
@@ -288,13 +295,12 @@ func NewKVStore(uuid string, pdClient pd.Client, spkv SafePointKV, tikvclient Cl
 		pdClient:        pdClient.WithCallerComponent("kv-store"),
 		regionCache:     regionCache,
 		kv:              spkv,
-		safePoint:       0,
-		spTime:          time.Now(),
 		replicaReadSeed: rand.Uint32(),
 		ctx:             ctx,
 		cancel:          cancel,
 		gP:              NewSpool(128, 10*time.Second),
 	}
+	store.gcStateCacheMu.lastCacheTime = time.Now()
 	store.clientMu.client = client.NewReqCollapse(client.NewInterceptedClient(tikvclient))
 	store.clientMu.client.SetEventListener(regionCache.GetClientEventListener())
 
@@ -302,7 +308,7 @@ func NewKVStore(uuid string, pdClient pd.Client, spkv SafePointKV, tikvclient Cl
 	loadOption(store, opt...)
 
 	store.wg.Add(2)
-	go store.runSafePointChecker()
+	go store.runTxnSafePointUpdater()
 	go store.safeTSUpdater()
 
 	return store, nil
@@ -347,26 +353,31 @@ func (s *KVStore) IsLatchEnabled() bool {
 	return s.txnLatches != nil
 }
 
-func (s *KVStore) runSafePointChecker() {
+func (s *KVStore) runTxnSafePointUpdater() {
 	defer s.wg.Done()
-	d := gcSafePointUpdateInterval
+	d := pollTxnSafePointInterval
+	gcStatesClient := s.pdClient.GetGCStatesClient(uint32(s.getCodec().GetKeyspaceID()))
 	for {
 		select {
-		case spCachedTime := <-time.After(d):
-			cachedSafePoint, err := loadSafePoint(s.GetSafePointKV())
+		case now := <-time.After(d):
+			gcStates, err := gcStatesClient.GetGCState(context.Background())
 			if err == nil {
 				metrics.TiKVLoadSafepointCounter.WithLabelValues("ok").Inc()
-				s.UpdateSPCache(cachedSafePoint, spCachedTime)
-				d = gcSafePointUpdateInterval
+				s.UpdateTxnSafePointCache(gcStates.TxnSafePoint, now)
+				d = pollTxnSafePointInterval
 			} else {
 				metrics.TiKVLoadSafepointCounter.WithLabelValues("fail").Inc()
-				logutil.BgLogger().Error("fail to load safepoint from pd", zap.Error(err))
-				d = gcSafePointQuickRepeatInterval
+				logutil.BgLogger().Error("fail to load txn safe point from pd", zap.Error(err))
+				d = pollTxnSafePointQuickRepeatInterval
 			}
 		case <-s.ctx.Done():
 			return
 		}
 	}
+}
+
+func (s *KVStore) getCodec() Codec {
+	return s.pdClient.(*CodecPDClient).GetCodec()
 }
 
 // Begin a global transaction.

--- a/tikv/safepoint.go
+++ b/tikv/safepoint.go
@@ -55,12 +55,13 @@ const (
 	// This is almost the same as 'tikv_gc_safe_point' in the table 'mysql.tidb',
 	// save this to pd instead of tikv, because we can't use interface of table
 	// if the safepoint on tidb is expired.
+	// Deprecated: All use this is no longer recommended and should be replaced by using the txn safe point.
 	GcSavedSafePoint = "/tidb/store/gcworker/saved_safe_point"
 
-	GcSafePointCacheInterval       = time.Second * 100
-	gcCPUTimeInaccuracyBound       = time.Second
-	gcSafePointUpdateInterval      = time.Second * 10
-	gcSafePointQuickRepeatInterval = time.Second
+	GcSafePointCacheInterval            = time.Second * 100
+	gcCPUTimeInaccuracyBound            = time.Second * 10
+	pollTxnSafePointInterval            = time.Second * 10
+	pollTxnSafePointQuickRepeatInterval = time.Second
 )
 
 // SafePointKV is used for a seamingless integration for mockTest and runtime.
@@ -205,6 +206,7 @@ func saveSafePoint(kv SafePointKV, t uint64) error {
 	return nil
 }
 
+// Deprecated: Do not use
 func loadSafePoint(kv SafePointKV) (uint64, error) {
 	str, err := kv.Get(GcSavedSafePoint)
 


### PR DESCRIPTION
Ref:
* https://github.com/pingcap/tidb/issues/58720
* https://github.com/tikv/pd/issues/8978

This PR updates the implementation of `CheckVisibility` and uses txn safe point instead of etcd safe point to do the check.
This is required as part of supporting keyspace level GC.