### PR TITLE
kv: fix some goroutine leak when fail halfway in NewKVStore

### DIFF
--- a/tikv/kv_test.go
+++ b/tikv/kv_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/internal/mockstore/mocktikv"
 	"github.com/tikv/client-go/v2/oracle"
@@ -272,4 +273,9 @@ func (s *testKVSuite) TestMinSafeTsFromMixed2() {
 	s.Require().Equal(uint64(10), s.store.GetMinSafeTS(oracle.GlobalTxnScope))
 	s.Require().Equal(mockClient.tikvSafeTs, s.store.GetMinSafeTS("z1"))
 	s.Require().Equal(uint64(10), s.store.GetMinSafeTS("z2"))
+}
+
+func (s *testKVSuite) TestErrorHalfwayInNewKVStore() {
+	_, err := NewKVStore("TestErrorHalfwayInNewKVStore", s.store.pdClient, NewMockSafePointKV(), &mocktikv.RPCClient{})
+	require.Error(s.T(), err)
 }


### PR DESCRIPTION
(I'm not sure how to cherry-pick to release branches)

before

```
=== RUN   TestKV
=== RUN   TestKV/TestErrorHalfwayInNewKVStore
[2025/09/24 15:54:58.401 +08:00] [INFO] [client.go:349] ["[pd] http client closed"] [source=test]
--- PASS: TestKV/TestErrorHalfwayInNewKVStore (0.00s)
--- PASS: TestKV (0.00s)
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 11 in state select, with github.com/tikv/client-go/v2/oracle/oracles.(*pdOracle).updateTS on top of the stack:
goroutine 11 [select]:
github.com/tikv/client-go/v2/oracle/oracles.(*pdOracle).updateTS(0x1400026c820, {0x103b39a40, 0x1044e7780})
	/Users/lance/Developer/client-go/oracle/oracles/pd.go:485 +0xdc
created by github.com/tikv/client-go/v2/oracle/oracles.NewPdOracle in goroutine 7
	/Users/lance/Developer/client-go/oracle/oracles/pd.go:196 +0x19c

 Goroutine 12 in state select, with github.com/tikv/client-go/v2/internal/locate.(*bgRunner).scheduleWithTrigger.func1 on top of the stack:
goroutine 12 [select]:
github.com/tikv/client-go/v2/internal/locate.(*bgRunner).scheduleWithTrigger.func1()
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:622 +0x100
created by github.com/tikv/client-go/v2/internal/locate.(*bgRunner).scheduleWithTrigger in goroutine 7
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:614 +0xd8

 Goroutine 13 in state select, with github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1 on top of the stack:
goroutine 13 [select]:
github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1()
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:596 +0xc4
created by github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule in goroutine 7
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:589 +0xc4

 Goroutine 14 in state select, with github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1 on top of the stack:
goroutine 14 [select]:
github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1()
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:596 +0xc4
created by github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule in goroutine 7
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:589 +0xc4

 Goroutine 15 in state select, with github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1 on top of the stack:
goroutine 15 [select]:
github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1()
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:596 +0xc4
created by github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule in goroutine 7
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:589 +0xc4

 Goroutine 16 in state select, with github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1 on top of the stack:
goroutine 16 [select]:
github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule.func1()
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:596 +0xc4
created by github.com/tikv/client-go/v2/internal/locate.(*bgRunner).schedule in goroutine 7
	/Users/lance/Developer/client-go/internal/locate/region_cache.go:589 +0xc4
]

Process finished with the exit code 1
```

after

```
=== RUN   TestKV
=== RUN   TestKV/TestErrorHalfwayInNewKVStore
[2025/09/24 15:57:18.137 +08:00] [INFO] [client.go:349] ["[pd] http client closed"] [source=test]
--- PASS: TestKV/TestErrorHalfwayInNewKVStore (0.00s)
--- PASS: TestKV (0.00s)
PASS

Process finished with the exit code 0
```