### PR TITLE
apicodec: do not decode empty key for codec v2

### DIFF
--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/util/intest"
 	"github.com/tikv/client-go/v2/util/redact"
 	"go.uber.org/zap"
 )
@@ -706,6 +707,9 @@ func (c *codecV2) EncodeKey(key []byte) []byte {
 
 func (c *codecV2) DecodeKey(encodedKey []byte) ([]byte, error) {
 	if len(encodedKey) == 0 {
+		if !intest.InTest {
+			logutil.BgLogger().Warn("codecV2.DecodeKey called with empty key, it should not happen in production", zap.Stack("stack"))
+		}
 		return nil, nil
 	}
 	// If the given key does not start with the correct prefix,

--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -708,7 +708,9 @@ func (c *codecV2) EncodeKey(key []byte) []byte {
 func (c *codecV2) DecodeKey(encodedKey []byte) ([]byte, error) {
 	if len(encodedKey) == 0 {
 		if !intest.InTest {
-			logutil.BgLogger().Warn("codecV2.DecodeKey called with empty key, it should not happen in production", zap.Stack("stack"))
+			logutil.BgLogger().Warn(
+				"codecV2.DecodeKey called with empty key. This shouldn't happen in prod",
+				zap.Stack("stack"))
 		}
 		return nil, nil
 	}

--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -705,6 +705,9 @@ func (c *codecV2) EncodeKey(key []byte) []byte {
 }
 
 func (c *codecV2) DecodeKey(encodedKey []byte) ([]byte, error) {
+	if len(encodedKey) == 0 {
+		return nil, nil
+	}
 	// If the given key does not start with the correct prefix,
 	// return out of bound error.
 	if !bytes.HasPrefix(encodedKey, c.prefix) {

--- a/util/intest/in_unittest.go
+++ b/util/intest/in_unittest.go
@@ -1,0 +1,20 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build intest
+
+package intest
+
+// InTest checks if the code is running in test.
+var InTest = true

--- a/util/intest/in_unittest.go
+++ b/util/intest/in_unittest.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2025 TiKV Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/util/intest/not_in_unittest.go
+++ b/util/intest/not_in_unittest.go
@@ -1,0 +1,20 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !intest
+
+package intest
+
+// InTest checks if the code is running in test.
+var InTest = false

--- a/util/intest/not_in_unittest.go
+++ b/util/intest/not_in_unittest.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2025 TiKV Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
When next-gen is enabled in TiDB, many unit tests failed because `codecV2` cannot decode the empty key. These unit tests rely on the unistore, which doesn't have a assumption about the key existence of `ErrConflict`:

https://github.com/pingcap/tidb/blob/60e5a4b8b7087eef42e9478cbe2efa4c154876fe/pkg/store/mockstore/unistore/tikv/server.go#L267

This PR makes `codecV2` supports decoding the empty key. It is also compatible with `codecV1`:

```
func (c *codecV1) DecodeKey(key []byte) ([]byte, error) {
	return key, nil
}
```


 