### PR TITLE
Fix the problem that ttl manager may be unset unexpectedly when LockKeys is called multiple times in a single fair locking stage

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -1598,6 +1598,67 @@ func (s *testCommitterSuite) TestAggressiveLockingResetTTLManager() {
 	s.NoError(txn.Rollback())
 }
 
+func (s *testCommitterSuite) TestAggressiveLockingKeepAliveAfterMultiLockKeysOperation() {
+	test := func(isRetried bool, isPrimaryChanged bool) {
+		txn := s.begin()
+		txn.SetPessimistic(true)
+		s.True(txn.GetCommitter().IsNil())
+
+		txn.StartAggressiveLocking()
+		lockCtx := kv.NewLockCtx(txn.StartTS(), 1000, time.Now())
+
+		if isRetried {
+			// Test in the condition that the aggressive locking stage is retried, so that the transaction used
+			// to set primary previously.
+			lastPrimary := []byte("k0")
+			if !isPrimaryChanged {
+				lastPrimary = []byte("k1")
+			}
+			err := txn.LockKeys(context.Background(), lockCtx, lastPrimary)
+			s.NoError(err)
+			s.Equal(lastPrimary, txn.GetCommitter().GetPrimaryKey())
+			s.Equal(lastPrimary, txn.GetAggressiveLockingPrimary())
+			txn.RetryAggressiveLocking(context.Background())
+			s.Equal(lastPrimary, txn.GetAggressiveLockingLastPrimary())
+		}
+
+		err := txn.LockKeys(context.Background(), lockCtx, []byte("k1"))
+		s.NoError(err)
+		s.True(txn.IsInAggressiveLockingMode())
+		s.True(txn.IsInAggressiveLockingStage([]byte("k1")))
+		s.True(txn.GetCommitter().IsTTLRunning())
+		s.Equal([]byte("k1"), txn.GetCommitter().GetPrimaryKey())
+		err = txn.LockKeys(context.Background(), lockCtx, []byte("k2"))
+		s.NoError(err)
+		s.True(txn.IsInAggressiveLockingMode())
+		s.True(txn.IsInAggressiveLockingStage([]byte("k1")))
+		s.True(txn.IsInAggressiveLockingStage([]byte("k2")))
+		s.True(txn.GetCommitter().IsTTLRunning())
+		s.Equal([]byte("k1"), txn.GetCommitter().GetPrimaryKey())
+
+		txn.DoneAggressiveLocking(context.Background())
+		s.True(txn.GetCommitter().IsTTLRunning())
+
+		// Check the keys are still locked
+		txn2 := s.begin()
+		txn2.SetPessimistic(true)
+		lockCtx2 := kv.NewLockCtx(txn2.StartTS(), 100, time.Now())
+		err = txn2.LockKeys(context.Background(), lockCtx2, []byte("k1"))
+		s.Error(err)
+		s.ErrorIs(err, tikverr.ErrLockWaitTimeout)
+
+		err = txn2.LockKeys(context.Background(), lockCtx2, []byte("k2"))
+		s.Error(err)
+		s.ErrorIs(err, tikverr.ErrLockWaitTimeout)
+
+		s.NoError(txn2.Rollback())
+		s.NoError(txn.Rollback())
+	}
+	test(false, false)
+	test(true, false)
+	test(true, true)
+}
+
 type aggressiveLockingExitPhase int
 
 const (

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -136,6 +136,16 @@ func (txn TxnProbe) GetAggressiveLockingPreviousKeysInfo() []AggressiveLockedKey
 	return keys
 }
 
+// GetAggressiveLockingPrimary returns the primary assigned in the current aggressive locking stage, if any.
+func (txn TxnProbe) GetAggressiveLockingPrimary() []byte {
+	return txn.aggressiveLockingContext.primaryKey
+}
+
+// GetAggressiveLockingLastPrimary returns the primary assigned in the previous aggressive locking attempt, if any.
+func (txn TxnProbe) GetAggressiveLockingLastPrimary() []byte {
+	return txn.aggressiveLockingContext.lastPrimaryKey
+}
+
 func newTwoPhaseCommitterWithInit(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, error) {
 	c, err := newTwoPhaseCommitter(txn, sessionID)
 	if err != nil {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -1566,7 +1566,7 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 			metrics.AggressiveLockedKeysDerived.Add(float64(filteredAggressiveLockedKeysCount))
 			metrics.AggressiveLockedKeysNew.Add(float64(len(keys)))
 
-			txn.resetTTLManagerForAggressiveLockingMode(len(keys) != 0)
+			txn.resetTTLManagerForAggressiveLockingMode(len(keys) != 0, assignedPrimaryKey)
 
 			if len(keys) == 0 {
 				if lockCtx.Stats != nil {
@@ -1742,24 +1742,30 @@ func (txn *KVTxn) resetPrimary(keepTTLManager bool) {
 }
 
 // resetTTLManagerForAggressiveLockingMode is used in a fair locking procedure to reset the ttlManager when necessary.
-// This function is only used during the LockKeys invocation, and the parameter hasNewLockToAcquire indicates whether
-// there are any key needs to be locked in the current LockKeys call, after filtering out those that has already been
-// locked before the most recent RetryAggressiveLocking.
+// This function is only used during the LockKeys invocation. The parameter hasNewLockToAcquire indicates whether
+// there are any key needs to be locked in the current LockKeys call, after filtering out those that have already been
+// locked before the most recent RetryAggressiveLocking. The parameter assignedPrimary is whether the primary is
+// just assigned in the current LockKeys invocation where this function is called.
 // Also note that this function is not the only path that fair locking resets the ttlManager. DoneAggressiveLocking may
 // also stop the ttlManager if no key is locked after exiting.
-func (txn *KVTxn) resetTTLManagerForAggressiveLockingMode(hasNewLockToAcquire bool) {
+func (txn *KVTxn) resetTTLManagerForAggressiveLockingMode(hasNewLockToAcquire bool, assignedPrimary bool) {
 	if !txn.IsInAggressiveLockingMode() {
 		// Not supposed to be called in a non fair locking context
 		return
 	}
 	// * When there's no new lock to acquire, assume the primary key is not changed in this case. Keep the ttlManager
-	// running.
+	//   running.
+	// * When the current LockKeys invocation didn't trigger assigning primary, it's sure that we shouldn't reset
+	//   the ttlManager this time.
 	// * When there is key to write:
 	//   * If the primary key is not changed, also keep the ttlManager running. Then, when sending the
 	//     acquirePessimisticLock requests, it will call ttlManager.run() again, but it's reentrant and will do nothing
 	//     as the ttlManager is already running.
 	//   * If the primary key is changed, the ttlManager will need to run on the new primary key instead. Reset it.
-	if hasNewLockToAcquire && !bytes.Equal(txn.aggressiveLockingContext.primaryKey, txn.aggressiveLockingContext.lastPrimaryKey) {
+	//     Note that primaryKey != lastPrimaryKey is true when LockKeys is called the second time in the same
+	//     aggressive locking stage, in which case the ttlManager should not be reset. This case is excluded by checking
+	//     assignedPrimary.
+	if hasNewLockToAcquire && assignedPrimary && !bytes.Equal(txn.aggressiveLockingContext.primaryKey, txn.aggressiveLockingContext.lastPrimaryKey) {
 		txn.committer.reset()
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/pingcap/tidb/issues/66571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for aggressive locking behavior across multiple lock operations, including retry scenarios and TTL management verification.
  * Enhanced test utilities to inspect aggressive locking state and context during transaction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->