### PR TITLE
util/async: make TestExecConcurrent stable

### DIFF
--- a/util/async/runloop_test.go
+++ b/util/async/runloop_test.go
@@ -142,6 +142,9 @@ func TestExecCancelWhileWaiting(t *testing.T) {
 }
 
 func TestExecConcurrent(t *testing.T) {
+	defaultMaxProcs := runtime.GOMAXPROCS(0)
+	defer runtime.GOMAXPROCS(defaultMaxProcs)
+	runtime.GOMAXPROCS(1)
 	l := NewRunLoop()
 	l.Append(func() {
 		time.Sleep(time.Millisecond)


### PR DESCRIPTION
close #1682

When run test with `-race`, `runtime.Gosched` may not works as the test expected.