### PR TITLE
config: expose `region-cache-ttl-jitter-sec` configuration

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -100,6 +100,10 @@ type TiKVClient struct {
 	// If a Region has not been accessed for more than the given duration (in seconds), it
 	// will be reloaded from the PD.
 	RegionCacheTTL uint `toml:"region-cache-ttl" json:"region-cache-ttl"`
+	// RegionCacheTTLJitterSec is the jitter in seconds for region cache TTL.
+	// The actual TTL will be randomly chosen in the range [RegionCacheTTL, RegionCacheTTL + RegionCacheTTLJitterSec].
+	// This can help to avoid cache stampede when many regions expire at the same time.
+	RegionCacheTTLJitterSec uint `toml:"region-cache-ttl-jitter-sec" json:"region-cache-ttl-jitter-sec"`
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
@@ -176,9 +180,10 @@ func DefaultTiKVClient() TiKVClient {
 
 		EnableChunkRPC: true,
 
-		RegionCacheTTL:       600,
-		StoreLimit:           0,
-		StoreLivenessTimeout: DefStoreLivenessTimeout,
+		RegionCacheTTL:          600,
+		RegionCacheTTLJitterSec: 60,
+		StoreLimit:              0,
+		StoreLivenessTimeout:    DefStoreLivenessTimeout,
 
 		TTLRefreshedTxnSize: 32 * 1024 * 1024,
 


### PR DESCRIPTION
Expose the configuration `region-cache-ttl-jitter-sec` for region cache invalid in the real test integration env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region cache TTL jitter configuration option with a default value of 60 seconds, enabling variable cache expiration times within a defined range.

sysbench point get test(after set region-cache-ttl and region-cache-ttl-jitter-sec to 0, the client-go will not cache any region info)
<img width="1526" height="692" alt="img_v3_02vd_0cbc2965-2645-4ff4-973f-a9cb424bf7cg" src="https://github.com/user-attachments/assets/8d24aca0-4a90-491f-b44c-2d8ce14922ca" />


<!-- end of auto-generated comment: release notes by coderabbit.ai -->