### PR TITLE
(tidb-7.5) Support buckets for `ScanRegions` of mocktikv

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2518,6 +2518,10 @@ func (r *Region) Contains(key []byte) bool {
 // for the maximum region endKey is empty.
 // startKey < key <= endKey.
 func (r *Region) ContainsByEnd(key []byte) bool {
+	// Only a region's right bound expands to inf contains the point at inf.
+	if len(key) == 0 {
+		return len(r.EndKey()) == 0
+	}
 	return bytes.Compare(r.meta.GetStartKey(), key) < 0 &&
 		(bytes.Compare(key, r.meta.GetEndKey()) <= 0 || len(r.meta.GetEndKey()) == 0)
 }

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -1376,9 +1376,9 @@ func (s *testRegionCacheSuite) TestContains() {
 }
 
 func (s *testRegionCacheSuite) TestContainsByEnd() {
-	s.False(createSampleRegion(nil, nil).ContainsByEnd([]byte{}))
+	s.True(createSampleRegion(nil, nil).ContainsByEnd([]byte{}))
 	s.True(createSampleRegion(nil, nil).ContainsByEnd([]byte{10}))
-	s.False(createSampleRegion([]byte{10}, nil).ContainsByEnd([]byte{}))
+	s.True(createSampleRegion([]byte{10}, nil).ContainsByEnd([]byte{}))
 	s.False(createSampleRegion([]byte{10}, nil).ContainsByEnd([]byte{10}))
 	s.True(createSampleRegion([]byte{10}, nil).ContainsByEnd([]byte{11}))
 	s.False(createSampleRegion(nil, []byte{10}).ContainsByEnd([]byte{}))

--- a/internal/mockstore/mocktikv/cluster.go
+++ b/internal/mockstore/mocktikv/cluster.go
@@ -404,6 +404,7 @@ func (c *Cluster) ScanRegions(startKey, endKey []byte, limit int) []*pd.Region {
 			Meta:      proto.Clone(region.Meta).(*metapb.Region),
 			Leader:    leader,
 			DownPeers: c.getDownPeers(region),
+			Buckets:   proto.Clone(region.Buckets).(*metapb.Buckets),
 		}
 		result = append(result, r)
 	}


### PR DESCRIPTION
ref pingcap/tidb#53850, pingcap/tidb#62040

Cherry pick #1052 to 7.5 and support buckets for `ScanRegions` of mocktikv.