### PR TITLE
region_request: log unknown region error for debugging

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1926,6 +1926,12 @@ func (s *RegionRequestSender) onRegionError(
 	}
 
 	regionErrLabel := regionErrorToLabel(regionErr)
+	if regionErrLabel == "unknown" {
+		logutil.Logger(bo.GetCtx()).Info(
+			"unknown region error",
+			zap.Stringer("error", regionErr),
+		)
+	}
 	metrics.TiKVRegionErrorCounter.WithLabelValues(regionErrLabel, storeIDLabel(ctx)).Inc()
 	if s.Stats != nil {
 		s.Stats.RecordRPCErrorStats(regionErrLabel)


### PR DESCRIPTION
## Summary
- Add INFO log when `regionErrorToLabel` returns "unknown"
- Logs the full error content to help identify unhandled region error types
- Useful for debugging when "unknown" appears in metrics
