### PR TITLE
Warn when filtering out regions without leaders

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2425,6 +2425,10 @@ func (c *RegionCache) handleRegionInfos(bo *retry.Backoffer, regionsInfo []*rout
 	for _, r := range regionsInfo {
 		// Leader id = 0 indicates no leader.
 		if needLeader && (r.Leader == nil || r.Leader.GetId() == 0) {
+			logutil.BgLogger().Warn("filter out region without leader",
+				zap.Uint64("regionId", r.Meta.Id),
+				zap.String("startKey", redact.Key(r.Meta.StartKey)),
+				zap.String("endKey", redact.Key(r.Meta.EndKey)))
 			continue
 		}
 		region, err := newRegion(bo, c, r)
@@ -2437,7 +2441,7 @@ func (c *RegionCache) handleRegionInfos(bo *retry.Backoffer, regionsInfo []*rout
 		return nil, nil
 	}
 	if len(regions) < len(regionsInfo) {
-		logutil.Logger(context.Background()).Debug(
+		logutil.Logger(context.Background()).Warn(
 			"regionCache: scanRegion finished but some regions has no leader.")
 	}
 	return regions, nil


### PR DESCRIPTION
The caller of methods like "scan region" may expect that the returned regions can fully cover the ranges in the parameter. We should WARN here if some regions are filtered out, leaving gaps in the returned regions.
Note: The check of `regionsHaveGapInRanges` is performed before `handleRegionInfos`, so it is possible to silently drop some regions after the check