### PR TITLE
Print gRPC errors when batch client needs to reconnect

### DIFF
--- a/internal/client/client_batch.go
+++ b/internal/client/client_batch.go
@@ -750,7 +750,7 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient, tikvTransport
 			if c.isStopped() {
 				return
 			}
-			logutil.BgLogger().Debug(
+			logutil.BgLogger().Info(
 				"batchRecvLoop fails when receiving, needs to reconnect",
 				zap.String("target", c.target),
 				zap.String("forwardedHost", streamClient.forwardedHost),


### PR DESCRIPTION
## Summary
Change log level from Debug to Info when batchRecvLoop fails and needs to reconnect, so users can see the gRPC error reason in logs.

Closes #1382

## Changes
- `internal/client/client_batch.go`: Changed `logutil.BgLogger().Debug` to `logutil.BgLogger().Info` for the reconnection error log

## Testing
- [x] Build passes
- [x] Linter passes (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted error logging verbosity for batch receive operations to improve diagnostic visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->