### PR TITLE
integration_tests: bump tidb to 0511849

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20260309153435-8478a5610086
-	github.com/pingcap/tidb v1.1.0-beta.0.20250609033843-a165d9fd7c01
+	github.com/pingcap/tidb v0.0.0-20260320131726-051184927f34
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2
@@ -177,8 +177,5 @@ require (
 
 replace (
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
-	// todo: remove this replace after tidb updated the dependency
-	github.com/pingcap/tidb => github.com/pingcap/tidb v0.0.0-20260320131726-051184927f34
-	github.com/pingcap/tidb/pkg/parser => github.com/pingcap/tidb/pkg/parser v0.0.0-20260320131726-051184927f34
 	github.com/tikv/client-go/v2 => ../
 )

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1452,8 +1452,8 @@ github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0R
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
 github.com/pingcap/tidb v0.0.0-20260320131726-051184927f34 h1:NdCaize6dNy0DAaJSOD73LBh+LJOM4pHd37zq8scLEg=
 github.com/pingcap/tidb v0.0.0-20260320131726-051184927f34/go.mod h1:hhl5j5PAPBlcz94n7Q+E921pF0QtlMIY+HVqdkxdh0I=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260320131726-051184927f34 h1:PNjl0BZw2fafGlNECR+qPfv/zJB2H9Hu7gOx6vgG6DE=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260320131726-051184927f34/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20250604120526-b159f56cd452 h1:EcKhxZWCKKxbhmH19ueem9wpIIcyImBNBKaR0yQJrCQ=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20250604120526-b159f56cd452/go.mod h1:+8feuexTKcXHZF/dkDfvCwEyBAmgb4paFc3/WeYV2eE=
 github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe h1:Zmz9mON+2NoKDVjkJbk6NZbFoTzVzk8MPTbRnu+MiVM=
 github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
## Summary

Bump integration_tests to the latest pingcap/tidb master revision 0511849.

## Changes

- replace github.com/pingcap/tidb from forked github.com/bufferflies/tidb to latest upstream github.com/pingcap/tidb
- replace github.com/pingcap/tidb/pkg/parser from forked parser to latest upstream parser
- keep github.com/tikv/client-go/v2 => ../ for local integration validation
- run go mod tidy in integration_tests

## Details

Updated in integration_tests/go.mod:

- github.com/pingcap/tidb => github.com/pingcap/tidb v0.0.0-20260320131726-051184927f34
- github.com/pingcap/tidb/pkg/parser => github.com/pingcap/tidb/pkg/parser v0.0.0-20260320131726-051184927f34

go mod tidy also refreshed a few transitive/module selections, including:

- github.com/pingcap/errors
- github.com/stretchr/testify
- github.com/tikv/client-go/v2

## Validation

```bash
cd integration_tests
go mod tidy
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated integration test dependency versions and refreshed replace directives to newer upstream revisions to ensure tests run against more recent library releases.
  * No public APIs changed; only dependency metadata updated (small, non-functional changes to test configuration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->