### PR TITLE
resourcecontrol: propagate request source for RU metrics

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -38,6 +38,7 @@ type RequestInfo struct {
 	replicaNumber int64
 	requestSize   uint64
 	accessType    controller.AccessLocationType
+	requestSource string
 	// predictedReadBytes is an optional caller-supplied read-bytes
 	// estimate. The PD controller decides whether to use it for paging
 	// accounting based on request type; non-cop hints may be ignored.
@@ -100,6 +101,7 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 			bypass:             bypass,
 			requestSize:        uint64(req.GetSize()),
 			accessType:         toPDAccessLocationType(req.AccessLocation),
+			requestSource:      req.GetRequestSource(),
 			predictedReadBytes: req.PredictedReadBytes,
 			isCop:              isCopRequest(req),
 		}
@@ -127,6 +129,7 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 		bypass:        bypass,
 		requestSize:   uint64(req.GetSize()),
 		accessType:    toPDAccessLocationType(req.AccessLocation),
+		requestSource: req.GetRequestSource(),
 	}
 }
 
@@ -163,6 +166,11 @@ func (req *RequestInfo) RequestSize() uint64 {
 
 func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
+}
+
+// RequestSource returns the source of the underlying TiKV request.
+func (req *RequestInfo) RequestSource() string {
+	return req.requestSource
 }
 
 // PredictedReadBytes implements PD's controller.RequestInfo interface,

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -13,12 +13,20 @@ import (
 
 func TestMakeRequestInfo(t *testing.T) {
 	// Test a non-write request.
-	req := &tikvrpc.Request{Req: &kvrpcpb.BatchGetRequest{}, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}}}
+	readRequestSource := "leader_external_Select"
+	req := &tikvrpc.Request{
+		Req: &kvrpcpb.BatchGetRequest{},
+		Context: kvrpcpb.Context{
+			Peer:          &metapb.Peer{StoreId: 1},
+			RequestSource: readRequestSource,
+		},
+	}
 	info := MakeRequestInfo(req)
 	assert.False(t, info.IsWrite())
 	assert.Equal(t, uint64(0), info.WriteBytes())
 	assert.False(t, info.Bypass())
 	assert.Equal(t, uint64(1), info.StoreID())
+	assert.Equal(t, readRequestSource, info.RequestSource())
 
 	// Test a prewrite request.
 	mutation := &kvrpcpb.Mutation{Key: []byte("foo"), Value: []byte("bar")}
@@ -31,6 +39,7 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(9), info.WriteBytes())
 	assert.True(t, info.Bypass())
 	assert.Equal(t, uint64(2), info.StoreID())
+	assert.Equal(t, requestSource, info.RequestSource())
 	// Test a commit request.
 	commitReq := &kvrpcpb.CommitRequest{Keys: [][]byte{[]byte("qux")}}
 	req = &tikvrpc.Request{Type: tikvrpc.CmdCommit, Req: commitReq, ReplicaNumber: 2, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 3}}}
@@ -39,6 +48,7 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(3), info.WriteBytes())
 	assert.False(t, info.Bypass())
 	assert.Equal(t, uint64(3), info.StoreID())
+	assert.Empty(t, info.RequestSource())
 
 	// Test Nil Peer in Context
 	req = &tikvrpc.Request{Type: tikvrpc.CmdCommit, Req: commitReq, ReplicaNumber: 2, Context: kvrpcpb.Context{}}


### PR DESCRIPTION
Ref tikv/pd#10634

Related PR: tikv/pd#10588

## What problem does this PR solve?

`pd/client` records RU consumption inside its resource-group controller, but client-go's `resourcecontrol.RequestInfo` does not currently propagate the TiKV request source. Without that value, the per-request-source RU metric introduced by tikv/pd#10588 cannot attribute RRU/WRU to user queries, DDL, stats, and other internal activities.

## What is changed and how does it work?

- Store `tikvrpc.Request.GetRequestSource()` in client-go's `resourcecontrol.RequestInfo` for both read and write requests.
- Add `RequestSource()` so `RequestInfo` implements the optional request-source provider recognized by `pd/client`.
- Cover request-source propagation for read requests, write requests, and requests without a source.

This PR only propagates request metadata. It does not change resource-control bypass behavior, define client-go RU counters, or duplicate RU accounting in the client-go interceptor. The metric itself is owned and recorded by `pd/client` in tikv/pd#10588.

The metric becomes effective after client-go consumes a `pd/client` version containing tikv/pd#10588.

## Tests

```text
go test ./internal/resourcecontrol -count=1
```

## Release note

```release-note
None
```
