### PR TITLE
region cache: Preserve needReloadOnAccess Flag on Region Cache Reload Failure

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1549,6 +1549,8 @@ func (c *RegionCache) findRegionByKey(bo *retry.Backoffer, key []byte, isEndKey 
 			logutil.Logger(bo.GetCtx()).Error("load region failure",
 				zap.String("key", redact.Key(key)), zap.Error(err),
 				zap.String("encode-key", redact.Key(c.codec.EncodeRegionKey(key))))
+			// mark as need sync reload
+			r.setSyncFlags(needReloadOnAccess)
 		} else {
 			logutil.Eventf(bo.GetCtx(), "load region %d from pd, due to need-reload", lr.GetID())
 			reloadOnAccess := flags&needReloadOnAccess > 0
@@ -1693,6 +1695,8 @@ func (c *RegionCache) LocateRegionByID(bo *retry.Backoffer, regionID uint64) (*K
 				// ignore error and use old region info.
 				logutil.Logger(bo.GetCtx()).Error("load region failure",
 					zap.Uint64("regionID", regionID), zap.Error(err))
+				// mark as need sync reload
+				r.setSyncFlags(needReloadOnAccess)
 			} else {
 				r = lr
 				c.mu.Lock()


### PR DESCRIPTION
Tracked by issue https://github.com/tikv/client-go/issues/1647

Reset the **needReloadOnAccess** flag for a region when the region cache fails to reload region information(from pd) for an obsolete record.

Please refer to the issue description for the motivation behind this change.