### PR TITLE
ruv2: track TiFlash RU in RUDetails

### DIFF
--- a/config/ruv2_test.go
+++ b/config/ruv2_test.go
@@ -51,5 +51,5 @@ func TestUpdateTiKVRUV2FromExecDetailsV2AndWriteRPCCount(t *testing.T) {
 		},
 	}, 31)
 
-	require.Equal(t, int64(157258), ruDetails.TiKVRUV2())
+	require.InDelta(t, 157258.29118786956, ruDetails.TiKVRUV2(), 1e-9)
 }

--- a/internal/client/client_async_test.go
+++ b/internal/client/client_async_test.go
@@ -206,8 +206,8 @@ func TestSendRequestAsyncUpdateTiKVRUV2(t *testing.T) {
 	rl.Exec(ctx)
 	require.True(t, called)
 
-	expected := int64((weights.ResourceManagerWriteCntTiKV + weights.TiKVKVEngineCacheMiss) * weights.RUScale)
-	require.Equal(t, expected, ruDetails.TiKVRUV2())
+	expected := (weights.ResourceManagerWriteCntTiKV + weights.TiKVKVEngineCacheMiss) * weights.RUScale
+	require.InDelta(t, expected, ruDetails.TiKVRUV2(), 1e-9)
 }
 
 func TestSendRequestAsyncTimeout(t *testing.T) {

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -812,10 +812,10 @@ type RUDetails struct {
 	readRU         *uatomic.Float64
 	writeRU        *uatomic.Float64
 	ruWaitDuration *uatomic.Duration
+	// tiflashRU stores RRU+WRU of Tiflash.
+	tiflashRU *uatomic.Float64
 	// tikvRUV2 stores TiKV RU v2 value in scaled units.
 	tikvRUV2 *uatomic.Float64
-	// tidbRUV2 stores TiDB RU v2 value in scaled units.
-	tidbRUV2 *uatomic.Float64
 }
 
 // NewRUDetails creates a new RUDetails.
@@ -824,8 +824,8 @@ func NewRUDetails() *RUDetails {
 		readRU:         uatomic.NewFloat64(0),
 		writeRU:        uatomic.NewFloat64(0),
 		ruWaitDuration: uatomic.NewDuration(0),
+		tiflashRU:      uatomic.NewFloat64(0),
 		tikvRUV2:       uatomic.NewFloat64(0),
-		tidbRUV2:       uatomic.NewFloat64(0),
 	}
 }
 
@@ -836,8 +836,8 @@ func NewRUDetailsWith(rru, wru float64, waitDur time.Duration) *RUDetails {
 		readRU:         uatomic.NewFloat64(rru),
 		writeRU:        uatomic.NewFloat64(wru),
 		ruWaitDuration: uatomic.NewDuration(waitDur),
+		tiflashRU:      uatomic.NewFloat64(0),
 		tikvRUV2:       uatomic.NewFloat64(0),
-		tidbRUV2:       uatomic.NewFloat64(0),
 	}
 }
 
@@ -847,8 +847,8 @@ func (rd *RUDetails) Clone() *RUDetails {
 		readRU:         uatomic.NewFloat64(rd.readRU.Load()),
 		writeRU:        uatomic.NewFloat64(rd.writeRU.Load()),
 		ruWaitDuration: uatomic.NewDuration(rd.ruWaitDuration.Load()),
+		tiflashRU:      uatomic.NewFloat64(rd.tiflashRU.Load()),
 		tikvRUV2:       uatomic.NewFloat64(rd.tikvRUV2.Load()),
-		tidbRUV2:       uatomic.NewFloat64(rd.tidbRUV2.Load()),
 	}
 }
 
@@ -857,18 +857,17 @@ func (rd *RUDetails) Merge(other *RUDetails) {
 	rd.readRU.Add(other.readRU.Load())
 	rd.writeRU.Add(other.writeRU.Load())
 	rd.ruWaitDuration.Add(other.ruWaitDuration.Load())
+	rd.tiflashRU.Add(other.tiflashRU.Load())
 	rd.tikvRUV2.Add(other.tikvRUV2.Load())
-	rd.tidbRUV2.Add(other.tidbRUV2.Load())
 }
 
 // String implements fmt.Stringer interface.
 func (rd *RUDetails) String() string {
 	return fmt.Sprintf(
-		"RRU:%f, WRU:%f, WaitDuration:%v, TiKVRUV2:%d",
+		"RRU:%f, WRU:%f, WaitDuration:%v",
 		rd.readRU.Load(),
 		rd.writeRU.Load(),
 		rd.ruWaitDuration.Load(),
-		rd.TiKVRUV2(),
 	)
 }
 
@@ -887,9 +886,14 @@ func (rd *RUDetails) RUWaitDuration() time.Duration {
 	return rd.ruWaitDuration.Load()
 }
 
-// TiKVRUV2 returns the TiKV RU v2 value (scaled integer) accumulated in the client.
-func (rd *RUDetails) TiKVRUV2() int64 {
-	return int64(rd.tikvRUV2.Load())
+// TiflashRU returns the Tiflash RU (RRU+WRU) accumulated in the client.
+func (rd *RUDetails) TiflashRU() float64 {
+	return rd.tiflashRU.Load()
+}
+
+// TiKVRUV2 returns the TiKV RU v2 value accumulated in the client.
+func (rd *RUDetails) TiKVRUV2() float64 {
+	return rd.tikvRUV2.Load()
 }
 
 // AddTiKVRUV2 adds a delta (scaled) to the accumulated TiKV RU v2 value.
@@ -900,30 +904,6 @@ func (rd *RUDetails) AddTiKVRUV2(delta float64) {
 	rd.tikvRUV2.Add(delta)
 }
 
-// TiDBRUV2 returns the TiDB RU v2 value (scaled integer) accumulated in the client.
-func (rd *RUDetails) TiDBRUV2() int64 {
-	if rd == nil || rd.tidbRUV2 == nil {
-		return 0
-	}
-	return int64(rd.tidbRUV2.Load())
-}
-
-// AddTiDBRUV2 adds a delta (scaled) to the accumulated TiDB RU v2 value.
-func (rd *RUDetails) AddTiDBRUV2(delta float64) {
-	if rd == nil || rd.tidbRUV2 == nil || delta == 0 {
-		return
-	}
-	rd.tidbRUV2.Add(delta)
-}
-
-// TotalRUV2 returns the total RU v2 value (scaled integer) accumulated in the client.
-func (rd *RUDetails) TotalRUV2() int64 {
-	if rd == nil {
-		return 0
-	}
-	return rd.TiKVRUV2() + rd.TiDBRUV2()
-}
-
 // Update updates the RU runtime stats with the given consumption info.
 func (rd *RUDetails) Update(consumption *rmpb.Consumption, waitDuration time.Duration) {
 	if rd == nil || consumption == nil {
@@ -932,4 +912,14 @@ func (rd *RUDetails) Update(consumption *rmpb.Consumption, waitDuration time.Dur
 	rd.readRU.Add(consumption.RRU)
 	rd.writeRU.Add(consumption.WRU)
 	rd.ruWaitDuration.Add(waitDuration)
+}
+
+// UpdateTiFlash updates the Tiflash RU (RRU+WRU) with the given consumption info.
+func (rd *RUDetails) UpdateTiFlash(consumption *rmpb.Consumption) {
+	if rd == nil || consumption == nil {
+		return
+	}
+	rd.readRU.Add(consumption.RRU)
+	rd.writeRU.Add(consumption.WRU)
+	rd.tiflashRU.Add(consumption.RRU + consumption.WRU)
 }

--- a/util/execdetails_test.go
+++ b/util/execdetails_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -410,4 +411,24 @@ func TestTimeDetailMergeNil(t *testing.T) {
 	}
 	a.Merge(nil)
 	assert.Equal(t, 10*time.Millisecond, a.ProcessTime)
+}
+
+func TestRUDetailsUpdateTiFlash(t *testing.T) {
+	rd := NewRUDetails()
+	rd.Update(&rmpb.Consumption{
+		RRU: 1.5,
+		WRU: 2.5,
+	}, 3*time.Millisecond)
+	rd.UpdateTiFlash(&rmpb.Consumption{
+		RRU: 3.0,
+		WRU: 4.0,
+	})
+
+	assert.InDelta(t, 4.5, rd.RRU(), 1e-9)
+	assert.InDelta(t, 6.5, rd.WRU(), 1e-9)
+	assert.InDelta(t, 7.0, rd.TiflashRU(), 1e-9)
+	assert.Equal(t, 3*time.Millisecond, rd.RUWaitDuration())
+
+	cloned := rd.Clone()
+	assert.InDelta(t, rd.TiflashRU(), cloned.TiflashRU(), 1e-9)
 }


### PR DESCRIPTION
## Summary
- track TiFlash RU separately in RUDetails while still accumulating RRU/WRU
- keep TiKV RU v2 in floating-point form instead of truncating to int
- remove unused TiDB RU v2 helpers and update the affected tests

## Tests
- go test ./config -run TestUpdateTiKVRUV2FromExecDetailsV2AndWriteRPCCount
- go test ./internal/client -run TestSendRequestAsyncUpdateTiKVRUV2
- go test ./util -run 'TestRUDetailsUpdateTiFlash|TestTimeDetailMergeNil'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TiFlash resource unit (RU) tracking for v2 RU calculations.

* **Refactor**
  * Changed TiKV RU v2 return type to floating-point for improved precision.
  * Removed TiDB RU v2 tracking APIs.

* **Tests**
  * Updated test assertions to accommodate floating-point RU comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->