### PR TITLE
txnkv: Add a named error `ErrCommitTSLag`  when waiting for `commitWaitUntilTSO` timeout

### DIFF
--- a/config/retry/config.go
+++ b/config/retry/config.go
@@ -133,6 +133,7 @@ var (
 	BoTxnNotFound              = NewConfig("txnNotFound", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrResolveLockTimeout)
 	BoStaleCmd                 = NewConfig("staleCommand", &metrics.BackoffHistogramStaleCmd, NewBackoffFnCfg(2, 1000, NoJitter), tikverr.ErrTiKVStaleCommand)
 	BoMaxTsNotSynced           = NewConfig("maxTsNotSynced", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrTiKVMaxTimestampNotSynced)
+	BoCommitTSLag              = NewConfig("commitTSLag", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 500, NoJitter), tikverr.ErrCommitTSLag)
 	BoMaxRegionNotInitialized  = NewConfig("regionNotInitialized", &metrics.BackoffHistogramEmpty, NewBackoffFnCfg(2, 1000, NoJitter), tikverr.ErrRegionNotInitialized)
 	BoIsWitness                = NewConfig("isWitness", &metrics.BackoffHistogramIsWitness, NewBackoffFnCfg(1000, 10000, EqualJitter), tikverr.ErrIsWitness)
 	// TxnLockFast's `base` load from vars.BackoffLockFast when create BackoffFn.

--- a/error/error.go
+++ b/error/error.go
@@ -91,6 +91,8 @@ var (
 	ErrRegionNotInitialized = errors.New("region not Initialized")
 	// ErrTiKVDiskFull is the error when tikv server disk usage is full.
 	ErrTiKVDiskFull = errors.New("tikv disk full")
+	// ErrCommitTSLag is the error when the commit TS which fetched from PD drifts and falls behind the expected value.
+	ErrCommitTSLag = errors.New("commit timestamp lags behind expected")
 	// ErrRegionRecoveryInProgress is the error when region is recovering.
 	ErrRegionRecoveryInProgress = errors.New("region is being online unsafe recovered")
 	// ErrRegionFlashbackInProgress is the error when a region in the flashback progress receive any other request.
@@ -419,4 +421,9 @@ func ExtractDebugInfoStrFromKeyErr(keyErr *kvrpcpb.KeyError) string {
 		return ""
 	}
 	return string(debugStr)
+}
+
+// IsErrorCommitTSLag checks if the error is commit ts lag error.
+func IsErrorCommitTSLag(err error) bool {
+	return errors.Is(err, ErrCommitTSLag)
 }

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -1,6 +1,6 @@
 module txnkv
 
-go 1.23.0
+go 1.23.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20251109100001-1907922fbd18 // indirect
+	github.com/pingcap/kvproto v0.0.0-20251218093338-9f0ac2fc9a1a // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20250625073039-fb496b371ff3 // indirect
+	github.com/tikv/pd/client v0.0.0-20251211035544-6cebb3314abe // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/integration_tests/option_test.go
+++ b/integration_tests/option_test.go
@@ -36,21 +36,68 @@ package tikv_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/suite"
+	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"github.com/tikv/client-go/v2/util"
+	"github.com/tikv/client-go/v2/util/intest"
 )
+
+type mockCommitTSOracle struct {
+	oracle.Oracle
+	mu struct {
+		sync.Mutex
+		startTS         uint64
+		commitTSOffsets []uint64
+	}
+}
+
+func (o *mockCommitTSOracle) ResetMock(startTS uint64, commitTSOffsets []uint64) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.mu.startTS = startTS
+	o.mu.commitTSOffsets = commitTSOffsets
+}
+
+func (o *mockCommitTSOracle) GetTimestamp(ctx context.Context, option *oracle.Option) (uint64, error) {
+	if ts := ctx.Value(transaction.CtxInGetTimestampForCommitKey); ts != nil {
+		o.mu.Lock()
+		startTS, ok := ts.(uint64)
+		if !ok || startTS != o.mu.startTS {
+			o.mu.Unlock()
+		} else {
+			defer o.mu.Unlock()
+			if len(o.mu.commitTSOffsets) == 0 {
+				panic("empty mock oracle ts set")
+			}
+			offset := o.mu.commitTSOffsets[0]
+			o.mu.commitTSOffsets = o.mu.commitTSOffsets[1:]
+			return o.mu.startTS + offset, nil
+		}
+	}
+	return o.Oracle.GetTimestamp(ctx, option)
+}
 
 type testOptionSuite struct {
 	suite.Suite
-	store tikv.StoreProbe
+	mockOracle *mockCommitTSOracle
+	store      tikv.StoreProbe
 }
 
 func (s *testOptionSuite) SetupSuite() {
 	s.store = tikv.StoreProbe{KVStore: NewTestStore(s.T())}
+	s.mockOracle = &mockCommitTSOracle{Oracle: s.store.GetOracle()}
+	s.store.SetOracle(s.mockOracle)
 }
 
 func (s *testOptionSuite) TearDownSuite() {
@@ -61,36 +108,128 @@ func TestOption(t *testing.T) {
 	suite.Run(t, new(testOptionSuite))
 }
 
+func (s *testOptionSuite) MetricValues(m any) *dto.Metric {
+	metric := &dto.Metric{}
+	s.NoError(m.(prometheus.Metric).Write(metric))
+	return metric
+}
+
+func (s *testOptionSuite) GetHistogramMetricSampleCount(m any) uint64 {
+	return s.MetricValues(m).GetHistogram().GetSampleCount()
+}
+
 func (s *testOptionSuite) TestSetCommitWaitUntilTSO() {
-	getTS1 := func(startTS uint64) uint64 { return 100 }
-	getTS2 := func(startTS uint64) uint64 {
-		return startTS + 200
+	if *withTiKV {
+		s.T().Skip("TestSetCommitWaitUntilTSO only runs on local mock storage")
 	}
-	getTS3 := func(startTS uint64) uint64 {
-		now := oracle.GetTimeFromTS(startTS)
-		return oracle.GoTimeToTS(now.Add(10 * time.Second))
-	}
-	type testCase struct {
-		getTS   func(startTS uint64) uint64
-		noError bool
-	}
-
-	for _, tc := range []testCase{
-		{getTS1, true},
-		{getTS2, true},
-		{getTS3, false},
-	} {
-		txn, err := s.store.Begin()
-		s.NoError(err)
-		commitUntil := tc.getTS(txn.StartTS())
-		txn.KVTxn.SetCommitWaitUntilTSO(commitUntil)
-		s.NoError(txn.Set([]byte("somekey"), []byte("somevalue")))
-		err = txn.Commit(context.Background())
-		s.Equal(tc.noError, err == nil)
-
-		if tc.noError {
-			s.Greater(txn.CommitTS(), uint64(100))
+	origInTest := intest.InTest
+	defer func() {
+		intest.InTest = origInTest
+	}()
+	intest.InTest = true
+	doWithCollectHistSamplesInc := func(do func() error, metrics []any) ([]uint64, error) {
+		cnt := make([]uint64, len(metrics))
+		for i, metric := range metrics {
+			cnt[i] = s.GetHistogramMetricSampleCount(metric)
 		}
+		err := do()
+		for i, metric := range metrics {
+			cnt[i] = s.GetHistogramMetricSampleCount(metric) - cnt[i]
+		}
+		return cnt, err
+	}
+
+	for _, tc := range []struct {
+		name string
+		// We will call `txn.SetCommitWaitUntilTSO(commitWaitTSO + txn.StartTS())`
+		commitWaitTSO uint64
+		// Mock the PD TSOs in commit phase as {
+		//		mockCommitTSO[0] + txn.StartTS(), // first attempt
+		//		mockCommitTSO[1] + txn.StartTS(), // second attempt
+		//      ...
+		//	}
+		mockCommitTSO  []uint64
+		setWaitTimeout time.Duration
+		err            bool
+	}{
+		{
+			name:          "no lag commit ts",
+			commitWaitTSO: 1,
+			mockCommitTSO: []uint64{100},
+		},
+		{
+			name:          "lag, retry once and success",
+			commitWaitTSO: 200,
+			mockCommitTSO: []uint64{100, 201},
+		},
+		{
+			name:          "lag, retry twice and success",
+			commitWaitTSO: 300,
+			mockCommitTSO: []uint64{100, 200, 301},
+		},
+		{
+			name:          "lag too much, fail directly",
+			commitWaitTSO: oracle.ComposeTS(10000, 0),
+			mockCommitTSO: []uint64{100},
+			err:           true,
+		},
+		{
+			name:           "lag, retry but timeout",
+			commitWaitTSO:  100,
+			mockCommitTSO:  []uint64{10, 20},
+			setWaitTimeout: time.Millisecond,
+			err:            true,
+		},
+	} {
+		s.Run(tc.name, func() {
+			txn, err := s.store.Begin()
+			s.NoError(err)
+			s.NoError(txn.Set([]byte("somekey:"+uuid.NewString()), []byte("somevalue")))
+
+			txn.SetCommitWaitUntilTSO(tc.commitWaitTSO + txn.StartTS())
+			if tc.setWaitTimeout > 0 {
+				txn.SetCommitWaitUntilTSOTimeout(tc.setWaitTimeout)
+			}
+			var commitDetail *util.CommitDetails
+			inc, err := doWithCollectHistSamplesInc(func() error {
+				s.mockOracle.ResetMock(txn.StartTS(), tc.mockCommitTSO)
+				defer s.mockOracle.ResetMock(0, nil)
+				return txn.Commit(context.WithValue(context.Background(), util.CommitDetailCtxKey, &commitDetail))
+			}, []any{
+				// ok metrics
+				metrics.LagCommitTSWaitHistogramWithOK,
+				metrics.LagCommitTSAttemptHistogramWithOK,
+				// err metrics
+				metrics.LagCommitTSWaitHistogramWithError,
+				metrics.LagCommitTSAttemptHistogramWithError,
+			})
+
+			s.Equal(txn.StartTS()+tc.commitWaitTSO, txn.GetCommitWaitUntilTSO())
+			if !tc.err {
+				s.NoError(err)
+				s.Equal(txn.CommitTS(), txn.StartTS()+tc.mockCommitTSO[len(tc.mockCommitTSO)-1])
+				if len(tc.mockCommitTSO) == 1 {
+					// if fetch TSO once and then success, there is no lag metrics
+					s.Equal([]uint64{0, 0, 0, 0}, inc)
+					s.Equal(util.CommitTSLagDetails{}, commitDetail.LagDetails)
+				} else {
+					s.Equal([]uint64{1, 1, 0, 0}, inc)
+					s.NotZero(txn.KVTxn.GetCommitWaitUntilTSO())
+					lagWaitTime := commitDetail.LagDetails.WaitTime
+					s.Positive(lagWaitTime)
+					s.Equal(util.CommitTSLagDetails{
+						WaitTime:    lagWaitTime,
+						BackoffCnt:  len(tc.mockCommitTSO) - 1,
+						FirstLagTS:  txn.StartTS() + tc.mockCommitTSO[0],
+						WaitUntilTS: txn.GetCommitWaitUntilTSO(),
+					}, commitDetail.LagDetails)
+				}
+			} else {
+				s.Error(err)
+				s.True(tikverr.IsErrorCommitTSLag(err))
+				s.Equal([]uint64{0, 0, 1, 1}, inc)
+			}
+		})
 	}
 }
 

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -192,6 +192,11 @@ var (
 	ReadRequestLeaderRemoteBytes   prometheus.Observer
 	ReadRequestFollowerLocalBytes  prometheus.Observer
 	ReadRequestFollowerRemoteBytes prometheus.Observer
+
+	LagCommitTSWaitHistogramWithOK       prometheus.Observer
+	LagCommitTSWaitHistogramWithError    prometheus.Observer
+	LagCommitTSAttemptHistogramWithOK    prometheus.Observer
+	LagCommitTSAttemptHistogramWithError prometheus.Observer
 )
 
 func initShortcuts() {
@@ -353,4 +358,9 @@ func initShortcuts() {
 	ReadRequestLeaderRemoteBytes = TiKVReadRequestBytes.WithLabelValues("leader", "cross-zone")
 	ReadRequestFollowerLocalBytes = TiKVReadRequestBytes.WithLabelValues("follower", "local")
 	ReadRequestFollowerRemoteBytes = TiKVReadRequestBytes.WithLabelValues("follower", "cross-zone")
+
+	LagCommitTSWaitHistogramWithOK = TiKVTxnLagCommitTSWaitHistogram.WithLabelValues("ok")
+	LagCommitTSWaitHistogramWithError = TiKVTxnLagCommitTSWaitHistogram.WithLabelValues("err")
+	LagCommitTSAttemptHistogramWithOK = TiKVTxnLagCommitTSAttemptHistogram.WithLabelValues("ok")
+	LagCommitTSAttemptHistogramWithError = TiKVTxnLagCommitTSAttemptHistogram.WithLabelValues("err")
 }

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1769,6 +1769,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			return err
 		}
 		commitDetail.GetLatestTsTime = time.Since(start)
+		c.txn.fillCommitTSLagDetails(&commitDetail.LagDetails)
 		// Plus 1 to avoid producing the same commit TS with previously committed transactions
 		c.minCommitTSMgr.tryUpdate(latestTS+1, twoPCAccess)
 	}
@@ -1904,6 +1905,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			return err
 		}
 		commitDetail.GetCommitTsTime = time.Since(start)
+		c.txn.fillCommitTSLagDetails(&commitDetail.LagDetails)
 		logutil.Event(ctx, "finish get commit ts")
 		logutil.SetTag(ctx, "commitTs", commitTS)
 	}

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -136,10 +136,6 @@ func (txn TxnProbe) GetAggressiveLockingPreviousKeysInfo() []AggressiveLockedKey
 	return keys
 }
 
-func (txn TxnProbe) GetCommitWaitUntilTSOTimeout() time.Duration {
-	return txn.KVTxn.commitWaitUntilTSOTimeout
-}
-
 func newTwoPhaseCommitterWithInit(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, error) {
 	c, err := newTwoPhaseCommitter(txn, sessionID)
 	if err != nil {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -68,6 +68,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 	"github.com/tikv/client-go/v2/txnkv/txnutil"
 	"github.com/tikv/client-go/v2/util"
+	"github.com/tikv/client-go/v2/util/intest"
 	"github.com/tikv/client-go/v2/util/redact"
 	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -220,6 +221,12 @@ type KVTxn struct {
 	commitWaitUntilTSO uint64
 	// commitWaitUntilTSOTimeout is the maximum clock drift allowed in active-active replication.
 	commitWaitUntilTSOTimeout time.Duration
+	// commitLagWaitInfo collects the wait stats when when waiting for the lagging PD TSO to reach `commitWaitUntilTSO`
+	commitLagWaitStats struct {
+		waitDuration   time.Duration
+		firstAttemptTS uint64
+		backoffCnt     int
+	}
 }
 
 // NewTiKVTxn creates a new KVTxn.
@@ -352,9 +359,21 @@ func (txn *KVTxn) SetCommitWaitUntilTSO(commitWaitUntilTSO uint64) {
 	}
 }
 
+// GetCommitWaitUntilTSO returns the value set by `SetCommitWaitUntilTSO`.
+// If it returns zero, it means no wait
+func (txn *KVTxn) GetCommitWaitUntilTSO() uint64 {
+	return txn.commitWaitUntilTSO
+}
+
 // SetCommitWaitUntilTSOTimeout sets the maximum clock drift allowed in active-active replication.
 func (txn *KVTxn) SetCommitWaitUntilTSOTimeout(val time.Duration) {
 	txn.commitWaitUntilTSOTimeout = val
+}
+
+// GetCommitWaitUntilTSOTimeout returns the timeout to wait for the commit tso reach the expected value.
+// If it returns zero, it means it is not set and the default timeout should be used
+func (txn *KVTxn) GetCommitWaitUntilTSOTimeout() time.Duration {
+	return txn.commitWaitUntilTSOTimeout
 }
 
 // SetPessimistic indicates if the transaction should use pessimictic lock.
@@ -1927,47 +1946,110 @@ func (txn *KVTxn) MemHookSet() bool {
 	return txn.us.GetMemBuffer().MemHookSet()
 }
 
+type ctxInGetTimestampForCommitKeyType struct{}
+
+var CtxInGetTimestampForCommitKey = ctxInGetTimestampForCommitKeyType{}
+
 // GetTimestampForCommit returns the timestamp for commit.
 // Unlike a direct wrap, it also checks commitWaitUntilTSO constraint from the SetcommitWaitUntilTSO option.
-func (txn *KVTxn) GetTimestampForCommit(bo *retry.Backoffer, scope string) (uint64, error) {
-	ts, err := txn.store.GetTimestampWithRetry(bo, scope)
+func (txn *KVTxn) GetTimestampForCommit(bo *retry.Backoffer, scope string) (_ uint64, err error) {
+	if intest.InTest {
+		ctx := bo.GetCtx()
+		bo.SetCtx(context.WithValue(ctx, CtxInGetTimestampForCommitKey, txn.StartTS()))
+		defer bo.SetCtx(ctx)
+	}
+	firstAttemptTS, err := txn.store.GetTimestampWithRetry(bo, scope)
 	if err != nil {
-		return ts, err
+		return firstAttemptTS, err
 	}
-	if ts > txn.commitWaitUntilTSO {
-		return ts, nil
+
+	if firstAttemptTS > txn.commitWaitUntilTSO {
+		return firstAttemptTS, nil
 	}
+
+	start := time.Now()
+	attempts := 1
+	defer func() {
+		// If the first attempt got a valid TSO, it is not the lag case,
+		// so only to record the metrics when firstAttempt lags.
+		duration := time.Since(start)
+		txn.commitLagWaitStats.waitDuration = duration
+		txn.commitLagWaitStats.firstAttemptTS = firstAttemptTS
+		txn.commitLagWaitStats.backoffCnt = attempts - 1
+		if err != nil {
+			metrics.LagCommitTSAttemptHistogramWithError.Observe(float64(attempts))
+			metrics.LagCommitTSWaitHistogramWithError.Observe(duration.Seconds())
+		} else {
+			metrics.LagCommitTSAttemptHistogramWithOK.Observe(float64(attempts))
+			metrics.LagCommitTSWaitHistogramWithOK.Observe(duration.Seconds())
+		}
+	}()
 
 	// maxSleep is the maximum time we are allowed to wait for the expected commit TS.
 	// It is 1 second by default to avoid infinite blocking but can be overridden by commitWaitUntilTSOTimeout.
 	// If the TSO drift is larger than the maxSleep, return error directly.
-	maxSleep := 1000
+	maxSleep := time.Second
 	if txn.commitWaitUntilTSOTimeout > 0 {
-		maxSleep = int(txn.commitWaitUntilTSOTimeout.Milliseconds())
+		maxSleep = txn.commitWaitUntilTSOTimeout
 	}
-	interval := oracle.GetTimeFromTS(txn.commitWaitUntilTSO).Sub(oracle.GetTimeFromTS(ts))
-	if int(interval.Milliseconds()) > maxSleep {
-		return 0, errors.Errorf("commit_ts(%d) << origin_commit_ts(%d), clock drift and lag more than %v", ts, txn.commitWaitUntilTSO, interval)
+	interval := oracle.GetTimeFromTS(txn.commitWaitUntilTSO).Sub(oracle.GetTimeFromTS(firstAttemptTS))
+	if interval > maxSleep {
+		return 0, errors.Wrapf(
+			tikverr.ErrCommitTSLag,
+			"PD TSO '%d' lags the expected timestamp '%d', clock drift %v exceeds maximum allowed timeout %v",
+			firstAttemptTS, txn.commitWaitUntilTSO,
+			interval,
+			maxSleep,
+		)
 	}
 
-	bo = retry.NewBackoffer(bo.GetCtx(), maxSleep)
+	lastAttemptTS := firstAttemptTS
+	bo = retry.NewBackoffer(bo.GetCtx(), int(maxSleep.Milliseconds()))
 	mockErr := errors.Errorf("clock drift from the upstream cluster")
-	for ts <= txn.commitWaitUntilTSO {
+	for ts := firstAttemptTS; ts <= txn.commitWaitUntilTSO; {
 		// It's neither sleeping interval milliseconds (maybe sleep too long without handling any context.Cancel)
 		// nor sleep every 1ms until we reach the lag interval (maybe we just lag for 1ms, and but PD update the physical time every 50ms,
 		// so after sleeping 1ms, the next GetTimestamp still return the same physical part value)
 		// Just backoff, blindly.
-		err = bo.Backoff(retry.BoMaxTsNotSynced, mockErr)
+		err = bo.Backoff(retry.BoCommitTSLag, mockErr)
 		if err != nil {
-			return 0, err
+			break
 		}
 
+		attempts++
 		ts, err = txn.store.GetTimestampWithRetry(bo, scope)
 		if err != nil {
-			return 0, err
+			break
 		}
+		lastAttemptTS = ts
 	}
-	return ts, err
+
+	if err != nil {
+		if tikverr.IsErrorCommitTSLag(err) {
+			err = errors.Wrapf(
+				err,
+				"PD TSO '%d' lags the expected timestamp '%d', retry timeout: %v, attempts: %d, last attempted commit TS: %d",
+				firstAttemptTS,
+				txn.commitWaitUntilTSO,
+				maxSleep,
+				attempts,
+				lastAttemptTS,
+			)
+		}
+		return 0, err
+	}
+
+	return lastAttemptTS, err
+}
+
+func (txn *KVTxn) fillCommitTSLagDetails(details *util.CommitTSLagDetails) {
+	// only fill when `firstAttemptTS > 0` which indicates there is actually a lag
+	if stats := txn.commitLagWaitStats; stats.firstAttemptTS > 0 {
+		details.WaitTime = stats.waitDuration
+		details.FirstLagTS = stats.firstAttemptTS
+		details.BackoffCnt = stats.backoffCnt
+		details.WaitUntilTS = txn.commitWaitUntilTSO
+	}
 }
 
 // LifecycleHooks is a struct that contains hooks for a background goroutine.


### PR DESCRIPTION
close #1843

This PR:
- returns an error `ErrCommitTSLag` if the PD TSO lags too much compared with the value set by `txn. SetCommitWaitUntilTSOTimeout`
- Provide a method `IsErrorCommitTSLag` to determine the above error
- Add more metrics:  
  - `txn_lag_commit_ts_wait_seconds`: the total time waiting for the lag commit ts to reach the expected value
  - `txn_lag_commit_ts_attempt_count`: total attempts to get the PD TSO when lag is detected.
  - A new field `CommitTsLagWaitTime` for `CommitDetails`, which is the same as `txn_lag_commit_ts_wait_seconds`. It can be displayed in TiDB slow log details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds commit-timestamp lag metrics (wait durations and attempt counts), exposes lag details in commit diagnostics, and introduces an explicit error signal for commit-timestamp lag.
  * Adds instrumentation and public hooks to surface commit-wait configuration and metrics.

* **Tests**
  * Adds deterministic tests covering commit-wait scenarios, retries, timeouts, and metric assertions.

* **Chores**
  * Bumps Go toolchain and updates indirect dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->