### PR TITLE
txnkv: fix `SetCommitWaitUntilTSOTimeout` does not work in causal consistency

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1758,7 +1758,8 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 	// all nodes, we have to make sure the commit TS of this transaction is greater
 	// than the snapshot TS of all existent readers. So we get a new timestamp
 	// from PD and plus one as our MinCommitTS.
-	if commitTSMayBeCalculated && c.needLinearizability() {
+	// If `commitWaitUntilTSO > 0`, we also need to get a new timestamp from TSO to ensure the constraint satisfied.
+	if commitTSMayBeCalculated && (c.needLinearizability() || c.txn.commitWaitUntilTSO > 0) {
 		util.EvalFailpoint("getMinCommitTSFromTSO")
 		start := time.Now()
 		latestTS, err := c.txn.GetTimestampForCommit(bo, c.txn.GetScope())


### PR DESCRIPTION
fix #1846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for async commit functionality and causal consistency validation in transaction processing scenarios.

* **Bug Fixes**
  * Improved commit timestamp calculation to correctly handle deferred wait-until-timestamp requirements, particularly when combined with async commit and causal consistency features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->