### PR TITLE
client: fix the bug of attach-context in async api

### DIFF
--- a/internal/client/client_async.go
+++ b/internal/client/client_async.go
@@ -49,12 +49,6 @@ func (c *RPCClient) SendRequestAsync(ctx context.Context, addr string, req *tikv
 		return
 	}
 
-	batchReq := req.ToBatchCommandsRequest()
-	if batchReq == nil {
-		cb.Invoke(nil, errors.New("unsupported request type: "+req.Type.String()))
-		return
-	}
-
 	regionRPC := trace.StartRegion(ctx, req.Type.String())
 	spanRPC := opentracing.SpanFromContext(ctx)
 	if spanRPC != nil && spanRPC.Tracer() != nil {
@@ -71,6 +65,12 @@ func (c *RPCClient) SendRequestAsync(ctx context.Context, addr string, req *tikv
 		}
 	}
 	tikvrpc.AttachContext(req, req.Context)
+
+	batchReq := req.ToBatchCommandsRequest()
+	if batchReq == nil {
+		cb.Invoke(nil, errors.New("unsupported request type: "+req.Type.String()))
+		return
+	}
 
 	// TODO(zyguan): If the client created `WithGRPCDialOptions(grpc.WithBlock())`, `getConnPool` might be blocked for
 	// a while when the corresponding conn array is uninitialized. However, since tidb won't set this option, we just


### PR DESCRIPTION
`req.ToBatchCommandsRequest()` should be called after `tikvrpc.AttachContext`.