### PR TITLE
revert the setting of DoConstraintCheck flag

### DIFF
--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -102,11 +102,7 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize u
 		}
 		if m.IsPessimisticLock(i) {
 			pessimisticActions[i] = kvrpcpb.PrewriteRequest_DO_PESSIMISTIC_CHECK
-		} else if m.NeedConstraintCheckInPrewrite(i) || config.NextGen {
-			// For next-gen builds, we need to perform constraint checks on all non-locked keys.
-			// This is to prevent scenarios where a later lock's start_ts is smaller than the previous write's commit_ts,
-			// which can be problematic for CDC and could potentially break correctness.
-			// see https://github.com/tikv/tikv/issues/11187.
+		} else if m.NeedConstraintCheckInPrewrite(i) {
 			pessimisticActions[i] = kvrpcpb.PrewriteRequest_DO_CONSTRAINT_CHECK
 		} else {
 			pessimisticActions[i] = kvrpcpb.PrewriteRequest_SKIP_PESSIMISTIC_CHECK


### PR DESCRIPTION
Fix CSE#3854
In short,
`DoConstraintCheck` checks `self.start_ts >= other.commit_ts`
`SkipPessimisticCheck`, if not skipping conflict check, checks `self.for_update_Ts >= other.commit_ts`
For non-unique index keys, we need the latter. So they cannot use `DoConstraintCheck`.
The names become misleading now, we will need to refactor them later