### PR TITLE
hard-invalidate region on RegionNotFound instead of async reload

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2045,18 +2045,6 @@ func (c *RegionCache) BatchLoadRegionsFromKey(bo *retry.Backoffer, startKey []by
 	return regions[len(regions)-1].EndKey(), nil
 }
 
-// AsyncInvalidateCachedRegion marks a cached region for reload on next access
-// without invalidating it, so in-flight retries can still proceed.
-// It sets needDelayedReloadReady directly, skipping the GC promotion from
-// needDelayedReloadPending for faster reload.
-func (c *RegionCache) AsyncInvalidateCachedRegion(id RegionVerID) {
-	cachedRegion := c.GetCachedRegionWithRLock(id)
-	if cachedRegion == nil {
-		return
-	}
-	cachedRegion.setSyncFlags(needDelayedReloadReady)
-}
-
 // InvalidateCachedRegion removes a cached Region.
 func (c *RegionCache) InvalidateCachedRegion(id RegionVerID) {
 	c.InvalidateCachedRegionWithReason(id, Other)

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -303,9 +303,9 @@ func testRegionCacheStaleRead(t *testing.T) {
 			leaderAsyncReload:     util.Some(false),
 			leaderSuccessReplica:  []string{"z1"},
 			leaderSuccessReadType: SuccessStaleRead,
-			followerRegionValid:   true,
-			followerAsyncReload:   util.Some(true),
-			// may async reload region and access it from leader.
+			followerRegionValid:   false,
+			followerAsyncReload:   util.Some(false),
+			// region is hard-invalidated but the current request succeeds via leader retry.
 			followerSuccessReplica:  []string{"z1"},
 			followerSuccessReadType: SuccessStaleRead,
 		},

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -31,13 +31,14 @@ import (
 
 type replicaSelector struct {
 	baseReplicaSelector
-	replicaReadType kv.ReplicaReadType
-	isStaleRead     bool
-	isReadOnlyReq   bool
-	option          storeSelectorOp
-	target          *replica
-	proxy           *replica
-	attempts        int
+	replicaReadType            kv.ReplicaReadType
+	isStaleRead                bool
+	isReadOnlyReq              bool
+	option                     storeSelectorOp
+	target                     *replica
+	proxy                      *replica
+	attempts                   int
+	regionInvalidatedForRetry  bool // set when region is hard-invalidated but this selector should still retry on leader
 }
 
 func newReplicaSelector(
@@ -98,7 +99,13 @@ func buildTiKVReplicas(region *Region) []*replica {
 }
 
 func (s *replicaSelector) next(bo *retry.Backoffer, req *tikvrpc.Request) (rpcCtx *RPCContext, err error) {
-	if !s.region.isValid() {
+	if s.regionInvalidatedForRetry {
+		// Allow one more attempt on this selector even though the region is
+		// invalidated.  This is set by onRegionNotFound so that the current
+		// request can retry on the leader while concurrent requests are
+		// stopped by the hard invalidation.
+		s.regionInvalidatedForRetry = false
+	} else if !s.region.isValid() {
 		metrics.TiKVReplicaSelectorFailureCounter.WithLabelValues("invalid").Inc()
 		return nil, nil
 	}
@@ -523,11 +530,15 @@ func (s *replicaSelector) onRegionNotFound(
 	leaderIdx := s.region.getStore().workTiKVIdx
 	leader := s.replicas[leaderIdx]
 	if !leader.isExhausted(1, 0) {
-		// if the request is not sent to leader, we can retry it with leader and invalidate the region cache asynchronously. It helps in the scenario
-		// where region is split by the leader but not yet created in replica due to replica down.
+		// if the request is not sent to leader, we can retry it with leader and invalidate the region cache
+		// immediately. It helps in the scenario where region is split by the leader but not yet created
+		// in replica due to replica down.
+		// Hard-invalidate the region so that concurrent requests stop using the stale region,
+		// but allow this selector to retry on the leader via regionInvalidatedForRetry.
 		req.SetReplicaReadType(kv.ReplicaReadLeader)
 		s.replicaReadType = kv.ReplicaReadLeader
-		s.regionCache.AsyncInvalidateCachedRegion(ctx.Region)
+		s.regionInvalidatedForRetry = true
+		s.regionCache.InvalidateCachedRegion(ctx.Region)
 		return true, nil
 	}
 	s.regionCache.InvalidateCachedRegion(ctx.Region)

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -31,14 +31,14 @@ import (
 
 type replicaSelector struct {
 	baseReplicaSelector
-	replicaReadType            kv.ReplicaReadType
-	isStaleRead                bool
-	isReadOnlyReq              bool
-	option                     storeSelectorOp
-	target                     *replica
-	proxy                      *replica
-	attempts                   int
-	regionInvalidatedForRetry  bool // set when region is hard-invalidated but this selector should still retry on leader
+	replicaReadType           kv.ReplicaReadType
+	isStaleRead               bool
+	isReadOnlyReq             bool
+	option                    storeSelectorOp
+	target                    *replica
+	proxy                     *replica
+	attempts                  int
+	regionInvalidatedForRetry bool // set when region is hard-invalidated but this selector should still retry on leader
 }
 
 func newReplicaSelector(

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -1156,14 +1156,16 @@ func testReplicaReadAccessPathByBasicCase(s *testReplicaSelectorSuite) {
 					case kv.ReplicaReadLeader:
 						accessPath = []string{"{addr: store1, replica-read: false, stale-read: false}"}
 					case kv.ReplicaReadFollower:
-						// For RegionNotFoundErr from follower, it will retry on leader
+						// For RegionNotFoundErr from follower, it will retry on leader.
+						// The region is hard-invalidated to stop concurrent requests,
+						// but the current selector bypasses the validity check.
 						if tp == RegionNotFoundErr {
 							accessPath = []string{
 								"{addr: store2, replica-read: true, stale-read: false}",
 								"{addr: store1, replica-read: false, stale-read: false}",
 							}
 							respRegionError = nil
-							regionIsValid = true
+							regionIsValid = false
 						} else {
 							accessPath = []string{"{addr: store2, replica-read: true, stale-read: false}"}
 						}


### PR DESCRIPTION
issue https://github.com/tikv/client-go/issues/1892

The original [fix](https://github.com/tikv/client-go/pull/1891) does not work because in-flight requests continue to fail with region-not-found errors. This change hard-invalidates the region so that concurrent requests stop using the stale cache, and introduces a regionInvalidatedForRetry flag to allow the current request to retry on the leader before giving up.

Unit test

Deployed in prod to verify that it fixed `region-not-found `errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region cache invalidation to be synchronous instead of asynchronous, ensuring more immediate consistency when region states change.
  * Enhanced retry logic to allow requests to attempt on the leader even after hard region invalidation, improving reliability in region-not-found scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->