### PR TITLE
txn: handle shared lock conflict in ForceLock mode (#1879)

### DIFF
--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -458,3 +458,56 @@ func (s *testSharedLockSuite) TestPrewriteResolveExpiredSharedLock() {
 	// Cleanup
 	s.Nil(txn1.Rollback())
 }
+
+func (s *testSharedLockSuite) TestForceLockRetryOnSharedLock() {
+	pk1 := []byte("TestForceLockRetryOnSharedLock_pk1")
+	pk2 := []byte("TestForceLockRetryOnSharedLock_pk2")
+	key := []byte("TestForceLockRetryOnSharedLock_key")
+
+	// Step 1: txn1 acquires a shared lock on key
+	txn1 := s.begin()
+	s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+	s.Equal(pk1, txn1.GetCommitter().GetPrimaryKey())
+	lockCtx1 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+	lockCtx1.InShareMode = true
+	s.Nil(txn1.LockKeys(context.Background(), lockCtx1, key))
+
+	// Wait for the shared lock to be visible
+	s.Eventually(func() bool {
+		return len(s.scanLocks(key, s.getTS())) == 1
+	}, 5*time.Second, 100*time.Millisecond, "expect 1 shared lock")
+
+	// Step 2: txn2 in aggressive locking mode (ForceLock) acquires exclusive lock on the same key
+	txn2 := s.begin()
+	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+	s.Equal(pk2, txn2.GetCommitter().GetPrimaryKey())
+
+	txn2.StartAggressiveLocking()
+	lockCtx2 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+	errCh := make(chan error, 1)
+	go func() {
+		// Single key + aggressive locking → ForceLock mode
+		errCh <- txn2.LockKeys(context.Background(), lockCtx2, key)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-errCh:
+		s.Fail("ForceLock should block on shared lock, not return immediately")
+		return
+	default:
+	}
+
+	s.Nil(txn1.Rollback())
+	s.Nil(<-errCh, "ForceLock mode should resolve expired shared lock and succeed")
+
+	txn2.DoneAggressiveLocking(context.Background())
+
+	// Verify txn2 holds the exclusive lock
+	locks := s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	s.Equal(txn2.StartTS(), locks[0].TxnID)
+
+	// Cleanup
+	s.Nil(txn2.Rollback())
+}

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -472,6 +472,16 @@ func (action actionPessimisticLock) handlePessimisticLockResponseForceLockMode(
 	isMutationFailed := false
 	keyErrs := lockResp.GetErrors()
 
+	// the mutation will fail when it meets a shared lock
+	for _, keyErr := range keyErrs {
+		if lockInfo := keyErr.GetLocked(); lockInfo != nil {
+			if sharedLockInfos := lockInfo.GetSharedLockInfos(); len(sharedLockInfos) > 0 {
+				isMutationFailed = true
+				break
+			}
+		}
+	}
+
 	// We only allow single key in ForceLock mode now.
 	if len(mutationsPb) > 1 || len(lockResp.Results) > 1 {
 		panic("unreachable")


### PR DESCRIPTION
cherry pick #1879 to tidb-8.5

---

ref tikv/tikv#19087

Handle the KeyIsLocked error of shared lock in `handlePessimisticLockResponseForceLockMode`, unless it returns `Pessimistic lock response corrupted` error without auto retry.

- Mark mutation as failed when ForceLock encounters a shared lock so it retries instead of returning immediately.
- Add integration test to verify ForceLock blocks and resolves expired shared locks before acquiring the exclusive lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test for exclusive lock behavior when shared locks are held by other transactions.

* **Bug Fixes**
  * Enhanced handling of shared lock detection during exclusive lock operations to ensure proper lock state management in concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->