### PR TITLE
apicodec: fix a typo when encoding request for CmdMvccGetByKey

### DIFF
--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -281,7 +281,7 @@ func (c *codecV2) EncodeRequest(req *tikvrpc.Request) (*tikvrpc.Request, error) 
 		req.Req = &r
 	case tikvrpc.CmdMvccGetByKey:
 		r := *req.MvccGetByKey()
-		r.Key = c.EncodeRegionKey(r.Key)
+		r.Key = c.EncodeKey(r.Key)
 		req.Req = &r
 	case tikvrpc.CmdSplitRegion:
 		r := *req.SplitRegion()


### PR DESCRIPTION
It should be `EncodeKey` rather than `EncodeRegionKey`

Fix issue https://github.com/pingcap/tidb/issues/60716

Manually tested:

```
mysql> create table t (id int);
Query OK, 0 rows affected (0.10 sec)

mysql> insert into t values (1);
Query OK, 1 row affected (0.02 sec)

curl http://127.0.0.1:10080/mvcc/key/test/t/1
{
 "key": "74800000000000007F5F728000000000000001",
 "region_id": 1021,
 "value": {
  "info": {
   "writes": [
    {
     "start_ts": 457681415883718657,
     "commit_ts": 457681415883718659,
     "short_value": "gAABAAAAAQEAAQ=="
    }
   ]
  }
 }
}
```

Unit test is not easy to construct now, it's better to add UT after https://github.com/tikv/client-go/issues/1637