### PR TITLE
util: add grpc channelz collector for prometheus

### DIFF
--- a/util/collectors/channelz.go
+++ b/util/collectors/channelz.go
@@ -1,0 +1,561 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const channelzSubsystem = "grpc_channelz"
+
+// ChannelzFilter decides whether the collector should emit metrics for the
+// current node and whether it should keep walking into child nodes.
+//
+// The node is one of:
+//   - *channelzpb.Channel
+//   - *channelzpb.Subchannel
+//   - *channelzpb.Socket
+type ChannelzFilter func(node any) (collect bool, walkChildren bool)
+
+// ChannelzCollectorOpts configures a channelz collector.
+type ChannelzCollectorOpts struct {
+	Namespace string
+	Filter    ChannelzFilter
+
+	// IncludeChannelTrace enables per-channel trace statistics.
+	IncludeChannelTrace bool
+	// IncludeChannelState enables the current per-channel connectivity state metric.
+	IncludeChannelState bool
+
+	// DisableLocalLabel suppresses the "local" label on socket metrics.
+	DisableLocalLabel bool
+	// DisableRemoteLabel suppresses the "remote" label on socket metrics.
+	DisableRemoteLabel bool
+}
+
+// NewChannelzCollector constructs a Prometheus collector backed by the gRPC
+// channelz API on the supplied client connection.
+func NewChannelzCollector(conn *grpc.ClientConn, opts ChannelzCollectorOpts) prometheus.Collector {
+	return newChannelzCollector(channelzpb.NewChannelzClient(conn), opts)
+}
+
+type channelzCollector struct {
+	client              channelzpb.ChannelzClient
+	filter              ChannelzFilter
+	includeLocalLabel   bool
+	includeRemoteLabel  bool
+	includeChannelTrace bool
+	includeChannelState bool
+
+	channelCallsDesc             *prometheus.Desc
+	channelLastCallStartedDesc   *prometheus.Desc
+	channelStateDesc             *prometheus.Desc
+	channelTraceEventsLoggedDesc *prometheus.Desc
+	channelTraceCreationDesc     *prometheus.Desc
+	channelTraceEventsDesc       *prometheus.Desc
+	socketStreamsDesc            *prometheus.Desc
+	socketMessagesDesc           *prometheus.Desc
+	socketKeepAlivesDesc         *prometheus.Desc
+	socketLastStreamCreatedDesc  *prometheus.Desc
+	socketLastMessageDesc        *prometheus.Desc
+	socketFlowControlWindowDesc  *prometheus.Desc
+	fetchErrorsDesc              *prometheus.Desc
+	descs                        []*prometheus.Desc
+	getTopChannelsErrorsTotal    atomic.Uint64
+	getChannelErrorsTotal        atomic.Uint64
+	getSubchannelErrorsTotal     atomic.Uint64
+	getSocketErrorsTotal         atomic.Uint64
+}
+
+func newChannelzCollector(client channelzpb.ChannelzClient, opts ChannelzCollectorOpts) *channelzCollector {
+	c := &channelzCollector{
+		client:              client,
+		filter:              opts.Filter,
+		includeLocalLabel:   !opts.DisableLocalLabel,
+		includeRemoteLabel:  !opts.DisableRemoteLabel,
+		includeChannelTrace: opts.IncludeChannelTrace,
+		includeChannelState: opts.IncludeChannelState,
+	}
+
+	channelLabels := []string{"kind", "id", "target"}
+	socketLabels := c.socketLabelNames()
+
+	c.channelCallsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_calls_total"),
+		"Total calls observed by the channelz channel or subchannel.",
+		appendLabels(channelLabels, "type"),
+		nil,
+	)
+	c.channelLastCallStartedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_last_call_started_timestamp_seconds"),
+		"Unix timestamp of the last call started on the channelz channel or subchannel.",
+		channelLabels,
+		nil,
+	)
+	c.socketStreamsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_streams_total"),
+		"Total streams observed by the channelz socket.",
+		appendLabels(socketLabels, "type"),
+		nil,
+	)
+	c.socketMessagesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_messages_total"),
+		"Total messages observed by the channelz socket.",
+		appendLabels(socketLabels, "direction"),
+		nil,
+	)
+	c.socketKeepAlivesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_keepalives_total"),
+		"Total keepalive pings sent on the channelz socket.",
+		socketLabels,
+		nil,
+	)
+	c.socketLastStreamCreatedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_last_stream_created_timestamp_seconds"),
+		"Unix timestamp of the last stream created on the channelz socket.",
+		appendLabels(socketLabels, "side"),
+		nil,
+	)
+	c.socketLastMessageDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_last_message_timestamp_seconds"),
+		"Unix timestamp of the last message activity observed on the channelz socket.",
+		appendLabels(socketLabels, "direction"),
+		nil,
+	)
+	c.socketFlowControlWindowDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "socket_flow_control_window_bytes"),
+		"HTTP/2 flow control window exposed by the channelz socket.",
+		appendLabels(socketLabels, "side"),
+		nil,
+	)
+	c.fetchErrorsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "fetch_errors_total"),
+		"Total RPC fetch errors encountered by the channelz collector.",
+		[]string{"rpc"},
+		nil,
+	)
+	c.descs = []*prometheus.Desc{
+		c.channelCallsDesc,
+		c.channelLastCallStartedDesc,
+		c.socketStreamsDesc,
+		c.socketMessagesDesc,
+		c.socketKeepAlivesDesc,
+		c.socketLastStreamCreatedDesc,
+		c.socketLastMessageDesc,
+		c.socketFlowControlWindowDesc,
+		c.fetchErrorsDesc,
+	}
+	if c.includeChannelState {
+		c.channelStateDesc = prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_state"),
+			"Connectivity state of the channelz channel or subchannel, exported as a one-hot gauge.",
+			appendLabels(channelLabels, "state"),
+			nil,
+		)
+		c.descs = append(c.descs, c.channelStateDesc)
+	}
+	if c.includeChannelTrace {
+		c.channelTraceEventsLoggedDesc = prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_trace_events_logged_total"),
+			"Total number of events ever logged in the channelz trace object.",
+			channelLabels,
+			nil,
+		)
+		c.channelTraceCreationDesc = prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_trace_creation_timestamp_seconds"),
+			"Unix timestamp when the channelz trace object was created.",
+			channelLabels,
+			nil,
+		)
+		c.channelTraceEventsDesc = prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, channelzSubsystem, "channel_trace_event_count"),
+			"Current number of trace events in the channelz trace buffer, partitioned by severity.",
+			appendLabels(channelLabels, "severity"),
+			nil,
+		)
+		c.descs = append(c.descs, c.channelTraceEventsLoggedDesc, c.channelTraceCreationDesc, c.channelTraceEventsDesc)
+	}
+	return c
+}
+
+func (c *channelzCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, desc := range c.descs {
+		ch <- desc
+	}
+}
+
+func (c *channelzCollector) Collect(ch chan<- prometheus.Metric) {
+	w := channelzWalker{
+		collector:       c,
+		ch:              ch,
+		now:             time.Now(),
+		seenChannels:    make(map[int64]struct{}),
+		seenSubchannels: make(map[int64]struct{}),
+		seenSockets:     make(map[int64]struct{}),
+	}
+	w.walkTopChannels()
+	c.collectFetchErrorMetrics(ch)
+}
+
+type channelzWalker struct {
+	collector       *channelzCollector
+	ch              chan<- prometheus.Metric
+	now             time.Time
+	seenChannels    map[int64]struct{}
+	seenSubchannels map[int64]struct{}
+	seenSockets     map[int64]struct{}
+}
+
+func (w *channelzWalker) walkTopChannels() {
+	var startID int64
+	for {
+		resp, err := w.collector.client.GetTopChannels(context.Background(), &channelzpb.GetTopChannelsRequest{
+			StartChannelId: startID,
+			MaxResults:     0,
+		})
+		if err != nil {
+			w.collector.getTopChannelsErrorsTotal.Add(1)
+			return
+		}
+
+		var maxID int64
+		for _, channel := range resp.GetChannel() {
+			if id := channel.GetRef().GetChannelId(); id > maxID {
+				maxID = id
+			}
+			w.walkChannel(channel)
+		}
+
+		if resp.GetEnd() || len(resp.GetChannel()) == 0 || maxID <= startID {
+			return
+		}
+		startID = maxID + 1
+	}
+}
+
+func (w *channelzWalker) walkChannel(channel *channelzpb.Channel) {
+	if channel == nil {
+		return
+	}
+	id := channel.GetRef().GetChannelId()
+	if id <= 0 {
+		return
+	}
+	if _, ok := w.seenChannels[id]; ok {
+		return
+	}
+	w.seenChannels[id] = struct{}{}
+
+	collect, walkChildren := w.collector.applyFilter(channel)
+	if collect {
+		w.collectChannelMetrics("channel", id, channel.GetData())
+	}
+	if !walkChildren {
+		return
+	}
+
+	for _, ref := range channel.GetChannelRef() {
+		child, err := w.collector.client.GetChannel(context.Background(), &channelzpb.GetChannelRequest{ChannelId: ref.GetChannelId()})
+		if err != nil {
+			w.collector.getChannelErrorsTotal.Add(1)
+			continue
+		}
+		w.walkChannel(child.GetChannel())
+	}
+	for _, ref := range channel.GetSubchannelRef() {
+		child, err := w.collector.client.GetSubchannel(context.Background(), &channelzpb.GetSubchannelRequest{SubchannelId: ref.GetSubchannelId()})
+		if err != nil {
+			w.collector.getSubchannelErrorsTotal.Add(1)
+			continue
+		}
+		w.walkSubchannel(child.GetSubchannel())
+	}
+	for _, ref := range channel.GetSocketRef() {
+		socket, err := w.collector.client.GetSocket(context.Background(), &channelzpb.GetSocketRequest{SocketId: ref.GetSocketId()})
+		if err != nil {
+			w.collector.getSocketErrorsTotal.Add(1)
+			continue
+		}
+		w.walkSocket(socket.GetSocket())
+	}
+}
+
+func (w *channelzWalker) walkSubchannel(subchannel *channelzpb.Subchannel) {
+	if subchannel == nil {
+		return
+	}
+	id := subchannel.GetRef().GetSubchannelId()
+	if id <= 0 {
+		return
+	}
+	if _, ok := w.seenSubchannels[id]; ok {
+		return
+	}
+	w.seenSubchannels[id] = struct{}{}
+
+	collect, walkChildren := w.collector.applyFilter(subchannel)
+	if collect {
+		w.collectChannelMetrics("subchannel", id, subchannel.GetData())
+	}
+	if !walkChildren {
+		return
+	}
+
+	for _, ref := range subchannel.GetChannelRef() {
+		child, err := w.collector.client.GetChannel(context.Background(), &channelzpb.GetChannelRequest{ChannelId: ref.GetChannelId()})
+		if err != nil {
+			w.collector.getChannelErrorsTotal.Add(1)
+			continue
+		}
+		w.walkChannel(child.GetChannel())
+	}
+	for _, ref := range subchannel.GetSubchannelRef() {
+		child, err := w.collector.client.GetSubchannel(context.Background(), &channelzpb.GetSubchannelRequest{SubchannelId: ref.GetSubchannelId()})
+		if err != nil {
+			w.collector.getSubchannelErrorsTotal.Add(1)
+			continue
+		}
+		w.walkSubchannel(child.GetSubchannel())
+	}
+	for _, ref := range subchannel.GetSocketRef() {
+		socket, err := w.collector.client.GetSocket(context.Background(), &channelzpb.GetSocketRequest{SocketId: ref.GetSocketId()})
+		if err != nil {
+			w.collector.getSocketErrorsTotal.Add(1)
+			continue
+		}
+		w.walkSocket(socket.GetSocket())
+	}
+}
+
+func (w *channelzWalker) walkSocket(socket *channelzpb.Socket) {
+	if socket == nil {
+		return
+	}
+	id := socket.GetRef().GetSocketId()
+	if id <= 0 {
+		return
+	}
+	if _, ok := w.seenSockets[id]; ok {
+		return
+	}
+	w.seenSockets[id] = struct{}{}
+
+	collect, _ := w.collector.applyFilter(socket)
+	if collect {
+		w.collectSocketMetrics(id, socket)
+	}
+}
+
+func (w *channelzWalker) collectChannelMetrics(kind string, id int64, data *channelzpb.ChannelData) {
+	if data == nil {
+		return
+	}
+	labels := []string{kind, strconv.FormatInt(id, 10), data.GetTarget()}
+
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelCallsDesc), prometheus.CounterValue, float64(data.GetCallsStarted()), appendLabels(labels, "started")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelCallsDesc), prometheus.CounterValue, float64(data.GetCallsSucceeded()), appendLabels(labels, "succeeded")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelCallsDesc), prometheus.CounterValue, float64(data.GetCallsFailed()), appendLabels(labels, "failed")...)
+
+	if ts := data.GetLastCallStartedTimestamp(); ts != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelLastCallStartedDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), labels...)
+	}
+
+	if w.collector.includeChannelState {
+		currentState := normalizeConnectivityState(data.GetState())
+		for _, state := range []string{"unknown", "idle", "connecting", "ready", "transient_failure", "shutdown"} {
+			value := 0.0
+			if state == currentState {
+				value = 1
+			}
+			w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelStateDesc), prometheus.GaugeValue, value, appendLabels(labels, state)...)
+		}
+	}
+
+	if !w.collector.includeChannelTrace {
+		return
+	}
+	trace := data.GetTrace()
+	if trace == nil {
+		return
+	}
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelTraceEventsLoggedDesc), prometheus.CounterValue, float64(trace.GetNumEventsLogged()), labels...)
+	if ts := trace.GetCreationTimestamp(); ts != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelTraceCreationDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), labels...)
+	}
+
+	severityCounts := map[string]float64{
+		"unknown": 0,
+		"info":    0,
+		"warning": 0,
+		"error":   0,
+	}
+	for _, event := range trace.GetEvents() {
+		severityCounts[normalizeSeverity(event.GetSeverity())]++
+	}
+	for _, severity := range []string{"unknown", "info", "warning", "error"} {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.channelTraceEventsDesc), prometheus.GaugeValue, severityCounts[severity], appendLabels(labels, severity)...)
+	}
+}
+
+func (w *channelzWalker) collectSocketMetrics(id int64, socket *channelzpb.Socket) {
+	data := socket.GetData()
+	if data == nil {
+		return
+	}
+	labels := w.collector.socketLabelValues(id, socket)
+
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketStreamsDesc), prometheus.CounterValue, float64(data.GetStreamsStarted()), appendLabels(labels, "started")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketStreamsDesc), prometheus.CounterValue, float64(data.GetStreamsSucceeded()), appendLabels(labels, "succeeded")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketStreamsDesc), prometheus.CounterValue, float64(data.GetStreamsFailed()), appendLabels(labels, "failed")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketMessagesDesc), prometheus.CounterValue, float64(data.GetMessagesSent()), appendLabels(labels, "sent")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketMessagesDesc), prometheus.CounterValue, float64(data.GetMessagesReceived()), appendLabels(labels, "received")...)
+	w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketKeepAlivesDesc), prometheus.CounterValue, float64(data.GetKeepAlivesSent()), labels...)
+
+	if ts := data.GetLastLocalStreamCreatedTimestamp(); hasUsableTimestamp(ts) {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketLastStreamCreatedDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), appendLabels(labels, "local")...)
+	}
+	if ts := data.GetLastRemoteStreamCreatedTimestamp(); hasUsableTimestamp(ts) {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketLastStreamCreatedDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), appendLabels(labels, "remote")...)
+	}
+	if ts := data.GetLastMessageSentTimestamp(); ts != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketLastMessageDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), appendLabels(labels, "sent")...)
+	}
+	if ts := data.GetLastMessageReceivedTimestamp(); ts != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketLastMessageDesc), prometheus.GaugeValue, timestampSeconds(ts.AsTime()), appendLabels(labels, "received")...)
+	}
+	if window := data.GetLocalFlowControlWindow(); window != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketFlowControlWindowDesc), prometheus.GaugeValue, float64(window.GetValue()), appendLabels(labels, "local")...)
+	}
+	if window := data.GetRemoteFlowControlWindow(); window != nil {
+		w.ch <- prometheus.MustNewConstMetric(cDesc(w.collector.socketFlowControlWindowDesc), prometheus.GaugeValue, float64(window.GetValue()), appendLabels(labels, "remote")...)
+	}
+}
+
+func (c *channelzCollector) socketLabelNames() []string {
+	labels := []string{"id"}
+	if c.includeLocalLabel {
+		labels = append(labels, "local")
+	}
+	if c.includeRemoteLabel {
+		labels = append(labels, "remote")
+	}
+	return labels
+}
+
+func (c *channelzCollector) socketLabelValues(id int64, socket *channelzpb.Socket) []string {
+	values := []string{strconv.FormatInt(id, 10)}
+	if c.includeLocalLabel {
+		values = append(values, formatAddress(socket.GetLocal()))
+	}
+	if c.includeRemoteLabel {
+		values = append(values, formatAddress(socket.GetRemote()))
+	}
+	return values
+}
+
+func (c *channelzCollector) applyFilter(node any) (collect bool, walkChildren bool) {
+	if c.filter == nil {
+		return true, true
+	}
+	return c.filter(node)
+}
+
+func (c *channelzCollector) collectFetchErrorMetrics(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.fetchErrorsDesc, prometheus.CounterValue, float64(c.getTopChannelsErrorsTotal.Load()), "GetTopChannels")
+	ch <- prometheus.MustNewConstMetric(c.fetchErrorsDesc, prometheus.CounterValue, float64(c.getChannelErrorsTotal.Load()), "GetChannel")
+	ch <- prometheus.MustNewConstMetric(c.fetchErrorsDesc, prometheus.CounterValue, float64(c.getSubchannelErrorsTotal.Load()), "GetSubchannel")
+	ch <- prometheus.MustNewConstMetric(c.fetchErrorsDesc, prometheus.CounterValue, float64(c.getSocketErrorsTotal.Load()), "GetSocket")
+}
+
+func appendLabels(labels []string, extra string) []string {
+	out := make([]string, 0, len(labels)+1)
+	out = append(out, labels...)
+	out = append(out, extra)
+	return out
+}
+
+func cDesc(desc *prometheus.Desc) *prometheus.Desc {
+	return desc
+}
+
+func timestampSeconds(t time.Time) float64 {
+	return float64(t.UnixNano()) / float64(time.Second)
+}
+
+func hasUsableTimestamp(ts *timestamppb.Timestamp) bool {
+	return ts != nil && ts.IsValid() && (ts.Seconds != 0 || ts.Nanos != 0)
+}
+
+func normalizeConnectivityState(state *channelzpb.ChannelConnectivityState) string {
+	if state == nil {
+		return "unknown"
+	}
+	switch state.GetState() {
+	case channelzpb.ChannelConnectivityState_IDLE:
+		return "idle"
+	case channelzpb.ChannelConnectivityState_CONNECTING:
+		return "connecting"
+	case channelzpb.ChannelConnectivityState_READY:
+		return "ready"
+	case channelzpb.ChannelConnectivityState_TRANSIENT_FAILURE:
+		return "transient_failure"
+	case channelzpb.ChannelConnectivityState_SHUTDOWN:
+		return "shutdown"
+	default:
+		return "unknown"
+	}
+}
+
+func normalizeSeverity(severity channelzpb.ChannelTraceEvent_Severity) string {
+	switch severity {
+	case channelzpb.ChannelTraceEvent_CT_INFO:
+		return "info"
+	case channelzpb.ChannelTraceEvent_CT_WARNING:
+		return "warning"
+	case channelzpb.ChannelTraceEvent_CT_ERROR:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+func formatAddress(addr *channelzpb.Address) string {
+	if addr == nil {
+		return ""
+	}
+	if tcpAddr := addr.GetTcpipAddress(); tcpAddr != nil {
+		ip := net.IP(tcpAddr.GetIpAddress()).String()
+		if tcpAddr.GetPort() < 0 {
+			return ip
+		}
+		return net.JoinHostPort(ip, strconv.Itoa(int(tcpAddr.GetPort())))
+	}
+	if udsAddr := addr.GetUdsAddress(); udsAddr != nil {
+		return udsAddr.GetFilename()
+	}
+	if otherAddr := addr.GetOtherAddress(); otherAddr != nil {
+		return otherAddr.GetName()
+	}
+	return ""
+}

--- a/util/collectors/channelz_test.go
+++ b/util/collectors/channelz_test.go
@@ -482,10 +482,8 @@ func newTestCollector(t *testing.T, server *fakeChannelzServer, opts ChannelzCol
 		_ = grpcServer.Serve(listener)
 	}()
 
-	ctx := context.Background()
-	conn, err := grpc.DialContext(
-		ctx,
-		"bufnet",
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
 		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 			return listener.Dial()
 		}),

--- a/util/collectors/channelz_test.go
+++ b/util/collectors/channelz_test.go
@@ -1,0 +1,630 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"context"
+	"net"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	channelzpb "google.golang.org/grpc/channelz/grpc_channelz_v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestChannelzCollectorCollect(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref: &channelzpb.ChannelRef{ChannelId: 1},
+						Data: &channelzpb.ChannelData{
+							Target:                   "cluster-a",
+							State:                    &channelzpb.ChannelConnectivityState{State: channelzpb.ChannelConnectivityState_READY},
+							CallsStarted:             12,
+							CallsSucceeded:           10,
+							CallsFailed:              2,
+							LastCallStartedTimestamp: timestamppb.New(base.Add(-20 * time.Second)),
+							Trace: &channelzpb.ChannelTrace{
+								NumEventsLogged:   4,
+								CreationTimestamp: timestamppb.New(base.Add(-5 * time.Minute)),
+								Events: []*channelzpb.ChannelTraceEvent{
+									{Severity: channelzpb.ChannelTraceEvent_CT_INFO},
+									{Severity: channelzpb.ChannelTraceEvent_CT_WARNING},
+									{Severity: channelzpb.ChannelTraceEvent_CT_ERROR},
+								},
+							},
+						},
+						SubchannelRef: []*channelzpb.SubchannelRef{{SubchannelId: 2}},
+						SocketRef:     []*channelzpb.SocketRef{{SocketId: 10}},
+					},
+				},
+				End: false,
+			},
+			2: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref: &channelzpb.ChannelRef{ChannelId: 3},
+						Data: &channelzpb.ChannelData{
+							Target:         "cluster-b",
+							State:          &channelzpb.ChannelConnectivityState{State: channelzpb.ChannelConnectivityState_IDLE},
+							CallsStarted:   2,
+							CallsSucceeded: 2,
+						},
+					},
+				},
+				End: true,
+			},
+		},
+		subchannels: map[int64]*channelzpb.Subchannel{
+			2: {
+				Ref: &channelzpb.SubchannelRef{SubchannelId: 2},
+				Data: &channelzpb.ChannelData{
+					Target:         "backend-a",
+					State:          &channelzpb.ChannelConnectivityState{State: channelzpb.ChannelConnectivityState_CONNECTING},
+					CallsStarted:   3,
+					CallsSucceeded: 2,
+					CallsFailed:    1,
+				},
+				SocketRef: []*channelzpb.SocketRef{{SocketId: 10}, {SocketId: 11}},
+			},
+		},
+		sockets: map[int64]*channelzpb.Socket{
+			10: {
+				Ref:    &channelzpb.SocketRef{SocketId: 10},
+				Local:  tcpAddress(net.ParseIP("127.0.0.1"), 8080),
+				Remote: tcpAddress(net.ParseIP("2001:db8::1"), 443),
+				Data: &channelzpb.SocketData{
+					StreamsStarted:                   5,
+					StreamsSucceeded:                 3,
+					StreamsFailed:                    1,
+					MessagesSent:                     9,
+					MessagesReceived:                 8,
+					KeepAlivesSent:                   4,
+					LastLocalStreamCreatedTimestamp:  timestamppb.New(base.Add(-11 * time.Second)),
+					LastRemoteStreamCreatedTimestamp: timestamppb.New(base.Add(-13 * time.Second)),
+					LastMessageSentTimestamp:         timestamppb.New(base.Add(-5 * time.Second)),
+					LastMessageReceivedTimestamp:     timestamppb.New(base.Add(-7 * time.Second)),
+					LocalFlowControlWindow:           wrapperspb.Int64(128),
+					RemoteFlowControlWindow:          wrapperspb.Int64(256),
+				},
+			},
+			11: {
+				Ref:    &channelzpb.SocketRef{SocketId: 11},
+				Local:  udsAddress("/tmp/channelz.sock"),
+				Remote: otherAddress("passthrough:///peer"),
+				Data: &channelzpb.SocketData{
+					StreamsStarted:               2,
+					StreamsSucceeded:             1,
+					StreamsFailed:                1,
+					LastMessageSentTimestamp:     timestamppb.New(base.Add(-9 * time.Second)),
+					LastMessageReceivedTimestamp: timestamppb.New(base.Add(-3 * time.Second)),
+				},
+			},
+		},
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+
+	requireMetricValue(t, families["grpc_channelz_channel_calls_total"], map[string]string{
+		"kind":   "channel",
+		"id":     "1",
+		"target": "cluster-a",
+		"type":   "started",
+	}, 12)
+	requireMetricValue(t, families["grpc_channelz_channel_calls_total"], map[string]string{
+		"kind":   "subchannel",
+		"id":     "2",
+		"target": "backend-a",
+		"type":   "failed",
+	}, 1)
+	require.Nil(t, families["grpc_channelz_channel_state"])
+	require.Nil(t, families["grpc_channelz_channel_trace_event_count"])
+
+	socket10Labels := map[string]string{
+		"id":     "10",
+		"local":  "127.0.0.1:8080",
+		"remote": "[2001:db8::1]:443",
+	}
+	requireMetricValue(t, families["grpc_channelz_socket_streams_total"], withLabels(socket10Labels, "type", "started"), 5)
+	requireMetricValue(t, families["grpc_channelz_socket_messages_total"], withLabels(socket10Labels, "direction", "sent"), 9)
+	requireMetricValue(t, families["grpc_channelz_socket_keepalives_total"], socket10Labels, 4)
+	requireMetricValue(t, families["grpc_channelz_socket_flow_control_window_bytes"], withLabels(socket10Labels, "side", "remote"), 256)
+	require.Equal(t, 1, countMetrics(t, families["grpc_channelz_socket_streams_total"], withLabels(socket10Labels, "type", "started")))
+
+	socket11Labels := map[string]string{
+		"id":     "11",
+		"local":  "/tmp/channelz.sock",
+		"remote": "passthrough:///peer",
+	}
+	requireMetricValue(t, families["grpc_channelz_socket_streams_total"], withLabels(socket11Labels, "type", "failed"), 1)
+	require.Nil(t, families["grpc_channelz_socket_active_streams"])
+	require.Nil(t, families["grpc_channelz_socket_failed_stream_ratio"])
+	require.Nil(t, families["grpc_channelz_socket_message_receive_lag_seconds"])
+}
+
+func TestChannelzCollectorChannelOptions(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref: &channelzpb.ChannelRef{ChannelId: 1},
+						Data: &channelzpb.ChannelData{
+							Target:                   "cluster-a",
+							State:                    &channelzpb.ChannelConnectivityState{State: channelzpb.ChannelConnectivityState_READY},
+							CallsStarted:             1,
+							LastCallStartedTimestamp: timestamppb.New(base.Add(-20 * time.Second)),
+							Trace: &channelzpb.ChannelTrace{
+								NumEventsLogged:   2,
+								CreationTimestamp: timestamppb.New(base.Add(-5 * time.Minute)),
+								Events: []*channelzpb.ChannelTraceEvent{
+									{Severity: channelzpb.ChannelTraceEvent_CT_WARNING},
+								},
+							},
+						},
+					},
+				},
+				End: true,
+			},
+		},
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{
+		IncludeChannelState: true,
+		IncludeChannelTrace: true,
+	})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+
+	requireMetricValue(t, families["grpc_channelz_channel_state"], map[string]string{
+		"kind":   "channel",
+		"id":     "1",
+		"target": "cluster-a",
+		"state":  "ready",
+	}, 1)
+	requireMetricValue(t, families["grpc_channelz_channel_state"], map[string]string{
+		"kind":   "channel",
+		"id":     "1",
+		"target": "cluster-a",
+		"state":  "idle",
+	}, 0)
+	requireMetricValue(t, families["grpc_channelz_channel_trace_events_logged_total"], map[string]string{
+		"kind":   "channel",
+		"id":     "1",
+		"target": "cluster-a",
+	}, 2)
+	requireMetricValue(t, families["grpc_channelz_channel_trace_event_count"], map[string]string{
+		"kind":     "channel",
+		"id":       "1",
+		"target":   "cluster-a",
+		"severity": "warning",
+	}, 1)
+}
+
+func TestChannelzCollectorFilter(t *testing.T) {
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref:           &channelzpb.ChannelRef{ChannelId: 1},
+						Data:          &channelzpb.ChannelData{Target: "root"},
+						ChannelRef:    []*channelzpb.ChannelRef{{ChannelId: 5}},
+						SubchannelRef: []*channelzpb.SubchannelRef{{SubchannelId: 2}},
+					},
+					{
+						Ref:       &channelzpb.ChannelRef{ChannelId: 4},
+						Data:      &channelzpb.ChannelData{Target: "blocked"},
+						SocketRef: []*channelzpb.SocketRef{{SocketId: 11}},
+					},
+				},
+				End: true,
+			},
+		},
+		channels: map[int64]*channelzpb.Channel{
+			5: {
+				Ref:       &channelzpb.ChannelRef{ChannelId: 5},
+				Data:      &channelzpb.ChannelData{Target: "child"},
+				SocketRef: []*channelzpb.SocketRef{{SocketId: 13}},
+			},
+		},
+		subchannels: map[int64]*channelzpb.Subchannel{
+			2: {
+				Ref:       &channelzpb.SubchannelRef{SubchannelId: 2},
+				Data:      &channelzpb.ChannelData{Target: "sub"},
+				SocketRef: []*channelzpb.SocketRef{{SocketId: 10}},
+			},
+		},
+		sockets: map[int64]*channelzpb.Socket{
+			10: {Ref: &channelzpb.SocketRef{SocketId: 10}, Data: &channelzpb.SocketData{StreamsStarted: 1}},
+			11: {Ref: &channelzpb.SocketRef{SocketId: 11}, Data: &channelzpb.SocketData{StreamsStarted: 1}},
+			13: {Ref: &channelzpb.SocketRef{SocketId: 13}, Data: &channelzpb.SocketData{StreamsStarted: 2}},
+		},
+	}
+
+	filter := func(node any) (bool, bool) {
+		switch node := node.(type) {
+		case *channelzpb.Channel:
+			switch node.GetRef().GetChannelId() {
+			case 1:
+				return false, true
+			case 4:
+				return false, false
+			}
+		case *channelzpb.Subchannel:
+			if node.GetRef().GetSubchannelId() == 2 {
+				return true, false
+			}
+		}
+		return true, true
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{Filter: filter})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+
+	require.Equal(t, 0, countMetrics(t, families["grpc_channelz_channel_calls_total"], map[string]string{"id": "1"}))
+	require.Equal(t, 1, countMetrics(t, families["grpc_channelz_channel_calls_total"], map[string]string{"kind": "subchannel", "id": "2", "target": "sub", "type": "started"}))
+	require.Equal(t, 0, countMetrics(t, families["grpc_channelz_socket_streams_total"], map[string]string{"id": "10"}))
+	require.Equal(t, 1, countMetrics(t, families["grpc_channelz_channel_calls_total"], map[string]string{"kind": "channel", "id": "5", "target": "child", "type": "started"}))
+	require.Equal(t, 1, countMetrics(t, families["grpc_channelz_socket_streams_total"], map[string]string{"id": "13", "type": "started"}))
+	require.Equal(t, 0, countMetrics(t, families["grpc_channelz_channel_calls_total"], map[string]string{"id": "4"}))
+	require.Equal(t, 0, countMetrics(t, families["grpc_channelz_socket_streams_total"], map[string]string{"id": "11"}))
+}
+
+func TestChannelzCollectorSocketLabelToggles(t *testing.T) {
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref:       &channelzpb.ChannelRef{ChannelId: 1},
+						Data:      &channelzpb.ChannelData{Target: "root"},
+						SocketRef: []*channelzpb.SocketRef{{SocketId: 10}},
+					},
+				},
+				End: true,
+			},
+		},
+		sockets: map[int64]*channelzpb.Socket{
+			10: {
+				Ref:    &channelzpb.SocketRef{SocketId: 10},
+				Local:  tcpAddress(net.ParseIP("127.0.0.1"), 1000),
+				Remote: tcpAddress(net.ParseIP("127.0.0.2"), 2000),
+				Data:   &channelzpb.SocketData{StreamsStarted: 1},
+			},
+		},
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{
+		DisableLocalLabel:  true,
+		DisableRemoteLabel: true,
+	})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+	mf := families["grpc_channelz_socket_streams_total"]
+	require.NotNil(t, mf)
+	requireMetricValue(t, mf, map[string]string{"id": "10", "type": "started"}, 1)
+	require.Equal(t, []string{"id", "type"}, labelNames(mf.GetMetric()[0]))
+}
+
+func TestChannelzCollectorSkipsZeroStreamTimestamp(t *testing.T) {
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref:       &channelzpb.ChannelRef{ChannelId: 1},
+						Data:      &channelzpb.ChannelData{Target: "root"},
+						SocketRef: []*channelzpb.SocketRef{{SocketId: 10}},
+					},
+				},
+				End: true,
+			},
+		},
+		sockets: map[int64]*channelzpb.Socket{
+			10: {
+				Ref: &channelzpb.SocketRef{SocketId: 10},
+				Data: &channelzpb.SocketData{
+					StreamsStarted:                   1,
+					LastLocalStreamCreatedTimestamp:  &timestamppb.Timestamp{},
+					LastRemoteStreamCreatedTimestamp: timestamppb.New(time.Unix(1_700_000_000, 0)),
+				},
+			},
+		},
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+
+	require.Equal(t, 0, countMetrics(t, families["grpc_channelz_socket_last_stream_created_timestamp_seconds"], map[string]string{
+		"id":   "10",
+		"side": "local",
+	}))
+	require.Equal(t, 1, countMetrics(t, families["grpc_channelz_socket_last_stream_created_timestamp_seconds"], map[string]string{
+		"id":   "10",
+		"side": "remote",
+	}))
+}
+
+func TestChannelzCollectorFetchErrors(t *testing.T) {
+	server := &fakeChannelzServer{
+		topChannels: map[int64]*channelzpb.GetTopChannelsResponse{
+			0: {
+				Channel: []*channelzpb.Channel{
+					{
+						Ref:           &channelzpb.ChannelRef{ChannelId: 1},
+						Data:          &channelzpb.ChannelData{Target: "root", CallsStarted: 1},
+						ChannelRef:    []*channelzpb.ChannelRef{{ChannelId: 2}},
+						SubchannelRef: []*channelzpb.SubchannelRef{{SubchannelId: 3}},
+						SocketRef:     []*channelzpb.SocketRef{{SocketId: 10}},
+					},
+				},
+				End: true,
+			},
+		},
+		channelErrors:    map[int64]error{2: status.Error(codes.Unavailable, "channel unavailable")},
+		subchannelErrors: map[int64]error{3: status.Error(codes.Unavailable, "subchannel unavailable")},
+		socketErrors:     map[int64]error{10: status.Error(codes.Unavailable, "socket unavailable")},
+	}
+
+	collector, cleanup := newTestCollector(t, server, ChannelzCollectorOpts{})
+	defer cleanup()
+
+	families := gatherMetricFamilies(t, collector)
+
+	requireMetricValue(t, families["grpc_channelz_channel_calls_total"], map[string]string{
+		"kind":   "channel",
+		"id":     "1",
+		"target": "root",
+		"type":   "started",
+	}, 1)
+	requireMetricValue(t, families["grpc_channelz_fetch_errors_total"], map[string]string{"rpc": "GetTopChannels"}, 0)
+	requireMetricValue(t, families["grpc_channelz_fetch_errors_total"], map[string]string{"rpc": "GetChannel"}, 1)
+	requireMetricValue(t, families["grpc_channelz_fetch_errors_total"], map[string]string{"rpc": "GetSubchannel"}, 1)
+	requireMetricValue(t, families["grpc_channelz_fetch_errors_total"], map[string]string{"rpc": "GetSocket"}, 1)
+}
+
+type fakeChannelzServer struct {
+	channelzpb.UnimplementedChannelzServer
+
+	topChannels      map[int64]*channelzpb.GetTopChannelsResponse
+	topChannelErrors map[int64]error
+	channels         map[int64]*channelzpb.Channel
+	channelErrors    map[int64]error
+	subchannels      map[int64]*channelzpb.Subchannel
+	subchannelErrors map[int64]error
+	sockets          map[int64]*channelzpb.Socket
+	socketErrors     map[int64]error
+}
+
+func (s *fakeChannelzServer) GetTopChannels(_ context.Context, req *channelzpb.GetTopChannelsRequest) (*channelzpb.GetTopChannelsResponse, error) {
+	if err := s.topChannelErrors[req.GetStartChannelId()]; err != nil {
+		return nil, err
+	}
+	if resp := s.topChannels[req.GetStartChannelId()]; resp != nil {
+		return resp, nil
+	}
+	return &channelzpb.GetTopChannelsResponse{End: true}, nil
+}
+
+func (s *fakeChannelzServer) GetChannel(_ context.Context, req *channelzpb.GetChannelRequest) (*channelzpb.GetChannelResponse, error) {
+	if err := s.channelErrors[req.GetChannelId()]; err != nil {
+		return nil, err
+	}
+	if channel := s.channels[req.GetChannelId()]; channel != nil {
+		return &channelzpb.GetChannelResponse{Channel: channel}, nil
+	}
+	return nil, status.Error(codes.NotFound, "channel not found")
+}
+
+func (s *fakeChannelzServer) GetSubchannel(_ context.Context, req *channelzpb.GetSubchannelRequest) (*channelzpb.GetSubchannelResponse, error) {
+	if err := s.subchannelErrors[req.GetSubchannelId()]; err != nil {
+		return nil, err
+	}
+	if subchannel := s.subchannels[req.GetSubchannelId()]; subchannel != nil {
+		return &channelzpb.GetSubchannelResponse{Subchannel: subchannel}, nil
+	}
+	return nil, status.Error(codes.NotFound, "subchannel not found")
+}
+
+func (s *fakeChannelzServer) GetSocket(_ context.Context, req *channelzpb.GetSocketRequest) (*channelzpb.GetSocketResponse, error) {
+	if err := s.socketErrors[req.GetSocketId()]; err != nil {
+		return nil, err
+	}
+	if socket := s.sockets[req.GetSocketId()]; socket != nil {
+		return &channelzpb.GetSocketResponse{Socket: socket}, nil
+	}
+	return nil, status.Error(codes.NotFound, "socket not found")
+}
+
+func newTestCollector(t *testing.T, server *fakeChannelzServer, opts ChannelzCollectorOpts) (prometheus.Collector, func()) {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	channelzpb.RegisterChannelzServer(grpcServer, server)
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(
+		ctx,
+		"bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	collector := NewChannelzCollector(conn, opts)
+	return collector, func() {
+		require.NoError(t, conn.Close())
+		grpcServer.Stop()
+		require.NoError(t, listener.Close())
+	}
+}
+
+func gatherMetricFamilies(t *testing.T, collector prometheus.Collector) map[string]*dto.MetricFamily {
+	t.Helper()
+
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(collector))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	result := make(map[string]*dto.MetricFamily, len(families))
+	for _, family := range families {
+		result[family.GetName()] = family
+	}
+	return result
+}
+
+func requireMetricValue(t *testing.T, family *dto.MetricFamily, labels map[string]string, want float64) {
+	t.Helper()
+
+	metric := findMetric(t, family, labels)
+	require.InDelta(t, want, metricValue(t, family, metric), 0.000001)
+}
+
+func countMetrics(t *testing.T, family *dto.MetricFamily, labels map[string]string) int {
+	t.Helper()
+
+	if family == nil {
+		return 0
+	}
+	count := 0
+	for _, metric := range family.GetMetric() {
+		if labelsMatch(metric, labels) {
+			count++
+		}
+	}
+	return count
+}
+
+func findMetric(t *testing.T, family *dto.MetricFamily, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	require.NotNil(t, family)
+	for _, metric := range family.GetMetric() {
+		if labelsMatch(metric, labels) {
+			return metric
+		}
+	}
+	require.FailNow(t, "metric not found", "family=%s labels=%v", family.GetName(), labels)
+	return nil
+}
+
+func metricValue(t *testing.T, family *dto.MetricFamily, metric *dto.Metric) float64 {
+	t.Helper()
+
+	switch family.GetType() {
+	case dto.MetricType_COUNTER:
+		return metric.GetCounter().GetValue()
+	case dto.MetricType_GAUGE:
+		return metric.GetGauge().GetValue()
+	default:
+		require.FailNow(t, "unsupported metric family type", "family=%s type=%s", family.GetName(), family.GetType().String())
+		return 0
+	}
+}
+
+func labelsMatch(metric *dto.Metric, want map[string]string) bool {
+	for key, value := range want {
+		if labelValue(metric, key) != value {
+			return false
+		}
+	}
+	return true
+}
+
+func labelValue(metric *dto.Metric, key string) string {
+	for _, label := range metric.GetLabel() {
+		if label.GetName() == key {
+			return label.GetValue()
+		}
+	}
+	return ""
+}
+
+func labelNames(metric *dto.Metric) []string {
+	names := make([]string, 0, len(metric.GetLabel()))
+	for _, label := range metric.GetLabel() {
+		names = append(names, label.GetName())
+	}
+	sort.Strings(names)
+	return names
+}
+
+func withLabels(labels map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		out[k] = v
+	}
+	out[key] = value
+	return out
+}
+
+func tcpAddress(ip net.IP, port int32) *channelzpb.Address {
+	return &channelzpb.Address{
+		Address: &channelzpb.Address_TcpipAddress{
+			TcpipAddress: &channelzpb.Address_TcpIpAddress{
+				IpAddress: ip,
+				Port:      port,
+			},
+		},
+	}
+}
+
+func udsAddress(path string) *channelzpb.Address {
+	return &channelzpb.Address{
+		Address: &channelzpb.Address_UdsAddress_{
+			UdsAddress: &channelzpb.Address_UdsAddress{Filename: path},
+		},
+	}
+}
+
+func otherAddress(name string) *channelzpb.Address {
+	return &channelzpb.Address{
+		Address: &channelzpb.Address_OtherAddress_{
+			OtherAddress: &channelzpb.Address_OtherAddress{Name: name},
+		},
+	}
+}


### PR DESCRIPTION
The collector walks client-side channelz objects (Channel, Subchannel, Socket) via the gRPC channelz API and exports raw channel/socket metrics with configurable namespace, optional filtering, and optional local/remote socket labels. Channel state and trace metrics are opt-in via IncludeChannelState and IncludeChannelTrace, while collector self-metrics are limited to fetch error counters.

<img width="1238" height="592" alt="2026-04-02_174243" src="https://github.com/user-attachments/assets/80f8fd0f-e608-4803-a408-6bed57dcb25e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus collector that exports detailed gRPC Channelz metrics: channel/subchannel/socket activity, call counts and timestamps, optional connectivity-state and trace metrics, keepalive and flow-control data, address normalization, and configurable filtering/labeling.

* **Tests**
  * Added end-to-end tests validating metric emission, label sets, filtering/traversal behavior, timestamp handling, and fetch-error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->