### PR TITLE
integration_tests: bump tidb to b152507

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20260309153435-8478a5610086
-	github.com/pingcap/tidb v1.1.0-beta.0.20250609033843-a165d9fd7c01
+	github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2


### PR DESCRIPTION
## Summary

Bump integration_tests tidb dependency to commit b1525070ca3ecfa4c9e791ec451df2d553497cce.

## Changes

- update github.com/pingcap/tidb in integration_tests/go.mod to the pseudo-version for b152507
- keep changes limited to integration_tests/
- run go mod tidy in integration_tests

## Validation

```bash
cd integration_tests
go mod tidy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->