### PR TITLE
txnkv: prevent some actions from being interrupted by kill

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -2707,7 +2707,7 @@ func (s *testCommitterSuite) TestKillSignal() {
 	s.ErrorContains(err, "query interrupted")
 }
 
-func (s *testCommitterSuite) TestUninterruptableAction() {
+func (s *testCommitterSuite) TestUninterruptibleAction() {
 	s.Run("Cleanup", func() {
 		var killed uint32 = 0
 		txn := s.begin()

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -912,7 +912,7 @@ func (s *sendReqState) next() (done bool) {
 	bo, req := s.args.bo, s.args.req
 
 	// check whether the session/query is killed during the Next()
-	if req.IsInterruptable() {
+	if req.IsInterruptible() {
 		if err := bo.CheckKilled(); err != nil {
 			s.vars.resp, s.vars.err = nil, err
 			return true

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -911,9 +911,11 @@ func (s *sendReqState) next() (done bool) {
 	bo, req := s.args.bo, s.args.req
 
 	// check whether the session/query is killed during the Next()
-	if err := bo.CheckKilled(); err != nil {
-		s.vars.resp, s.vars.err = nil, err
-		return true
+	if req.IsInterruptable() {
+		if err := bo.CheckKilled(); err != nil {
+			s.vars.resp, s.vars.err = nil, err
+			return true
+		}
 	}
 
 	// handle send error

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -335,7 +335,7 @@ func (req *Request) IsDebugReq() bool {
 // IsInterruptable checks if the request can be interrupted when the query is killed.
 func (req *Request) IsInterruptable() bool {
 	switch req.Type {
-	case CmdPessimisticRollback, CmdBatchRollback:
+	case CmdPessimisticRollback, CmdBatchRollback, CmdCommit:
 		return false
 	default:
 		return true

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -332,6 +332,16 @@ func (req *Request) IsDebugReq() bool {
 	return false
 }
 
+// IsInterruptable checks if the request can be interrupted when the query is killed.
+func (req *Request) IsInterruptable() bool {
+	switch req.Type {
+	case CmdPessimisticRollback, CmdBatchRollback:
+		return false
+	default:
+		return true
+	}
+}
+
 // Get returns GetRequest in request.
 func (req *Request) Get() *kvrpcpb.GetRequest {
 	return req.Req.(*kvrpcpb.GetRequest)

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -340,8 +340,8 @@ func (req *Request) IsDebugReq() bool {
 	return false
 }
 
-// IsInterruptable checks if the request can be interrupted when the query is killed.
-func (req *Request) IsInterruptable() bool {
+// IsInterruptible checks if the request can be interrupted when the query is killed.
+func (req *Request) IsInterruptible() bool {
 	switch req.Type {
 	case CmdPessimisticRollback, CmdBatchRollback, CmdCommit:
 		return false

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -75,7 +75,7 @@ const slowRequestThreshold = time.Minute
 type twoPhaseCommitAction interface {
 	handleSingleBatch(*twoPhaseCommitter, *retry.Backoffer, batchMutations) error
 	tiKVTxnRegionsNumHistogram() prometheus.Observer
-	isInterruptable() bool
+	isInterruptible() bool
 	String() string
 }
 
@@ -1071,9 +1071,9 @@ func (c *twoPhaseCommitter) doActionOnBatches(
 	if c.txn != nil && c.txn.vars != nil && c.txn.vars.Killed != nil {
 		// Do not reset the killed flag here. Let the upper layer reset the flag.
 		// Before it resets, any request is considered valid to be killed if the
-		// corresponding action is interruptable.
+		// corresponding action is interruptible.
 		status := atomic.LoadUint32(c.txn.vars.Killed)
-		if status != 0 && action.isInterruptable() {
+		if status != 0 && action.isInterruptible() {
 			logutil.BgLogger().Info(
 				"query is killed", zap.Uint32(
 					"signal",

--- a/txnkv/transaction/cleanup.go
+++ b/txnkv/transaction/cleanup.go
@@ -103,7 +103,7 @@ func (action actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *retry.Ba
 	return nil
 }
 
-func (actionCleanup) isInterruptable() bool {
+func (actionCleanup) isInterruptible() bool {
 	return false
 }
 

--- a/txnkv/transaction/cleanup.go
+++ b/txnkv/transaction/cleanup.go
@@ -103,6 +103,10 @@ func (action actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *retry.Ba
 	return nil
 }
 
+func (actionCleanup) isInterruptable() bool {
+	return false
+}
+
 func (c *twoPhaseCommitter) cleanupMutations(bo *retry.Backoffer, mutations CommitterMutations) error {
 	return c.doActionOnMutations(bo, actionCleanup{isInternal: c.txn.isInternal()}, mutations)
 }

--- a/txnkv/transaction/commit.go
+++ b/txnkv/transaction/commit.go
@@ -248,7 +248,7 @@ func (action actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *retry.Bac
 }
 
 func (actionCommit) isInterruptable() bool {
-	return true
+	return false
 }
 
 func (c *twoPhaseCommitter) commitMutations(bo *retry.Backoffer, mutations CommitterMutations) error {

--- a/txnkv/transaction/commit.go
+++ b/txnkv/transaction/commit.go
@@ -247,6 +247,10 @@ func (action actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *retry.Bac
 	return nil
 }
 
+func (actionCommit) isInterruptable() bool {
+	return true
+}
+
 func (c *twoPhaseCommitter) commitMutations(bo *retry.Backoffer, mutations CommitterMutations) error {
 	if span := opentracing.SpanFromContext(bo.GetCtx()); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.commitMutations", opentracing.ChildOf(span.Context()))

--- a/txnkv/transaction/commit.go
+++ b/txnkv/transaction/commit.go
@@ -247,7 +247,7 @@ func (action actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *retry.Bac
 	return nil
 }
 
-func (actionCommit) isInterruptable() bool {
+func (actionCommit) isInterruptible() bool {
 	return false
 }
 

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -525,6 +525,10 @@ func (action actionPessimisticLock) handlePessimisticLockResponseForceLockMode(
 	return true, nil
 }
 
+func (actionPessimisticLock) isInterruptable() bool {
+	return true
+}
+
 func (actionPessimisticRollback) handleSingleBatch(
 	c *twoPhaseCommitter, bo *retry.Backoffer, batch batchMutations,
 ) error {
@@ -558,6 +562,10 @@ func (actionPessimisticRollback) handleSingleBatch(
 		return c.pessimisticRollbackMutations(bo, batch.mutations)
 	}
 	return nil
+}
+
+func (actionPessimisticRollback) isInterruptable() bool {
+	return false
 }
 
 func (c *twoPhaseCommitter) pessimisticLockMutations(

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -525,7 +525,7 @@ func (action actionPessimisticLock) handlePessimisticLockResponseForceLockMode(
 	return true, nil
 }
 
-func (actionPessimisticLock) isInterruptable() bool {
+func (actionPessimisticLock) isInterruptible() bool {
 	return true
 }
 
@@ -564,7 +564,7 @@ func (actionPessimisticRollback) handleSingleBatch(
 	return nil
 }
 
-func (actionPessimisticRollback) isInterruptable() bool {
+func (actionPessimisticRollback) isInterruptible() bool {
 	return false
 }
 

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -284,7 +284,7 @@ func (action actionPipelinedFlush) handleSingleBatch(
 	}
 }
 
-func (actionPipelinedFlush) isInterruptable() bool {
+func (actionPipelinedFlush) isInterruptible() bool {
 	return true
 }
 

--- a/txnkv/transaction/pipelined_flush.go
+++ b/txnkv/transaction/pipelined_flush.go
@@ -284,6 +284,10 @@ func (action actionPipelinedFlush) handleSingleBatch(
 	}
 }
 
+func (actionPipelinedFlush) isInterruptable() bool {
+	return true
+}
+
 func (c *twoPhaseCommitter) pipelinedFlushMutations(bo *retry.Backoffer, mutations CommitterMutations, generation uint64) error {
 	if span := opentracing.SpanFromContext(bo.GetCtx()); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.pipelinedFlushMutations", opentracing.ChildOf(span.Context()))

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -282,6 +282,10 @@ func (action actionPrewrite) handleSingleBatchFailpoint(c *twoPhaseCommitter, bo
 	return nil
 }
 
+func (actionPrewrite) isInterruptable() bool {
+	return true
+}
+
 func (c *twoPhaseCommitter) prewriteMutations(bo *retry.Backoffer, mutations CommitterMutations) error {
 	if span := opentracing.SpanFromContext(bo.GetCtx()); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.prewriteMutations", opentracing.ChildOf(span.Context()))

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -282,7 +282,7 @@ func (action actionPrewrite) handleSingleBatchFailpoint(c *twoPhaseCommitter, bo
 	return nil
 }
 
-func (actionPrewrite) isInterruptable() bool {
+func (actionPrewrite) isInterruptible() bool {
 	return true
 }
 


### PR DESCRIPTION
Ignore the kill flag when trying to send CommitRequest, PessimisticRollbackRequest and BatchRollbackRequest so that the locks can be cleaned up properly.

Fix https://github.com/pingcap/tidb/issues/61454 .

