### PR TITLE
txnkv: fix the issue that lockKeys doesn't release the internal rlock

### DIFF
--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1339,6 +1339,7 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 		}
 
 		if lockedInShareMode && !lockCtx.InShareMode {
+			memBuf.RUnlock()
 			return errors.New("upgrading a shared lock to an exclusive lock is not supported")
 		}
 


### PR DESCRIPTION
ref: https://github.com/tikv/tikv/issues/19087