### PR TITLE
region cache: do not invalidate the valid region cache when new region cache is loaded (#1698)

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1791,7 +1791,7 @@ func (c *RegionCache) BatchLoadRegionsWithKeyRange(bo *retry.Backoffer, startKey
 	// TODO(youjiali1995): scanRegions always fetch regions from PD and these regions don't contain buckets information
 	// for less traffic, so newly inserted regions in region cache don't have buckets information. We should improve it.
 	for _, region := range regions {
-		c.insertRegionToCache(region, true, false)
+		c.insertRegionToCache(region, false, false)
 	}
 
 	return
@@ -1816,7 +1816,7 @@ func (c *RegionCache) BatchLoadRegionsWithKeyRanges(bo *retry.Backoffer, keyRang
 	defer c.mu.Unlock()
 
 	for _, region := range regions {
-		c.insertRegionToCache(region, true, false)
+		c.insertRegionToCache(region, false, false)
 	}
 	return
 }


### PR DESCRIPTION
Cherry pick #1698 to tidb-8.5

---

For some functions that bypass the region cache, we should leave the exist region valid.

| Initial State | Bypass Region Cache | Finish State (old region) | Finish State (new region) |
| - | - | - | - |
| valid | yes | valid | valid |
| valid | no | valid | valid |
| invalid | yes | valid | invalid |
| invalid | no | valid | invalid |
