### PR TITLE
snapshot: set `ReplicaRead` to false when `ReplicaReadType` fallbacks to `ReplicaReadLeader` (#1663)

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c // indirect
+	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/kvproto v0.0.0-20240227073058-929ab83f9754 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -44,12 +44,15 @@ import (
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
-	"github.com/tikv/client-go/v2/error"
+	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
@@ -163,7 +166,7 @@ func (s *testSnapshotSuite) TestSnapshotCache() {
 	_, err = snapshot.Get(context.Background(), []byte("a"))
 	s.Nil(err)
 	_, err = snapshot.Get(context.Background(), []byte("b"))
-	s.True(error.IsErrNotFound(err))
+	s.True(tikverr.IsErrNotFound(err))
 
 	s.Nil(failpoint.Enable("tikvclient/snapshot-get-cache-fail", `return(true)`))
 	ctx := context.WithValue(context.Background(), "TestSnapshotCache", true)
@@ -173,14 +176,14 @@ func (s *testSnapshotSuite) TestSnapshotCache() {
 	s.Nil(err)
 	s.Equal([]byte("x"), value)
 	_, err = snapshot.Get(ctx, []byte("y"))
-	s.True(error.IsErrNotFound(err))
+	s.True(tikverr.IsErrNotFound(err))
 
 	// check cache from Get
 	value, err = snapshot.Get(ctx, []byte("a"))
 	s.Nil(err)
 	s.Equal([]byte("a"), value)
 	_, err = snapshot.Get(ctx, []byte("b"))
-	s.True(error.IsErrNotFound(err))
+	s.True(tikverr.IsErrNotFound(err))
 
 	s.Nil(failpoint.Disable("tikvclient/snapshot-get-cache-fail"))
 }
@@ -228,7 +231,7 @@ func (s *testSnapshotSuite) TestSkipLargeTxnLock() {
 	txn1 := s.beginTxn()
 	// txn1 is not blocked by txn in the large txn protocol.
 	_, err = txn1.Get(ctx, x)
-	s.True(error.IsErrNotFound(err))
+	s.True(tikverr.IsErrNotFound(err))
 
 	res, err := toTiDBTxn(&txn1).BatchGet(ctx, toTiDBKeys([][]byte{x, y, []byte("z")}))
 	s.Nil(err)
@@ -260,7 +263,7 @@ func (s *testSnapshotSuite) TestPointGetSkipTxnLock() {
 	s.Equal(committer.GetPrimaryKey(), x)
 	// Point get secondary key. Shouldn't be blocked by the lock and read old data.
 	_, err = snapshot.Get(ctx, y)
-	s.True(error.IsErrNotFound(err))
+	s.True(tikverr.IsErrNotFound(err))
 	s.Less(time.Since(start), 500*time.Millisecond)
 
 	// Commit the primary key
@@ -419,4 +422,44 @@ func (s *testSnapshotSuite) TestSnapshotCacheBypassMaxUint64() {
 	snapshot.Get(context.Background(), []byte("x"))
 	snapshot.BatchGet(context.Background(), [][]byte{[]byte("y"), []byte("z")})
 	s.Empty(snapshot.SnapCache())
+}
+
+func (s *testSnapshotSuite) TestReplicaReadAdjuster() {
+	_, err := s.store.SplitRegions(context.Background(), [][]byte{[]byte("y1")}, false, nil)
+	s.Nil(err)
+	for _, hit := range []bool{true, false} {
+		txn := s.beginTxn()
+
+		// check the replica read type
+		fn := func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
+			return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+				// when the request is fallback to leader read, the ReplicaRead should be false to avoid read-index in store.
+				s.Equal(hit, req.ReplicaRead)
+				if hit {
+					s.Equal(kv.ReplicaReadMixed, req.ReplicaReadType)
+				} else {
+					s.Equal(kv.ReplicaReadLeader, req.ReplicaReadType)
+				}
+				return next(target, req)
+			}
+		}
+		txn.SetRPCInterceptor(interceptor.NewRPCInterceptor("check-req", fn))
+
+		// set up the replica read and adaptive read
+		txn.GetSnapshot().SetReplicaRead(kv.ReplicaReadMixed)
+		txn.GetSnapshot().SetReplicaReadAdjuster(func(int) (tikv.StoreSelectorOption, kv.ReplicaReadType) {
+			if hit {
+				return tikv.WithMatchLabels([]*metapb.StoreLabel{
+					{
+						Key:   tikv.DCLabelKey,
+						Value: "dc1",
+					},
+				}), kv.ReplicaReadMixed
+			}
+			return nil, kv.ReplicaReadLeader
+		})
+		txn.Get(context.Background(), []byte("x"))
+		txn.BatchGet(context.Background(), [][]byte{[]byte("y"), []byte("z")})
+		txn.Rollback()
+	}
 }

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -468,7 +468,7 @@ func (s *replicaSelectorV2) onFlashbackInProgress(ctx *RPCContext, req *tikvrpc.
 		req.BusyThresholdMs = 0
 		s.busyThreshold = 0
 		s.replicaReadType = kv.ReplicaReadLeader
-		req.ReplicaReadType = kv.ReplicaReadLeader
+		req.SetReplicaReadType(kv.ReplicaReadLeader)
 		return true
 	}
 	return false

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -837,7 +837,7 @@ func TestReplicaReadAccessPathByCase2(t *testing.T) {
 		expect: &accessPathResult{
 			accessPath: []string{
 				"{addr: store2, replica-read: true, stale-read: false}",
-				"{addr: store1, replica-read: true, stale-read: false}"},
+				"{addr: store1, replica-read: false, stale-read: false}"},
 			respErr:         "",
 			respRegionError: nil,
 			backoffCnt:      0,

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -286,6 +286,14 @@ func NewReplicaReadRequest(typ CmdType, pointer interface{}, replicaReadType kv.
 	return req
 }
 
+func (req *Request) SetReplicaReadType(replicaReadType kv.ReplicaReadType) {
+	if req == nil {
+		return
+	}
+	req.ReplicaRead = replicaReadType.IsFollowerRead()
+	req.ReplicaReadType = replicaReadType
+}
+
 // GetReplicaReadSeed returns ReplicaReadSeed pointer.
 func (req *Request) GetReplicaReadSeed() *uint32 {
 	if req != nil {

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -459,7 +459,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 			if op != nil {
 				ops = append(ops, op)
 			}
-			req.ReplicaReadType = readType
+			req.SetReplicaReadType(readType)
 		}
 		resp, _, _, err := cli.SendReqCtx(bo, req, batch.region, timeout, tikvrpc.TiKV, "", ops...)
 		if err != nil {
@@ -698,7 +698,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte) ([]
 		if op != nil {
 			ops = append(ops, op)
 		}
-		req.ReplicaReadType = readType
+		req.SetReplicaReadType(readType)
 	}
 
 	var firstLock *txnlock.Lock


### PR DESCRIPTION
Cherry pick #1663 to tidb-8.1

---

ref pingcap/tidb#61745

The [`replicaReadAdjuster`](https://github.com/tikv/client-go/blob/96b6487fac411fea3b4e15170d419d7b8307d6f2/txnkv/txnsnapshot/snapshot.go#L147-L148) can choose leader and follower replica after a request is created.
When the request is created as a replica-read request but fallback to leader read by `replicaReadAdjuster`, we need to set the [`replica_read`](https://github.com/pingcap/kvproto/blob/dc99a8f6e3487e3a73013c2e7d7cf9d5cbb55c45/proto/kvrpcpb.proto#L861) to false as well. Unless it can perform a meaningless read-index in leader and harm the performance.

## Before this PR

![image](https://github.com/user-attachments/assets/ce29517a-2c8c-47a2-9849-c869278eeee9)

Many read-index proposals.

![image](https://github.com/user-attachments/assets/fe8caa05-3f4c-4bd9-88c7-651872607887)

## This PR

![image](https://github.com/user-attachments/assets/53b73a55-689e-4436-b137-f1e8814fc496)

Few read-index proposals.

![image](https://github.com/user-attachments/assets/e935cbe7-73ed-4dcf-8076-3e7df0c2764c)
