### PR TITLE
integration_tests: remove tidb replace and bump to b152507

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 // indirect
-	github.com/pingcap/tidb/pkg/parser v0.0.0-20250604120526-b159f56cd452 // indirect
+	github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e // indirect
 	github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1452,8 +1452,8 @@ github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0R
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
 github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e h1:VnpEPrQ2jBQlnBdXWowkzAJ2FJotwPjo1BmnMR6vgdg=
 github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e/go.mod h1:eMzLtpe0gvraDYmLH0vAYJn/QZT/o3VEQSWlHf4wsUc=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20250604120526-b159f56cd452 h1:EcKhxZWCKKxbhmH19ueem9wpIIcyImBNBKaR0yQJrCQ=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20250604120526-b159f56cd452/go.mod h1:+8feuexTKcXHZF/dkDfvCwEyBAmgb4paFc3/WeYV2eE=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e h1:eHtFDQynLMsHBpHrt0DstEjWMUldgW6C2vFkLhHctqM=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e/go.mod h1:K5X1FVP5k4EvzAlnUUAwAxV58thzPpl7bU5g6mg48Cg=
 github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe h1:Zmz9mON+2NoKDVjkJbk6NZbFoTzVzk8MPTbRnu+MiVM=
 github.com/pingcap/tipb v0.0.0-20260210113932-1447c9d7e9fe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
## Summary

Remove the temporary tidb replace in integration_tests and bump github.com/pingcap/tidb to commit [b1525070ca3ecfa4c9e791ec451df2d553497cce](https://github.com/pingcap/tidb/commit/b1525070ca3ecfa4c9e791ec451df2d553497cce).

## Changes

- remove integration_tests replace entries for github.com/pingcap/tidb and github.com/pingcap/tidb/pkg/parser
- bump github.com/pingcap/tidb to the pseudo-version for b152507
- align github.com/pingcap/tidb/pkg/parser to the same b152507 commit
- run go mod tidy in integration_tests
- keep changes limited to integration_tests/

## Validation

```bash
cd integration_tests
go mod tidy
```
