### PR TITLE
fix(resourcecontrol): bypass RU accounting for NextGen background activities

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -70,15 +70,18 @@ const reqTypeAnalyze = 104
 var bypassResourceSourceList = []string{
 	/* DDL */
 	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/ddl/job_worker.go#L503
-	"add_index",
+	util.InternalTxnAddIndex,
 	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/ddl/backfilling_operators.go#L1230
-	"merge_temp_index",
+	util.InternalTxnMergeTempIndex,
 	/* BR */
 	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/option.go#L214
 	util.InternalTxnBR,
 	/* Import Into */
 	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/option.go#L224
 	util.InternalImportInto,
+	/* Workload Learning */
+	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/option.go#L201
+	util.InternalTxnWorkloadLearning,
 }
 
 func shouldBypass(req *tikvrpc.Request) bool {

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -63,26 +63,51 @@ func toPDAccessLocationType(accessType kv.AccessLocationType) controller.AccessL
 }
 
 // reqTypeAnalyze is the type of analyze coprocessor request.
-// ref: https://github.com/pingcap/tidb/blob/ee4eac2ccb83e1ea653b8131d9a43495019cb5ac/pkg/kv/kv.go#L340
+// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/kv.go#L340
 const reqTypeAnalyze = 104
+
+// bypassResourceSourceList maintains a list of resource sources that should be bypassed from the resource control.
+var bypassResourceSourceList = []string{
+	/* DDL */
+	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/ddl/job_worker.go#L503
+	"add_index",
+	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/ddl/backfilling_operators.go#L1230
+	"merge_temp_index",
+	/* BR */
+	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/option.go#L214
+	util.InternalTxnBR,
+	/* Import Into */
+	// ref: https://github.com/pingcap/tidb/blob/e691904f3c60113f8031a48c3e4c5940e24b8104/pkg/kv/option.go#L224
+	util.InternalImportInto,
+}
 
 func shouldBypass(req *tikvrpc.Request) bool {
 	requestSource := req.GetRequestSource()
-	// Check both coprocessor request type and the request source to ensure the request is an internal analyze request.
-	// Internal analyze request may consume a lot of resources, bypass it to avoid affecting the user experience.
-	// This bypass currently only works with NextGen.
-	if config.NextGen && strings.Contains(requestSource, util.InternalTxnStats) {
-		var tp int64
-		switch req.Type {
-		case tikvrpc.CmdBatchCop:
-			tp = req.BatchCop().GetTp()
-		case tikvrpc.CmdCop, tikvrpc.CmdCopStream:
-			tp = req.Cop().GetTp()
+
+	// These bypasses currently only work with NextGen.
+	if config.NextGen {
+		// Check both coprocessor request type and the request source to ensure the request is an internal analyze request.
+		// Internal analyze request may consume a lot of resources, bypass it to avoid affecting the user experience.
+		if strings.Contains(requestSource, util.InternalTxnStats) {
+			var tp int64
+			switch req.Type {
+			case tikvrpc.CmdBatchCop:
+				tp = req.BatchCop().GetTp()
+			case tikvrpc.CmdCop, tikvrpc.CmdCopStream:
+				tp = req.Cop().GetTp()
+			}
+			if tp == reqTypeAnalyze {
+				return true
+			}
 		}
-		if tp == reqTypeAnalyze {
-			return true
+		// Check other resource source types that should be bypassed.
+		for _, source := range bypassResourceSourceList {
+			if strings.Contains(requestSource, source) {
+				return true
+			}
 		}
 	}
+
 	// Some internal requests should be bypassed, which may affect the user experience.
 	// For example, the `alter user password` request completely bypasses resource control.
 	// Although it does not consume many resources, it can still impact the user experience.

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/util"
 )
 
 func TestMakeRequestInfo(t *testing.T) {
@@ -47,6 +48,97 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(3), info.WriteBytes())
 	assert.False(t, info.Bypass())
 	assert.Equal(t, uint64(0), info.StoreID())
+}
+
+func TestMakeRequestInfoBypassCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		req            *tikvrpc.Request
+		expectedBypass bool
+		nextGenOnly    bool
+	}{
+		{
+			name:           "internal others",
+			req:            &tikvrpc.Request{Context: kvrpcpb.Context{RequestSource: "xxx_internal_others"}},
+			expectedBypass: true,
+		},
+		{
+			name: "add index",
+			req: &tikvrpc.Request{
+				Context: kvrpcpb.Context{RequestSource: util.InternalTxnAddIndex},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "merge temp index",
+			req: &tikvrpc.Request{
+				Context: kvrpcpb.Context{RequestSource: util.InternalTxnMergeTempIndex},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "br",
+			req: &tikvrpc.Request{
+				Context: kvrpcpb.Context{RequestSource: util.InternalTxnBR},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "import into",
+			req: &tikvrpc.Request{
+				Context: kvrpcpb.Context{RequestSource: util.InternalImportInto},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "workload learning",
+			req: &tikvrpc.Request{
+				Context: kvrpcpb.Context{RequestSource: util.InternalTxnWorkloadLearning},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "analyze stats",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCop,
+				Req: &coprocessor.Request{
+					Tp: reqTypeAnalyze,
+				},
+				Context: kvrpcpb.Context{
+					Peer:          &metapb.Peer{StoreId: 4},
+					RequestSource: util.InternalTxnStats,
+				},
+			},
+			expectedBypass: true,
+			nextGenOnly:    true,
+		},
+		{
+			name: "stats without analyze cop",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCop,
+				Req: &coprocessor.Request{
+					Tp: 1,
+				},
+				Context: kvrpcpb.Context{RequestSource: util.InternalTxnStats},
+			},
+			expectedBypass: false,
+			nextGenOnly:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.nextGenOnly && !config.NextGen {
+				t.Skip("rule only applies to nextgen")
+			}
+			assert.Equal(t, tt.expectedBypass, MakeRequestInfo(tt.req).Bypass())
+		})
+	}
 }
 
 func TestMakeRequestInfoPredictedReadBytes(t *testing.T) {

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -41,6 +41,10 @@ const (
 	InternalTxnMeta = InternalTxnOthers
 	// InternalTxnStats is the type of statistics txn.
 	InternalTxnStats = "stats"
+	// InternalTxnBR is the type of BR usage.
+	InternalTxnBR = "br"
+	// InternalImportInto is the type of IMPORT INTO usage
+	InternalImportInto = "ImportInto"
 )
 
 // explicit source types.

--- a/util/request_source.go
+++ b/util/request_source.go
@@ -45,6 +45,12 @@ const (
 	InternalTxnBR = "br"
 	// InternalImportInto is the type of IMPORT INTO usage
 	InternalImportInto = "ImportInto"
+	// InternalTxnAddIndex is the type of DDL add index backfill.
+	InternalTxnAddIndex = "add_index"
+	// InternalTxnMergeTempIndex is the type of DDL temp index merging.
+	InternalTxnMergeTempIndex = "merge_temp_index"
+	// InternalTxnWorkloadLearning is the type of workload-based cost learning.
+	InternalTxnWorkloadLearning = "WorkloadLearning"
 )
 
 // explicit source types.


### PR DESCRIPTION
Closes #1954

Tracking issue (TiDB side): pingcap/tidb#64339

Supersedes #1809.

> **Status:** Ready for review. Product prioritization and merge timing are tracked in pingcap/tidb#64339.

## What problem does this PR solve?

Under the `nextgen` build tag, resource control should bypass selected heavy internal activities so they do not consume the user-facing RU quota.

## What is changed and how does it work?

Expand `shouldBypass()` for the following NextGen request sources:

- DDL index backfill: `add_index` and `merge_temp_index`
- BR: `br`
- IMPORT INTO: `ImportInto`
- Workload Learning: `WorkloadLearning`

The existing internal Analyze and `internal_others` bypass behavior is preserved. This PR changes bypass behavior only; request-source RU observability is tracked separately by #1929 and tikv/pd#10588.

The original implementation commit from #1809 remains in this PR history with its original author attribution.

## Tests

```text
go test ./internal/resourcecontrol ./util -count=1
go test -tags nextgen ./internal/resourcecontrol ./util -count=1
```

Earlier manual verification on a local NextGen cluster confirmed that `add_index` and internal Analyze requests were bypassed without accruing RU, while normal user queries and non-Analyze stats operations continued to consume RU.

## Release note

```release-note
None
```