### PR TITLE
txn: remove `IsTempIndexKey` which bypass the checks for temp index keys

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -1091,10 +1091,3 @@ type SchemaVer = transaction.SchemaVer
 // MaxTxnTimeUse is the max time a Txn may use (in ms) from its begin to commit.
 // We use it to abort the transaction to guarantee GC worker will not influence it.
 const MaxTxnTimeUse = transaction.MaxTxnTimeUse
-
-// SetIsTempIndexKey inject the function to check whether a key is a temporary index key.
-// Call this function before using this package.
-// If not set, all keys will be treated as non-temporary index keys.
-func SetIsTempIndexKey(fn func([]byte) bool) {
-	transaction.IsTempIndexKey = fn
-}

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -102,9 +102,8 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize u
 		}
 		if m.IsPessimisticLock(i) {
 			pessimisticActions[i] = kvrpcpb.PrewriteRequest_DO_PESSIMISTIC_CHECK
-		} else if m.NeedConstraintCheckInPrewrite(i) ||
-			(config.NextGen && IsTempIndexKey != nil && !IsTempIndexKey(m.GetKey(i))) {
-			// For next-gen builds, we need to perform constraint checks on all non-temporary index keys.
+		} else if m.NeedConstraintCheckInPrewrite(i) || config.NextGen {
+			// For next-gen builds, we need to perform constraint checks on all non-locked keys.
 			// This is to prevent scenarios where a later lock's start_ts is smaller than the previous write's commit_ts,
 			// which can be problematic for CDC and could potentially break correctness.
 			// see https://github.com/tikv/tikv/issues/11187.
@@ -630,5 +629,3 @@ func (handler *prewrite1BatchReqHandler) handleSingleBatchSucceed(reqBegin time.
 	}
 	return nil
 }
-
-var IsTempIndexKey func([]byte) bool


### PR DESCRIPTION
In next-gen, we force constraint check for non-locked keys in pessimistic transaction, this for temp index is also not an exception.

Remove the `IsTempIndexKey` injection and treat temp index keys same as others.