### PR TITLE
trace: capture the callstack when region_request.SendReq() is called without trace ID

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1015,6 +1015,17 @@ func (s *sendReqState) next() (done bool) {
 		}
 	}
 
+	if len(req.Context.TraceId) == 0 {
+		if trace.IsCategoryEnabled(trace.CategoryDevDebug) {
+			trace.TraceEvent(bo.GetCtx(), trace.CategoryDevDebug, "send request with trace_id missing",
+				zap.Stack("stack"))
+
+			// If trace ID is not set, it may indicate the caller is not using client-go properly.
+			// Print the stack trace to capture all those cases.
+			trace.CheckFlightRecorderDumpTrigger(bo.GetCtx(), "dump_trigger.suspicious_event.dev_debug", "send_request_trace_id_missing")
+		}
+	}
+
 	if _, err := util.EvalFailpoint("beforeSendReqToRegion"); err == nil {
 		if hook := bo.GetCtx().Value("sendReqToRegionHook"); hook != nil {
 			h := hook.(func(*tikvrpc.Request))
@@ -1165,7 +1176,6 @@ func (s *sendReqState) send() (canceled bool) {
 			fields := []zap.Field{
 				zap.Stringer("cmd", req.Type),
 				zap.Duration("latency", rpcDuration),
-				zap.Bool("success", s.vars.err == nil && s.vars.resp != nil),
 			}
 			if s.vars.err != nil {
 				fields = append(fields, zap.Error(s.vars.err))

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -142,3 +142,25 @@ func TestTraceIDContext(t *testing.T) {
 	extractedID2 := TraceIDFromContext(ctxWithTrace2)
 	require.Equal(t, traceID2, extractedID2)
 }
+
+func TestCheckFlightRecorderDumpTrigger(t *testing.T) {
+	original := globalCheckFlightRecorderDumpTriggerFunc.Load()
+	defer func() {
+		globalCheckFlightRecorderDumpTriggerFunc.Store(original)
+	}()
+
+	// Test default behavior (returns false)
+	ctx := context.Background()
+	CheckFlightRecorderDumpTrigger(ctx, "just cover some code", 42)
+
+	// Test custom behavior
+	var covered bool
+	mock := func(ctx context.Context, triggerName string, val any) {
+		covered = true
+	}
+	SetCheckFlightRecorderDumpTriggerFunc(CheckFlightRecorderDumpTriggerFunc(mock))
+
+	require.False(t, covered)
+	CheckFlightRecorderDumpTrigger(ctx, "custom trigger", 123)
+	require.True(t, covered)
+}


### PR DESCRIPTION
For https://github.com/pingcap/tidb/pull/64569