### PR TITLE
integration_tests: make test after `TestSafePoint` stable

### DIFF
--- a/integration_tests/safepoint_test.go
+++ b/integration_tests/safepoint_test.go
@@ -146,4 +146,6 @@ func (s *testSafePointSuite) TestSafePoint() {
 	isMayFallBehind = strings.Contains(geterr2.Error(), "start timestamp may fall behind safe point")
 	isBehind = isFallBehind || isMayFallBehind
 	s.True(isBehind)
+	// sleep to wait for the next transaction will get a valid startTS to make the next test stable.
+	time.Sleep(time.Second)
 }


### PR DESCRIPTION
`TestSafePoint` will set the gc safe point to a big value that may makes the next test fail with error: "GC life time is shorter than transaction duration, transaction start ts is..."

This PR fix it and make test stable.