### PR TITLE
resource_control: use TotalVersionsSize for RU readBytes in NextGen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7
+	github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7 h1:ENZsbCKjZe5GyNVuKHTGYiYd4LnM8PRphBsYU6M19g0=
-github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4 h1:EJb7T8qTbKECF4AA2sQLJP5w2Smd+FHdE0eHvVPUS/Q=
+github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7
+	github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4
 	github.com/pingcap/tidb v1.1.0-beta.0.20250609033843-a165d9fd7c01
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1448,8 +1448,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7 h1:ENZsbCKjZe5GyNVuKHTGYiYd4LnM8PRphBsYU6M19g0=
-github.com/pingcap/kvproto v0.0.0-20260106110113-438649d89ee7/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4 h1:EJb7T8qTbKECF4AA2sQLJP5w2Smd+FHdE0eHvVPUS/Q=
+github.com/pingcap/kvproto v0.0.0-20260224061309-b336a102cdb4/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -201,7 +201,27 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	// Try to get read bytes from the `detailsV2`.
 	// TODO: clarify whether we should count the underlying storage engine read bytes or not.
 	if scanDetail := detailsV2.GetScanDetailV2(); scanDetail != nil {
-		readBytes = scanDetail.GetProcessedVersionsSize()
+		if config.NextGen {
+			// Using the total versions size as the read bytes, which includes not
+			// only processed versions size, but also skipped MVCC versions size.
+			// It can reflect the actual read bytes more accurately, especially for
+			// the request with a large number of MVCC versions.
+			//
+			// For compatibility with older versions of TiKV, if the
+			// processed versions size is greater than the total versions size,
+			// we use the processed versions size as the read bytes.
+			readBytes = max(scanDetail.GetTotalVersionsSize(), scanDetail.GetProcessedVersionsSize())
+		} else {
+			// NOTE: The original design intended to account for all MVCC read
+			// overhead, but TotalVersionsSize did not exist at the time, so
+			// ProcessedVersionsSize was used instead, which only counts the
+			// versions that are actually processed and excludes skipped MVCC
+			// versions. Since this behavior has already been released, switching
+			// to TotalVersionsSize would change the RU calculation. To avoid
+			// unexpected impact on existing users, we only fix this in NextGen
+			// and keep the legacy behavior here for now.
+			readBytes = scanDetail.GetProcessedVersionsSize()
+		}
 	}
 	// Get the KV CPU time in milliseconds from the execution time details.
 	kvCPU := getKVCPU(detailsV2, details)

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -3,9 +3,11 @@ package resourcecontrol
 import (
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/assert"
+	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
@@ -45,4 +47,39 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(3), info.WriteBytes())
 	assert.False(t, info.Bypass())
 	assert.Equal(t, uint64(0), info.StoreID())
+}
+
+func TestResponseInfoReadBytes(t *testing.T) {
+	resp := &tikvrpc.Response{
+		Resp: &coprocessor.Response{
+			ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+				ScanDetailV2: &kvrpcpb.ScanDetailV2{
+					TotalVersionsSize:     100,
+					ProcessedVersionsSize: 80,
+				},
+			},
+		},
+	}
+	info := MakeResponseInfo(resp)
+	if config.NextGen {
+		assert.Equal(t, uint64(100), info.ReadBytes())
+	} else {
+		assert.Equal(t, uint64(80), info.ReadBytes())
+	}
+
+	if config.NextGen {
+		// Compatibility: when processed > total (older TiKV), use processed.
+		respCompat := &tikvrpc.Response{
+			Resp: &coprocessor.Response{
+				ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+					ScanDetailV2: &kvrpcpb.ScanDetailV2{
+						TotalVersionsSize:     80,
+						ProcessedVersionsSize: 100,
+					},
+				},
+			},
+		}
+		infoCompat := MakeResponseInfo(respCompat)
+		assert.Equal(t, uint64(100), infoCompat.ReadBytes())
+	}
 }


### PR DESCRIPTION
## Summary

Cherry-pick from tidbcloud/client-go-cse#40 and tidbcloud/client-go-cse#43.

- Use `TotalVersionsSize` instead of `ProcessedVersionsSize` to calculate RU readBytes under NextGen, which includes skipped MVCC versions and reflects actual read cost more accurately.
- For compatibility with older TiKV versions, fall back to `ProcessedVersionsSize` when it is greater.
- Legacy (non-NextGen) behavior is preserved to avoid changing released RU calculation semantics.
- Bumps `kvproto` to pick up the `TotalVersionsSize` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate resource usage reporting in NextGen mode by considering both processed and total MVCC version sizes.

* **Chores**
  * Updated module dependency versions.

* **Tests**
  * Added test coverage verifying resource usage calculation across configuration modes and compatibility when processed sizes exceed totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->