### PR TITLE
Enable health tick on next gen

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -336,15 +336,9 @@ func NewKVStore(
 		}
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
-	var opts []locate.RegionCacheOpt
-	if config.NextGen {
-		opts = append(opts, locate.RegionCacheNoHealthTick)
-	} else {
-		opts = append(opts, locate.WithRequestHealthFeedbackCallback(func(ctx context.Context, addr string) error {
-			return requestHealthFeedbackFromKVClient(ctx, addr, tikvclient)
-		}))
-	}
-	regionCache := locate.NewRegionCache(pdClient, opts...)
+	regionCache := locate.NewRegionCache(pdClient, locate.WithRequestHealthFeedbackCallback(func(ctx context.Context, addr string) error {
+		return requestHealthFeedbackFromKVClient(ctx, addr, tikvclient)
+	}))
 	codec := pdClient.(*CodecPDClient).GetCodec()
 	etcdAddrs, etcdTlsCfg := spkv.extractConnectionInfo()
 	store := &KVStore{


### PR DESCRIPTION
The tick in health status manager in client-go is disabled for next gen in #1635 . Currently, the related functionalities in TiKV were ported to next gen, so it can be enabled now.

By the way, it needs to be pointed out that the option `RegionCacheNoHealthTick` is for test purposes to remove the background works. It doesn't completely disable health status related features, instead, it may partially run and has risk to cause unexpected results.