### PR TITLE
txnkv: `Get` always return `nil` value when not found

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251023055424-e9d10f5dcd23 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251111062912-404ef65745d5 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -165,8 +165,9 @@ func (s *testSnapshotSuite) TestGetAndBatchGetWithRequireCommitTS() {
 	s.Nil(err)
 	s.Equal(kv.NewValueEntry([]byte("c1"), commitTS), entry)
 
-	_, err = snapshot.Get(context.Background(), []byte("e"), kv.WithRequireCommitTS())
+	entry, err = snapshot.Get(context.Background(), []byte("e"), kv.WithRequireCommitTS())
 	s.EqualError(err, tikverr.ErrNotExist.Error())
+	s.Equal(kv.ValueEntry{}, entry)
 }
 
 func (s *testSnapshotSuite) TestSnapshotCache() {
@@ -201,8 +202,9 @@ func (s *testSnapshotSuite) TestSnapshotCache() {
 	entry, err := snapshot.Get(ctx, []byte("a"))
 	s.Nil(err)
 	s.Equal(kv.NewValueEntry([]byte("a"), 0), entry)
-	_, err = snapshot.Get(ctx, []byte("b"))
+	entry, err = snapshot.Get(ctx, []byte("b"))
 	s.True(tikverr.IsErrNotFound(err))
+	s.Equal(kv.ValueEntry{}, entry)
 
 	s.Nil(failpoint.Disable("tikvclient/snapshot-get-cache-fail"))
 	if config.NextGen {
@@ -236,8 +238,9 @@ func (s *testSnapshotSuite) TestSnapshotCache() {
 		entry, err = snapshot.Get(ctx, []byte("a"), kv.WithRequireCommitTS())
 		s.Nil(err)
 		s.Equal(kv.NewValueEntry([]byte("a"), expectedCommitTS), entry)
-		_, err = snapshot.Get(ctx, []byte("b"))
+		entry, err = snapshot.Get(ctx, []byte("b"))
 		s.True(tikverr.IsErrNotFound(err))
+		s.Equal(kv.ValueEntry{}, entry)
 	}
 	s.Nil(failpoint.Disable("tikvclient/snapshot-get-cache-fail"))
 }

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -696,7 +696,7 @@ func (s *KVSnapshot) Get(ctx context.Context, k []byte, options ...kv.GetOption)
 			atomic.AddInt64(&s.mu.hitCnt, 1)
 			s.mu.RUnlock()
 			if entry.IsValueEmpty() {
-				return entry, tikverr.ErrNotExist
+				return kv.ValueEntry{}, tikverr.ErrNotExist
 			}
 			return entry, nil
 		}


### PR DESCRIPTION
ref #1795

After previous PR: #1796, some behavior changed. When a deleted key is in the snapshot cache, `snap.Get` will return `kv.ValueEntry{ Value: []byte{} }, ErrNotExist` (The `entry.Value` is not `nil`) instead of `kv.ValueEntry{}, ErrNotExist` (before #1796, it returns `nil, ErrNotExist`). 

In this PR, we force return `kv.ValueEntry{}, ErrNotExist` with `entry.Value` set to nil to keep the same behavior before #1796 to avoid some potential bugs after the behavior change.

For example:

[here](https://github.com/pingcap/tidb/blob/5034f9b378c11b2117f7ef0e6a0337dae6729abc/pkg/structure/hash.go#L44-L51 ) returns `value, nil` if got `ErrNotExist`
```
func (t *TxStructure) HGet(key []byte, field []byte) ([]byte, error) {
	dataKey := t.encodeHashDataKey(key, field)
	value, err := t.reader.Get(context.TODO(), dataKey)
	if kv.ErrNotExist.Equal(err) {
		err = nil
	}
	return value, errors.Trace(err)
}
```

and [here](https://github.com/pingcap/tidb/blob/5034f9b378c11b2117f7ef0e6a0337dae6729abc/pkg/meta/meta.go#L592-L598) checks `v != nil` to check if table exists.

```
func (m *Mutator) checkTableNotExists(dbKey []byte, tableKey []byte) error {
	v, err := m.txn.HGet(dbKey, tableKey)
	if err == nil && v != nil {
		err = ErrTableExists.GenWithStack("table already exists")
	}
	return errors.Trace(err)
}
```

If the behavior changed, the above code will cause a bug