### PR TITLE
config: change RUScale default value to 1.40

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -145,7 +145,7 @@ type RUV2TiKVConfig struct {
 // Keep RUScale and the per-counter weights in sync with that fitting procedure when updating them.
 func DefaultRUV2TiKVConfig() RUV2TiKVConfig {
 	return RUV2TiKVConfig{
-		RUScale: 5697.054498,
+		RUScale: 1.40,
 
 		TiKVKVEngineCacheMiss:             0.45975389,
 		ResourceManagerWriteCntTiKV:       0.09642181,

--- a/config/ruv2_test.go
+++ b/config/ruv2_test.go
@@ -51,5 +51,5 @@ func TestUpdateTiKVRUV2FromExecDetailsV2AndWriteRPCCount(t *testing.T) {
 		},
 	}, 31)
 
-	require.InDelta(t, 157258.29118786956, ruDetails.TiKVRUV2(), 1e-9)
+	require.InDelta(t, 38.64481334, ruDetails.TiKVRUV2(), 1e-9)
 }


### PR DESCRIPTION
Change the default value of RUScale from 5697.054498 to 1.40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default resource unit scaling configuration to improve resource calculation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->