### PR TITLE
txnkv: reduce mem / goroutine costs for resolve lock tasks

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -46,15 +46,26 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/kvproto/pkg/errorpb"
-	"github.com/pingcap/log"
 	"github.com/pkg/errors"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/kv"
 	"github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
+
+// MaxRecordBackoffErrCount is the maximum number of backoff errors to be recorded in the log.
+const MaxRecordBackoffErrCount = 3
+
+type backoffErr struct {
+	Reason string
+	Time   time.Time
+}
+
+// Error implements the error interface for backoffErr.
+func (e backoffErr) Error() string {
+	return fmt.Sprintf("%s at %s", e.Reason, e.Time.Format(time.RFC3339Nano))
+}
 
 // Backoffer is a utility for retrying queries.
 type Backoffer struct {
@@ -68,7 +79,14 @@ type Backoffer struct {
 	vars *kv.Variables
 	noop bool
 
-	errors         []error
+	// errors is a fixed-length array to record the backoff errors,
+	// and it records the last maximum MaxRecordBackoffErrCount errors.
+	// If errorsNum <= MaxRecordBackoffErrCount, only the errors[:errorsNum] are valid.
+	// Otherwise, if errorsNum > MaxRecordBackoffErrCount, errors can be regarded as a circular array,
+	// and errors[errorsNum % MaxRecordBackoffErrCount] is the first error located
+	errors    [MaxRecordBackoffErrCount]backoffErr
+	errorsNum int
+
 	configs        []*Config
 	backoffSleepMS map[string]int
 	backoffTimes   map[string]int
@@ -130,6 +148,26 @@ func (b *Backoffer) BackoffWithMaxSleepTxnLockFast(maxSleepMs int, err error) er
 	return b.BackoffWithCfgAndMaxSleep(cfg, maxSleepMs, err)
 }
 
+func (b *Backoffer) appendErr(err error) {
+	b.errors[b.errorsNum%MaxRecordBackoffErrCount] = backoffErr{
+		Reason: err.Error(),
+		Time:   time.Now(),
+	}
+	b.errorsNum++
+}
+
+func (b *Backoffer) latestErrors() []backoffErr {
+	if b.errorsNum <= len(b.errors) {
+		return b.errors[:b.errorsNum]
+	}
+	errs := make([]backoffErr, len(b.errors))
+	firstIndex := b.errorsNum % MaxRecordBackoffErrCount
+	for i := 0; i < len(b.errors); i++ {
+		errs[i] = b.errors[(firstIndex+i)%len(b.errors)]
+	}
+	return errs
+}
+
 // BackoffWithCfgAndMaxSleep sleeps a while base on the Config and records the error message
 // and never sleep more than maxSleepMs for each sleep.
 func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err error) error {
@@ -153,11 +191,8 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 	if b.maxSleep > 0 && maxTimeExceeded {
 		longestSleepCfg, longestSleepTime := b.longestSleepCfg()
 		errMsg := fmt.Sprintf("%s backoffer.maxSleep %dms is exceeded, errors:", cfg.String(), b.maxSleep)
-		for i, err := range b.errors {
-			// Print only last 3 errors for non-DEBUG log levels.
-			if log.GetLevel() == zapcore.DebugLevel || i >= len(b.errors)-3 {
-				errMsg += "\n" + err.Error()
-			}
+		for _, err := range b.latestErrors() {
+			errMsg += "\n" + err.Error()
 		}
 		var backoffDetail bytes.Buffer
 		totalTimes := 0
@@ -181,7 +216,7 @@ func (b *Backoffer) BackoffWithCfgAndMaxSleep(cfg *Config, maxSleepMs int, err e
 		// Use the backoff type that contributes most to the timeout to generate a MySQL error.
 		return errors.WithStack(returnedErr)
 	}
-	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
+	b.appendErr(err)
 	b.configs = append(b.configs, cfg)
 
 	// Lazy initialize.
@@ -264,7 +299,8 @@ func (b *Backoffer) Clone() *Backoffer {
 		totalSleep:     b.totalSleep,
 		excludedSleep:  b.excludedSleep,
 		vars:           b.vars,
-		errors:         append([]error{}, b.errors...),
+		errors:         b.errors,
+		errorsNum:      b.errorsNum,
 		configs:        append([]*Config{}, b.configs...),
 		backoffSleepMS: copyMapWithoutRecursive(b.backoffSleepMS),
 		backoffTimes:   copyMapWithoutRecursive(b.backoffTimes),
@@ -283,7 +319,8 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 		maxSleep:       b.maxSleep,
 		totalSleep:     b.totalSleep,
 		excludedSleep:  b.excludedSleep,
-		errors:         append([]error{}, b.errors...),
+		errors:         b.errors,
+		errorsNum:      b.errorsNum,
 		configs:        append([]*Config{}, b.configs...),
 		backoffSleepMS: copyMapWithoutRecursive(b.backoffSleepMS),
 		backoffTimes:   copyMapWithoutRecursive(b.backoffTimes),
@@ -303,6 +340,7 @@ func (b *Backoffer) UpdateUsingForked(forked *Backoffer) {
 			b.totalSleep = forked.totalSleep
 			b.excludedSleep = forked.excludedSleep
 			b.errors = forked.errors
+			b.errorsNum = forked.errorsNum
 			b.backoffSleepMS = forked.backoffSleepMS
 			b.backoffTimes = forked.backoffTimes
 			break
@@ -363,7 +401,7 @@ func (b *Backoffer) GetBackoffSleepMS() map[string]int {
 
 // ErrorsNum returns the number of errors.
 func (b *Backoffer) ErrorsNum() int {
-	return len(b.errors)
+	return b.errorsNum
 }
 
 // Reset resets the sleep state of the backoffer, so that following backoff

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -156,6 +156,10 @@ func (b *Backoffer) appendErr(err error) {
 	b.errorsNum++
 }
 
+// latestErrors is called when the backoff time exceeds the max sleep time,
+// and it returns the latest N (N <= MaxRecordBackoffErrCount) backoff errors for logging.
+// It should only be called when the backoff time exceeds the max sleep time to reduce the performance overhead,
+// because it may involve some array copy when the number of errors exceeds MaxRecordBackoffErrCount.
 func (b *Backoffer) latestErrors() []backoffErr {
 	if b.errorsNum <= len(b.errors) {
 		return b.errors[:b.errorsNum]

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -37,11 +37,15 @@ package retry
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/assert"
+	tikverr "github.com/tikv/client-go/v2/error"
 )
 
 func TestBackoffWithMax(t *testing.T) {
@@ -85,6 +89,15 @@ func TestBackoffErrorType(t *testing.T) {
 	assert.Fail(t, "should not be here")
 }
 
+func assertCloneOrForkEqual(t *testing.T, b1, b2 *Backoffer) {
+	assert.Equal(t, b1.errors, b2.errors)
+	assert.Equal(t, b1.errorsNum, b2.errorsNum)
+	assert.Equal(t, b1.backoffSleepMS, b2.backoffSleepMS)
+	assert.Equal(t, b1.backoffTimes, b2.backoffTimes)
+	assert.Equal(t, b1.excludedSleep, b2.excludedSleep)
+	assert.Equal(t, b1.totalSleep, b2.totalSleep)
+}
+
 func TestBackoffDeepCopy(t *testing.T) {
 	var err error
 	b := NewBackofferWithVars(context.TODO(), 4, nil)
@@ -95,7 +108,9 @@ func TestBackoffDeepCopy(t *testing.T) {
 	}
 	bForked, cancel := b.Fork()
 	defer cancel()
+	assertCloneOrForkEqual(t, b, bForked)
 	bCloned := b.Clone()
+	assertCloneOrForkEqual(t, b, bCloned)
 	for _, b := range []*Backoffer{bForked, bCloned} {
 		err = b.Backoff(BoTiKVRPC, errors.New("tikv rpc"))
 		assert.ErrorIs(t, err, BoMaxRegionNotInitialized.err)
@@ -115,11 +130,7 @@ func TestBackoffUpdateUsingFork(t *testing.T) {
 	bForked.Backoff(BoTiKVRPC, errors.New("tikv rpc"))
 	bCloneForked := bForked.Clone()
 	b.UpdateUsingForked(bForked)
-	assert.Equal(t, b.errors, bCloneForked.errors)
-	assert.Equal(t, b.backoffSleepMS, bCloneForked.backoffSleepMS)
-	assert.Equal(t, b.backoffTimes, bCloneForked.backoffTimes)
-	assert.Equal(t, b.excludedSleep, bCloneForked.excludedSleep)
-	assert.Equal(t, b.totalSleep, bCloneForked.totalSleep)
+	assertCloneOrForkEqual(t, b, bCloneForked)
 	assert.Nil(t, b.parent)
 }
 
@@ -179,4 +190,60 @@ func TestMayBackoffForRegionError(t *testing.T) {
 		err = MayBackoffForRegionError(regionErr, b)
 		assert.EqualError(t, err, regionErr.String())
 	}
+}
+
+func TestBackoffErrorsKeep(t *testing.T) {
+	b := NewBackofferWithVars(context.TODO(), 1000000, nil)
+	assert.Zero(t, b.ErrorsNum())
+	assert.Empty(t, b.latestErrors())
+	cfg := NewConfig("foo", nil, NewBackoffFnCfg(1, 2, EqualJitter), tikverr.ErrTiKVServerTimeout)
+	errs := make([]error, 0, 32)
+	for i := 0; i < cap(errs); i++ {
+		cnt := i + 1
+		msg := fmt.Sprintf("currnet mock error count: %d", cnt)
+		errs = append(errs, fmt.Errorf("mockErr-%d", i))
+		assert.NoError(t, b.Backoff(cfg, errs[i]), msg)
+
+		// b.ErrorsNum() should return the real number of errors.
+		assert.Equal(t, len(errs), b.ErrorsNum(), msg)
+
+		// b.latestErrors() should return at most MaxRecordBackoffErrCount errors.
+		if cnt <= MaxRecordBackoffErrCount {
+			// If cnt <= MaxRecordBackoffErrCount, return cnt errors.
+			assert.Len(t, b.latestErrors(), cnt, msg)
+		} else {
+			// If cnt > MaxRecordBackoffErrCount, return MaxRecordBackoffErrCount errors.
+			assert.Len(t, b.latestErrors(), MaxRecordBackoffErrCount, msg)
+		}
+
+		// The returned errors should be the last MaxRecordBackoffErrCount errors.
+		realErrs := b.latestErrors()
+		expectedErrs := make([]backoffErr, 0, len(realErrs))
+		for j := max(0, cnt-MaxRecordBackoffErrCount); j < len(errs); j++ {
+			realErrIdx := len(expectedErrs)
+			expectedErrs = append(expectedErrs, backoffErr{
+				Reason: errs[j].Error(),
+				Time:   realErrs[realErrIdx].Time,
+			})
+		}
+		assert.Equal(t, expectedErrs, realErrs, msg)
+
+		// The time in returned errors should be in ascending order.
+		sort.Slice(expectedErrs, func(i, j int) bool {
+			return expectedErrs[i].Time.Before(expectedErrs[j].Time)
+		})
+		assert.Equal(t, expectedErrs, realErrs)
+
+		// The time in returned errors should near the now time
+		assert.InDelta(t, time.Now().Unix(), realErrs[0].Time.Unix(), 5)
+		assert.InDelta(t, time.Now().Unix(), realErrs[len(realErrs)-1].Time.Unix(), 5)
+	}
+}
+
+func TestBackoffError(t *testing.T) {
+	err := backoffErr{
+		Reason: "mockErr",
+		Time:   time.Unix(3600*4+1234, 0).In(time.FixedZone("xx", 3*3600)),
+	}
+	assert.Equal(t, "mockErr at 1970-01-01T07:20:34+03:00", err.Error())
 }

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -841,12 +841,32 @@ type RPCContext struct {
 }
 
 func (c *RPCContext) String() string {
+	if c == nil {
+		return "<nil>"
+	}
 	var runStoreType string
 	if c.Store != nil {
 		runStoreType = c.Store.StoreType().Name()
 	}
 	res := fmt.Sprintf("region ID: %d, meta: %s, peer: %s, addr: %s, idx: %d, reqStoreType: %s, runStoreType: %s",
 		c.Region.GetID(), c.Meta, c.Peer, c.Addr, c.AccessIdx, c.AccessMode, runStoreType)
+	if c.ProxyStore != nil {
+		res += fmt.Sprintf(", proxy store id: %d, proxy addr: %s", c.ProxyStore.storeID, c.ProxyStore.GetAddr())
+	}
+	return res
+}
+
+// BackoffInfoString returns the string used for backoff error logs
+func (c *RPCContext) BackoffInfoString() string {
+	if c == nil {
+		return "<nil>"
+	}
+	var runStoreType string
+	if c.Store != nil {
+		runStoreType = c.Store.StoreType().Name()
+	}
+	res := fmt.Sprintf("region: %s, peerID: %d, storeID: %d, addr: %s, idx: %d, reqStoreType: %s, runStoreType: %s",
+		c.Region.String(), c.Peer.GetId(), c.Peer.GetStoreId(), c.Addr, c.AccessIdx, c.AccessMode, runStoreType)
 	if c.ProxyStore != nil {
 		res += fmt.Sprintf(", proxy store id: %d, proxy addr: %s", c.ProxyStore.storeID, c.ProxyStore.GetAddr())
 	}

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -856,8 +856,8 @@ func (c *RPCContext) String() string {
 	return res
 }
 
-// BackoffInfoString returns the string used for backoff error logs
-func (c *RPCContext) BackoffInfoString() string {
+// ToBackoffReasonString returns the reason string used for backoff error logs
+func (c *RPCContext) ToBackoffReasonString() string {
 	if c == nil {
 		return "<nil>"
 	}

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -2426,11 +2426,11 @@ func failpointSendReqResult(req *tikvrpc.Request, et tikvrpc.EndpointType) (
 func newBackoffErrWithRPCContext(reason string, ctx *RPCContext) error {
 	// use go errors instead of errors to avoid stack trace for this error,
 	// which is not used by backoff logic.
-	return fmt.Errorf("%s, ctx: %s", reason, ctx.BackoffInfoString())
+	return fmt.Errorf("%s, ctx: %s", reason, ctx.ToBackoffReasonString())
 }
 
 func newBackoffErrWithRPCContextAndAdvice(reason string, ctx *RPCContext, advice string) error {
 	// use go errors instead of errors to avoid stack trace for this error,
 	// which is not used by backoff logic.
-	return fmt.Errorf("%s, ctx: %s, %s", reason, ctx.BackoffInfoString(), advice)
+	return fmt.Errorf("%s, ctx: %s, %s", reason, ctx.ToBackoffReasonString(), advice)
 }

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1794,12 +1794,12 @@ func (s *RegionRequestSender) onSendFail(bo *retry.Backoffer, ctx *RPCContext, r
 	if ctx.Store != nil && ctx.Store.StoreType().IsTiFlashRelatedType() {
 		err = bo.Backoff(
 			retry.BoTiFlashRPC,
-			errors.Errorf("send tiflash request error: %v, ctx: %v, try next peer later", err, ctx),
+			newBackoffErrWithRPCContextAndAdvice(fmt.Sprintf("send tiflash request error: %v", err), ctx, "try next peer later"),
 		)
 	} else {
 		err = bo.Backoff(
 			retry.BoTiKVRPC,
-			errors.Errorf("send tikv request error: %v, ctx: %v, try next peer later", err, ctx),
+			newBackoffErrWithRPCContextAndAdvice(fmt.Sprintf("send tikv request error: %v", err), ctx, "try next peer later"),
 		)
 	}
 	return err
@@ -1955,7 +1955,7 @@ func (s *RegionRequestSender) onRegionError(
 			s.regionCache.InvalidateCachedRegionWithReason(ctx.Region, NoLeader)
 			if err = bo.Backoff(
 				retry.BoRegionScheduling,
-				errors.Errorf("not leader: %v, ctx: %v", notLeader, ctx),
+				newBackoffErrWithRPCContext(fmt.Sprintf("not leader: %v", notLeader), ctx),
 			); err != nil {
 				return false, err
 			}
@@ -1971,7 +1971,7 @@ func (s *RegionRequestSender) onRegionError(
 	if diskFull := regionErr.GetDiskFull(); diskFull != nil {
 		if err = bo.Backoff(
 			retry.BoTiKVDiskFull,
-			errors.Errorf("tikv disk full: %v ctx: %v", diskFull.String(), ctx.String()),
+			newBackoffErrWithRPCContext(fmt.Sprintf("tikv disk full: %v", diskFull.String()), ctx),
 		); err != nil {
 			return false, nil
 		}
@@ -1981,7 +1981,7 @@ func (s *RegionRequestSender) onRegionError(
 	if regionErr.GetRecoveryInProgress() != nil {
 		s.regionCache.InvalidateCachedRegion(ctx.Region)
 		logutil.Logger(bo.GetCtx()).Debug("tikv reports `RecoveryInProgress`", zap.Stringer("ctx", ctx))
-		err = bo.Backoff(retry.BoRegionRecoveryInProgress, errors.Errorf("region recovery in progress, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoRegionRecoveryInProgress, newBackoffErrWithRPCContext("region recovery in progress", ctx))
 		if err != nil {
 			return false, err
 		}
@@ -1991,7 +1991,7 @@ func (s *RegionRequestSender) onRegionError(
 	if regionErr.GetIsWitness() != nil {
 		s.regionCache.InvalidateCachedRegion(ctx.Region)
 		logutil.Logger(bo.GetCtx()).Debug("tikv reports `IsWitness`", zap.Stringer("ctx", ctx))
-		err = bo.Backoff(retry.BoIsWitness, errors.Errorf("is witness, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoIsWitness, newBackoffErrWithRPCContext("is witness", ctx))
 		if err != nil {
 			return false, err
 		}
@@ -2087,9 +2087,9 @@ func (s *RegionRequestSender) onRegionError(
 			zap.Stringer("ctx", ctx),
 		)
 		if ctx != nil && ctx.Store != nil && ctx.Store.StoreType().IsTiFlashRelatedType() {
-			err = bo.Backoff(retry.BoTiFlashServerBusy, errors.Errorf("server is busy, ctx: %v", ctx))
+			err = bo.Backoff(retry.BoTiFlashServerBusy, newBackoffErrWithRPCContext("server is busy", ctx))
 		} else {
-			err = bo.Backoff(retry.BoTiKVServerBusy, errors.Errorf("server is busy, ctx: %v", ctx))
+			err = bo.Backoff(retry.BoTiKVServerBusy, newBackoffErrWithRPCContext("server is busy", ctx))
 		}
 		if err != nil {
 			return false, err
@@ -2106,7 +2106,7 @@ func (s *RegionRequestSender) onRegionError(
 			// Needn't backoff because the new leader should be elected soon
 			// and the replicaSelector will try the next peer.
 		} else {
-			err = bo.Backoff(retry.BoStaleCmd, errors.Errorf("stale command, ctx: %v", ctx))
+			err = bo.Backoff(retry.BoStaleCmd, newBackoffErrWithRPCContext("stale command", ctx))
 			if err != nil {
 				return false, err
 			}
@@ -2136,7 +2136,7 @@ func (s *RegionRequestSender) onRegionError(
 
 	if regionErr.GetMaxTimestampNotSynced() != nil {
 		logutil.Logger(bo.GetCtx()).Debug("tikv reports `MaxTimestampNotSynced`", zap.Stringer("ctx", ctx))
-		err = bo.Backoff(retry.BoMaxTsNotSynced, errors.Errorf("max timestamp not synced, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoMaxTsNotSynced, newBackoffErrWithRPCContext("max timestamp not synced", ctx))
 		if err != nil {
 			return false, err
 		}
@@ -2167,7 +2167,7 @@ func (s *RegionRequestSender) onRegionError(
 			zap.Stringer("ctx", ctx),
 		)
 		// The region can't provide service until split or merge finished, so backoff.
-		err = bo.Backoff(retry.BoRegionScheduling, errors.Errorf("read index not ready, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoRegionScheduling, newBackoffErrWithRPCContext("read index not ready", ctx))
 		if err != nil {
 			return false, err
 		}
@@ -2177,7 +2177,7 @@ func (s *RegionRequestSender) onRegionError(
 	if regionErr.GetProposalInMergingMode() != nil {
 		logutil.Logger(bo.GetCtx()).Debug("tikv reports `ProposalInMergingMode`", zap.Stringer("ctx", ctx))
 		// The region is merging and it can't provide service until merge finished, so backoff.
-		err = bo.Backoff(retry.BoRegionScheduling, errors.Errorf("region is merging, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoRegionScheduling, newBackoffErrWithRPCContext("region is merging", ctx))
 		if err != nil {
 			return false, err
 		}
@@ -2421,4 +2421,16 @@ func failpointSendReqResult(req *tikvrpc.Request, et tikvrpc.EndpointType) (
 		}
 	}
 	return
+}
+
+func newBackoffErrWithRPCContext(reason string, ctx *RPCContext) error {
+	// use go errors instead of errors to avoid stack trace for this error,
+	// which is not used by backoff logic.
+	return fmt.Errorf("%s, ctx: %s", reason, ctx.BackoffInfoString())
+}
+
+func newBackoffErrWithRPCContextAndAdvice(reason string, ctx *RPCContext, advice string) error {
+	// use go errors instead of errors to avoid stack trace for this error,
+	// which is not used by backoff logic.
+	return fmt.Errorf("%s, ctx: %s, %s", reason, ctx.BackoffInfoString(), advice)
 }

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -1194,7 +1194,7 @@ func TestGetErrMsg(t *testing.T) {
 func TestRPCContextString(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		var ctx *RPCContext
-		require.Equal(t, "<nil>", ctx.BackoffInfoString())
+		require.Equal(t, "<nil>", ctx.ToBackoffReasonString())
 		require.Equal(t, "<nil>", ctx.String())
 	})
 
@@ -1230,7 +1230,7 @@ func TestRPCContextString(t *testing.T) {
 				"region: %s, peerID: %d, storeID: %d, addr: %s, idx: %d, reqStoreType: %s, runStoreType: %s",
 				region.String(), peer.Id, peer.StoreId, "tikv-1", AccessIndex(4), tiKVOnly, tikvrpc.TiKV.Name(),
 			),
-			ctx.BackoffInfoString(),
+			ctx.ToBackoffReasonString(),
 		)
 	})
 
@@ -1246,7 +1246,7 @@ func TestRPCContextString(t *testing.T) {
 		}
 
 		require.Contains(t, ctx.String(), ", proxy store id: 2, proxy addr: tikv-2")
-		require.Contains(t, ctx.BackoffInfoString(), ", proxy store id: 2, proxy addr: tikv-2")
+		require.Contains(t, ctx.ToBackoffReasonString(), ", proxy store id: 2, proxy addr: tikv-2")
 	})
 }
 
@@ -1259,8 +1259,8 @@ func TestBackoffErrWithRPCContext(t *testing.T) {
 	}
 
 	err := newBackoffErrWithRPCContext("reason1", ctx)
-	require.Equal(t, "reason1, ctx: "+ctx.BackoffInfoString(), err.Error())
+	require.Equal(t, "reason1, ctx: "+ctx.ToBackoffReasonString(), err.Error())
 
 	err = newBackoffErrWithRPCContextAndAdvice("reason1", ctx, "advice1")
-	require.Equal(t, "reason1, ctx: "+ctx.BackoffInfoString()+", advice1", err.Error())
+	require.Equal(t, "reason1, ctx: "+ctx.ToBackoffReasonString()+", advice1", err.Error())
 }

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -1190,3 +1190,77 @@ func TestGetErrMsg(t *testing.T) {
 	}, "should panic")
 	require.Equal(t, "no cause err", getErrMsg(err))
 }
+
+func TestRPCContextString(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var ctx *RPCContext
+		require.Equal(t, "<nil>", ctx.BackoffInfoString())
+		require.Equal(t, "<nil>", ctx.String())
+	})
+
+	t.Run("without proxy", func(t *testing.T) {
+		region := RegionVerID{id: 100, confVer: 2, ver: 3}
+		meta := &metapb.Region{
+			Id:          region.id,
+			RegionEpoch: &metapb.RegionEpoch{ConfVer: region.confVer, Version: region.ver},
+		}
+		peer := &metapb.Peer{Id: 101, StoreId: 1}
+		store := newStore(1, "tikv-1", "", "", tikvrpc.TiKV, resolved, nil)
+		ctx := &RPCContext{
+			Region:     region,
+			Meta:       meta,
+			Peer:       peer,
+			AccessIdx:  4,
+			Store:      store,
+			Addr:       "tikv-1",
+			AccessMode: tiKVOnly,
+		}
+
+		require.Equal(
+			t,
+			fmt.Sprintf(
+				"region ID: %d, meta: %s, peer: %s, addr: %s, idx: %d, reqStoreType: %s, runStoreType: %s",
+				region.GetID(), meta, peer, "tikv-1", AccessIndex(4), tiKVOnly, tikvrpc.TiKV.Name(),
+			),
+			ctx.String(),
+		)
+		require.Equal(
+			t,
+			fmt.Sprintf(
+				"region: %s, peerID: %d, storeID: %d, addr: %s, idx: %d, reqStoreType: %s, runStoreType: %s",
+				region.String(), peer.Id, peer.StoreId, "tikv-1", AccessIndex(4), tiKVOnly, tikvrpc.TiKV.Name(),
+			),
+			ctx.BackoffInfoString(),
+		)
+	})
+
+	t.Run("with proxy", func(t *testing.T) {
+		store := newStore(1, "tikv-1", "", "", tikvrpc.TiKV, resolved, nil)
+		proxyStore := newStore(2, "tikv-2", "", "", tikvrpc.TiKV, resolved, nil)
+		ctx := &RPCContext{
+			Region:     RegionVerID{id: 200, confVer: 5, ver: 8},
+			Store:      store,
+			Addr:       "tikv-1",
+			AccessMode: tiKVOnly,
+			ProxyStore: proxyStore,
+		}
+
+		require.Contains(t, ctx.String(), ", proxy store id: 2, proxy addr: tikv-2")
+		require.Contains(t, ctx.BackoffInfoString(), ", proxy store id: 2, proxy addr: tikv-2")
+	})
+}
+
+func TestBackoffErrWithRPCContext(t *testing.T) {
+	ctx := &RPCContext{
+		Region:     RegionVerID{id: 200, confVer: 5, ver: 8},
+		Peer:       &metapb.Peer{Id: 101, StoreId: 1},
+		Addr:       "tikv-1",
+		AccessMode: tiKVOnly,
+	}
+
+	err := newBackoffErrWithRPCContext("reason1", ctx)
+	require.Equal(t, "reason1, ctx: "+ctx.BackoffInfoString(), err.Error())
+
+	err = newBackoffErrWithRPCContextAndAdvice("reason1", ctx, "advice1")
+	require.Equal(t, "reason1, ctx: "+ctx.BackoffInfoString()+", advice1", err.Error())
+}

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -494,7 +494,7 @@ func (s *replicaSelector) onNotLeader(
 	leader := notLeader.GetLeader()
 	if leader == nil {
 		// The region may be during transferring leader.
-		err = bo.Backoff(retry.BoRegionScheduling, errors.Errorf("no leader, ctx: %v", ctx))
+		err = bo.Backoff(retry.BoRegionScheduling, newBackoffErrWithRPCContext("no leader", ctx))
 		return err == nil, err
 	}
 	leaderIdx := s.updateLeader(leader)
@@ -568,7 +568,7 @@ func (s *replicaSelector) onServerIsBusy(
 			ctx.Store.healthStatus.markAlreadySlow()
 		}
 	}
-	backoffErr := errors.Errorf("server is busy, ctx: %v", ctx)
+	backoffErr := newBackoffErrWithRPCContext("server is busy", ctx)
 	if s.canFastRetry() {
 		s.addPendingBackoff(store, retry.BoTiKVServerBusy, backoffErr)
 		if s.target != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -50,6 +50,8 @@ var (
 	TiKVSendReqBySourceSummary                     *prometheus.SummaryVec
 	TiKVRPCNetLatencyHistogram                     *prometheus.HistogramVec
 	TiKVLockResolverCounter                        *prometheus.CounterVec
+	TiKVLockResolverAsyncRunningTasks              *prometheus.GaugeVec
+	TiKVLockResolverAsyncFallbackCounter           *prometheus.CounterVec
 	TiKVRegionErrorCounter                         *prometheus.CounterVec
 	TiKVRPCErrorCounter                            *prometheus.CounterVec
 	TiKVTxnWriteKVCountHistogram                   *prometheus.HistogramVec
@@ -230,6 +232,24 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Subsystem:   subsystem,
 			Name:        "lock_resolver_actions_total",
 			Help:        "Counter of lock resolver actions.",
+			ConstLabels: constLabels,
+		}, []string{LblType})
+
+	TiKVLockResolverAsyncRunningTasks = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "lock_resolver_async_running_tasks",
+			Help:        "The number of running async resolve lock tasks in lock resolver.",
+			ConstLabels: constLabels,
+		}, []string{LblType})
+
+	TiKVLockResolverAsyncFallbackCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "lock_resolver_async_fallback_total",
+			Help:        "The total count of fallback from async resolve lock in lock resolver.",
 			ConstLabels: constLabels,
 		}, []string{LblType})
 
@@ -1006,6 +1026,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVSendReqBySourceSummary)
 	prometheus.MustRegister(TiKVRPCNetLatencyHistogram)
 	prometheus.MustRegister(TiKVLockResolverCounter)
+	prometheus.MustRegister(TiKVLockResolverAsyncRunningTasks)
+	prometheus.MustRegister(TiKVLockResolverAsyncFallbackCounter)
 	prometheus.MustRegister(TiKVRegionErrorCounter)
 	prometheus.MustRegister(TiKVRPCErrorCounter)
 	prometheus.MustRegister(TiKVTxnWriteKVCountHistogram)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -51,7 +51,6 @@ var (
 	TiKVRPCNetLatencyHistogram                     *prometheus.HistogramVec
 	TiKVLockResolverCounter                        *prometheus.CounterVec
 	TiKVLockResolverAsyncRunningTasks              *prometheus.GaugeVec
-	TiKVLockResolverAsyncFallbackCounter           *prometheus.CounterVec
 	TiKVRegionErrorCounter                         *prometheus.CounterVec
 	TiKVRPCErrorCounter                            *prometheus.CounterVec
 	TiKVTxnWriteKVCountHistogram                   *prometheus.HistogramVec
@@ -241,15 +240,6 @@ func initMetrics(namespace, subsystem string, constLabels prometheus.Labels) {
 			Subsystem:   subsystem,
 			Name:        "lock_resolver_async_running_tasks",
 			Help:        "The number of running async resolve lock tasks in lock resolver.",
-			ConstLabels: constLabels,
-		}, []string{LblType})
-
-	TiKVLockResolverAsyncFallbackCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace:   namespace,
-			Subsystem:   subsystem,
-			Name:        "lock_resolver_async_fallback_total",
-			Help:        "The total count of fallback from async resolve lock in lock resolver.",
 			ConstLabels: constLabels,
 		}, []string{LblType})
 
@@ -1027,7 +1017,6 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVRPCNetLatencyHistogram)
 	prometheus.MustRegister(TiKVLockResolverCounter)
 	prometheus.MustRegister(TiKVLockResolverAsyncRunningTasks)
-	prometheus.MustRegister(TiKVLockResolverAsyncFallbackCounter)
 	prometheus.MustRegister(TiKVRegionErrorCounter)
 	prometheus.MustRegister(TiKVRPCErrorCounter)
 	prometheus.MustRegister(TiKVTxnWriteKVCountHistogram)

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -112,9 +112,11 @@ var (
 	LockResolverCountWithResolveLocks             prometheus.Counter
 	LockResolverCountWithResolveLockLite          prometheus.Counter
 
-	LockResolverAsyncRunningTasksForReadResolve prometheus.Gauge
+	LockResolverAsyncRunningTasksForReadResolve        prometheus.Gauge
+	LockResolverAsyncRunningTasksForResolveAsyncCommit prometheus.Gauge
 
-	LockResolverAsyncFallbackCounterForReadResolve prometheus.Counter
+	LockResolverAsyncFallbackCounterForReadResolve        prometheus.Counter
+	LockResolverAsyncFallbackCounterForResolveAsyncCommit prometheus.Counter
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK prometheus.Counter
 	RegionCacheCounterWithSendFail                    prometheus.Counter
@@ -280,8 +282,10 @@ func initShortcuts() {
 	LockResolverCountWithResolveLockLite = TiKVLockResolverCounter.WithLabelValues("query_resolve_lock_lite")
 
 	LockResolverAsyncRunningTasksForReadResolve = TiKVLockResolverAsyncRunningTasks.WithLabelValues("read_resolve")
+	LockResolverAsyncRunningTasksForResolveAsyncCommit = TiKVLockResolverAsyncRunningTasks.WithLabelValues("resolve_async_commit")
 
 	LockResolverAsyncFallbackCounterForReadResolve = TiKVLockResolverAsyncFallbackCounter.WithLabelValues("read_resolve")
+	LockResolverAsyncFallbackCounterForResolveAsyncCommit = TiKVLockResolverAsyncFallbackCounter.WithLabelValues("resolve_async_commit")
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK = TiKVRegionCacheCounter.WithLabelValues("invalidate_region_from_cache", "ok")
 	RegionCacheCounterWithSendFail = TiKVRegionCacheCounter.WithLabelValues("send_fail", "ok")

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -98,24 +98,28 @@ var (
 	TxnWriteSizeHistogramInternal    prometheus.Observer
 	TxnWriteSizeHistogramGeneral     prometheus.Observer
 
-	LockResolverCountWithBatchResolve                    prometheus.Counter
-	LockResolverCountWithExpired                         prometheus.Counter
-	LockResolverCountWithNotExpired                      prometheus.Counter
-	LockResolverCountWithWaitExpired                     prometheus.Counter
-	LockResolverCountWithResolve                         prometheus.Counter
-	LockResolverCountWithResolveForWrite                 prometheus.Counter
-	LockResolverCountWithResolveAsync                    prometheus.Counter
-	LockResolverCountWithQueryTxnStatus                  prometheus.Counter
-	LockResolverCountWithQueryTxnStatusCommitted         prometheus.Counter
-	LockResolverCountWithQueryTxnStatusRolledBack        prometheus.Counter
-	LockResolverCountWithQueryCheckSecondaryLocks        prometheus.Counter
-	LockResolverCountWithResolveLocks                    prometheus.Counter
-	LockResolverCountWithResolveLockLite                 prometheus.Counter
-	LockResolverCountWithAsyncResolveAsyncCommitFallback prometheus.Counter
-	LockResolverCountWithReadAsyncResolveFallback        prometheus.Counter
+	LockResolverCountWithBatchResolve                          prometheus.Counter
+	LockResolverCountWithExpired                               prometheus.Counter
+	LockResolverCountWithNotExpired                            prometheus.Counter
+	LockResolverCountWithWaitExpired                           prometheus.Counter
+	LockResolverCountWithResolve                               prometheus.Counter
+	LockResolverCountWithResolveForWrite                       prometheus.Counter
+	LockResolverCountWithResolveAsync                          prometheus.Counter
+	LockResolverCountWithQueryTxnStatus                        prometheus.Counter
+	LockResolverCountWithQueryTxnStatusCommitted               prometheus.Counter
+	LockResolverCountWithQueryTxnStatusRolledBack              prometheus.Counter
+	LockResolverCountWithQueryCheckSecondaryLocks              prometheus.Counter
+	LockResolverCountWithResolveLocks                          prometheus.Counter
+	LockResolverCountWithResolveLockLite                       prometheus.Counter
+	LockResolverCountWithAsyncResolveAsyncCommitFallback       prometheus.Counter
+	LockResolverCountWithReadAsyncResolveFallback              prometheus.Counter
+	LockResolverCountWithAsyncCheckSecondariesFallback         prometheus.Counter
+	LockResolverCountWithAsyncResolveAsyncCommitRegionFallback prometheus.Counter
 
-	LockResolverAsyncRunningTasksForReadResolve        prometheus.Gauge
-	LockResolverAsyncRunningTasksForResolveAsyncCommit prometheus.Gauge
+	LockResolverAsyncRunningTasksForReadResolve              prometheus.Gauge
+	LockResolverAsyncRunningTasksForResolveAsyncCommit       prometheus.Gauge
+	LockResolverAsyncRunningTasksForCheckSecondaries         prometheus.Gauge
+	LockResolverAsyncRunningTasksForResolveAsyncCommitRegion prometheus.Gauge
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK prometheus.Counter
 	RegionCacheCounterWithSendFail                    prometheus.Counter
@@ -281,9 +285,13 @@ func initShortcuts() {
 	LockResolverCountWithResolveLockLite = TiKVLockResolverCounter.WithLabelValues("query_resolve_lock_lite")
 	LockResolverCountWithAsyncResolveAsyncCommitFallback = TiKVLockResolverCounter.WithLabelValues("async_resolve_async_commit_fallback")
 	LockResolverCountWithReadAsyncResolveFallback = TiKVLockResolverCounter.WithLabelValues("read_async_resolve_fallback")
+	LockResolverCountWithAsyncCheckSecondariesFallback = TiKVLockResolverCounter.WithLabelValues("async_check_secondaries_fallback")
+	LockResolverCountWithAsyncResolveAsyncCommitRegionFallback = TiKVLockResolverCounter.WithLabelValues("async_resolve_async_commit_region_fallback")
 
 	LockResolverAsyncRunningTasksForReadResolve = TiKVLockResolverAsyncRunningTasks.WithLabelValues("read_resolve")
 	LockResolverAsyncRunningTasksForResolveAsyncCommit = TiKVLockResolverAsyncRunningTasks.WithLabelValues("resolve_async_commit")
+	LockResolverAsyncRunningTasksForCheckSecondaries = TiKVLockResolverAsyncRunningTasks.WithLabelValues("check_secondaries")
+	LockResolverAsyncRunningTasksForResolveAsyncCommitRegion = TiKVLockResolverAsyncRunningTasks.WithLabelValues("resolve_async_commit_region")
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK = TiKVRegionCacheCounter.WithLabelValues("invalidate_region_from_cache", "ok")
 	RegionCacheCounterWithSendFail = TiKVRegionCacheCounter.WithLabelValues("send_fail", "ok")

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -112,6 +112,10 @@ var (
 	LockResolverCountWithResolveLocks             prometheus.Counter
 	LockResolverCountWithResolveLockLite          prometheus.Counter
 
+	LockResolverAsyncRunningTasksForReadResolve prometheus.Gauge
+
+	LockResolverAsyncFallbackCounterForReadResolve prometheus.Counter
+
 	RegionCacheCounterWithInvalidateRegionFromCacheOK prometheus.Counter
 	RegionCacheCounterWithSendFail                    prometheus.Counter
 	RegionCacheCounterWithGetRegionByIDOK             prometheus.Counter
@@ -274,6 +278,10 @@ func initShortcuts() {
 	LockResolverCountWithQueryCheckSecondaryLocks = TiKVLockResolverCounter.WithLabelValues("query_check_secondary_locks")
 	LockResolverCountWithResolveLocks = TiKVLockResolverCounter.WithLabelValues("query_resolve_locks")
 	LockResolverCountWithResolveLockLite = TiKVLockResolverCounter.WithLabelValues("query_resolve_lock_lite")
+
+	LockResolverAsyncRunningTasksForReadResolve = TiKVLockResolverAsyncRunningTasks.WithLabelValues("read_resolve")
+
+	LockResolverAsyncFallbackCounterForReadResolve = TiKVLockResolverAsyncFallbackCounter.WithLabelValues("read_resolve")
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK = TiKVRegionCacheCounter.WithLabelValues("invalidate_region_from_cache", "ok")
 	RegionCacheCounterWithSendFail = TiKVRegionCacheCounter.WithLabelValues("send_fail", "ok")

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -98,25 +98,24 @@ var (
 	TxnWriteSizeHistogramInternal    prometheus.Observer
 	TxnWriteSizeHistogramGeneral     prometheus.Observer
 
-	LockResolverCountWithBatchResolve             prometheus.Counter
-	LockResolverCountWithExpired                  prometheus.Counter
-	LockResolverCountWithNotExpired               prometheus.Counter
-	LockResolverCountWithWaitExpired              prometheus.Counter
-	LockResolverCountWithResolve                  prometheus.Counter
-	LockResolverCountWithResolveForWrite          prometheus.Counter
-	LockResolverCountWithResolveAsync             prometheus.Counter
-	LockResolverCountWithQueryTxnStatus           prometheus.Counter
-	LockResolverCountWithQueryTxnStatusCommitted  prometheus.Counter
-	LockResolverCountWithQueryTxnStatusRolledBack prometheus.Counter
-	LockResolverCountWithQueryCheckSecondaryLocks prometheus.Counter
-	LockResolverCountWithResolveLocks             prometheus.Counter
-	LockResolverCountWithResolveLockLite          prometheus.Counter
+	LockResolverCountWithBatchResolve                    prometheus.Counter
+	LockResolverCountWithExpired                         prometheus.Counter
+	LockResolverCountWithNotExpired                      prometheus.Counter
+	LockResolverCountWithWaitExpired                     prometheus.Counter
+	LockResolverCountWithResolve                         prometheus.Counter
+	LockResolverCountWithResolveForWrite                 prometheus.Counter
+	LockResolverCountWithResolveAsync                    prometheus.Counter
+	LockResolverCountWithQueryTxnStatus                  prometheus.Counter
+	LockResolverCountWithQueryTxnStatusCommitted         prometheus.Counter
+	LockResolverCountWithQueryTxnStatusRolledBack        prometheus.Counter
+	LockResolverCountWithQueryCheckSecondaryLocks        prometheus.Counter
+	LockResolverCountWithResolveLocks                    prometheus.Counter
+	LockResolverCountWithResolveLockLite                 prometheus.Counter
+	LockResolverCountWithAsyncResolveAsyncCommitFallback prometheus.Counter
+	LockResolverCountWithReadAsyncResolveFallback        prometheus.Counter
 
 	LockResolverAsyncRunningTasksForReadResolve        prometheus.Gauge
 	LockResolverAsyncRunningTasksForResolveAsyncCommit prometheus.Gauge
-
-	LockResolverAsyncFallbackCounterForReadResolve        prometheus.Counter
-	LockResolverAsyncFallbackCounterForResolveAsyncCommit prometheus.Counter
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK prometheus.Counter
 	RegionCacheCounterWithSendFail                    prometheus.Counter
@@ -280,12 +279,11 @@ func initShortcuts() {
 	LockResolverCountWithQueryCheckSecondaryLocks = TiKVLockResolverCounter.WithLabelValues("query_check_secondary_locks")
 	LockResolverCountWithResolveLocks = TiKVLockResolverCounter.WithLabelValues("query_resolve_locks")
 	LockResolverCountWithResolveLockLite = TiKVLockResolverCounter.WithLabelValues("query_resolve_lock_lite")
+	LockResolverCountWithAsyncResolveAsyncCommitFallback = TiKVLockResolverCounter.WithLabelValues("async_resolve_async_commit_fallback")
+	LockResolverCountWithReadAsyncResolveFallback = TiKVLockResolverCounter.WithLabelValues("read_async_resolve_fallback")
 
 	LockResolverAsyncRunningTasksForReadResolve = TiKVLockResolverAsyncRunningTasks.WithLabelValues("read_resolve")
 	LockResolverAsyncRunningTasksForResolveAsyncCommit = TiKVLockResolverAsyncRunningTasks.WithLabelValues("resolve_async_commit")
-
-	LockResolverAsyncFallbackCounterForReadResolve = TiKVLockResolverAsyncFallbackCounter.WithLabelValues("read_resolve")
-	LockResolverAsyncFallbackCounterForResolveAsyncCommit = TiKVLockResolverAsyncFallbackCounter.WithLabelValues("resolve_async_commit")
 
 	RegionCacheCounterWithInvalidateRegionFromCacheOK = TiKVRegionCacheCounter.WithLabelValues("invalidate_region_from_cache", "ok")
 	RegionCacheCounterWithSendFail = TiKVRegionCacheCounter.WithLabelValues("send_fail", "ok")

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1192,14 +1192,19 @@ func (lr *LockResolver) resolveAsyncCommitLock(bo *retry.Backoffer, l *Lock, sta
 	logutil.BgLogger().Info("resolve async commit locks", zap.Uint64("startTS", l.TxnID), zap.Uint64("commitTS", status.commitTS), zap.Stringer("TxnStatus", status))
 	if asyncResolveAll {
 		asyncBo := retry.NewBackoffer(lr.asyncResolveCtx, asyncResolveLockMaxBackoff)
-		go func() {
+		asyncResolveAll = lr.tryAsyncResolve(func() {
 			err := lr.resolveAsyncResolveData(asyncBo, l, status, toResolveKeys)
 			if err != nil {
 				logutil.BgLogger().Info("failed to resolve async-commit locks asynchronously",
 					zap.Uint64("startTS", l.TxnID), zap.Uint64("commitTS", status.CommitTS()), zap.Error(err))
 			}
-		}()
-	} else {
+		}, metrics.LockResolverAsyncRunningTasksForResolveAsyncCommit)
+		if !asyncResolveAll {
+			metrics.LockResolverAsyncFallbackCounterForResolveAsyncCommit.Inc()
+		}
+	}
+
+	if !asyncResolveAll {
 		err := lr.resolveAsyncResolveData(bo, l, status, toResolveKeys)
 		if err != nil {
 			return TxnStatus{}, err

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -792,9 +792,9 @@ func (p *asyncResolveTaskPool) releasePermit() {
 	select {
 	case <-p.semaphore:
 	default:
-		logutil.BgLogger().Error("asyncResolveLockSemaphore channel should never be full when releasing")
+		logutil.BgLogger().Error("asyncResolveLockSemaphore channel should never be empty when releasing")
 		if intest.InTest {
-			panic("asyncResolveLockSemaphore channel should never be full when releasing")
+			panic("asyncResolveLockSemaphore channel should never be empty when releasing")
 		}
 	}
 }

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tiancaiamao/gp"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -63,7 +64,7 @@ type storage interface {
 // LockResolver resolves locks and also caches resolved txn status.
 type LockResolver struct {
 	store                    storage
-	asyncResolveSemaphore    chan struct{}
+	asyncResolvePool         *asyncResolveTaskPool
 	resolveLockLiteThreshold uint64
 	mu                       struct {
 		sync.RWMutex
@@ -100,7 +101,7 @@ type ResolvingLock struct {
 func NewLockResolver(store storage) *LockResolver {
 	r := &LockResolver{
 		store:                    store,
-		asyncResolveSemaphore:    globalAsyncResolveLockSemaphore,
+		asyncResolvePool:         newAsyncResolveTaskPool(globalAsyncResolveLockSemaphore),
 		resolveLockLiteThreshold: config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold,
 	}
 	r.mu.resolved = make(map[uint64]TxnStatus)
@@ -114,6 +115,7 @@ func NewLockResolver(store storage) *LockResolver {
 // Close cancels all background goroutines.
 func (lr *LockResolver) Close() {
 	lr.asyncResolveCancel()
+	lr.asyncResolvePool.Close()
 }
 
 // TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
@@ -621,7 +623,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			if forRead {
 				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
 				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
-				asyncResolve = lr.tryAsyncResolve(func() {
+				asyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
 					err := lr.resolveLock(asyncBo, l, status, lite, map[locate.RegionVerID]struct{}{})
@@ -689,70 +691,6 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 	}, nil
 }
 
-// AsyncResolveLockSemaphoreLimit is the max concurrency of async resolve lock.
-// It is set to a very large value to make sure it won't introduce some performance drawback in most cases,
-// and for some extreme cases it can also provide some protection to avoid OOM
-// by too many async resolve lock goroutines.
-const AsyncResolveLockSemaphoreLimit = 10000
-
-// createAsyncResolveLockSemaphore creates a `chan struct{}` with the specified limit.
-func createAsyncResolveLockSemaphore(limit int) chan struct{} {
-	ch := make(chan struct{}, limit)
-	for i := 0; i < limit; i++ {
-		ch <- struct{}{}
-	}
-	return ch
-}
-
-// globalAsyncResolveLockSemaphore provides the global limits of the concurrency for async resolve lock
-// by using a counting semaphore pattern.
-var globalAsyncResolveLockSemaphore = createAsyncResolveLockSemaphore(AsyncResolveLockSemaphoreLimit)
-
-var lastSemaphoreExhaustedLogTime atomic.Pointer[time.Time]
-
-// tryAsyncResolve tries to resolve a lock asynchronously.
-// It returns `true` if the async resolving process is launched successfully,
-// otherwise returns `false` which means the async resolving process is not accepted
-// because of too many concurrent async resolving processes.
-func (lr *LockResolver) tryAsyncResolve(
-	resolveFn func(),
-	runningTasksMetric prometheus.Gauge,
-) bool {
-	select {
-	case <-lr.asyncResolveSemaphore:
-		// acquired a permit, the async resolve is accepted.
-	default:
-		// the semaphore is used up, the async resolve is not accepted.
-		// The WARN log is rate is limited to avoid flooding.
-		if tm := lastSemaphoreExhaustedLogTime.Load(); tm == nil || time.Since(*tm) > 10*time.Second {
-			now := time.Now()
-			if lastSemaphoreExhaustedLogTime.CompareAndSwap(tm, &now) {
-				logutil.BgLogger().Warn(
-					"too many concurrent async resolving locks, async resolve lock is rejected to avoid OOM",
-				)
-			}
-		}
-		return false
-	}
-
-	go func() {
-		runningTasksMetric.Inc()
-		defer func() {
-			runningTasksMetric.Dec()
-			select {
-			case lr.asyncResolveSemaphore <- struct{}{}:
-			default:
-				logutil.BgLogger().Error("asyncResolveLockSemaphore channel should never be full when releasing")
-				if intest.InTest {
-					panic("asyncResolveLockSemaphore channel should never be full when releasing")
-				}
-			}
-		}()
-		resolveFn()
-	}()
-	return true
-}
-
 // Resolving returns the locks' information we are resolving currently.
 func (lr *LockResolver) Resolving() []ResolvingLock {
 	result := []ResolvingLock{}
@@ -771,6 +709,104 @@ func (lr *LockResolver) Resolving() []ResolvingLock {
 		}
 	}
 	return result
+}
+
+// AsyncResolveLockSemaphoreLimit is the max concurrency of async resolve lock.
+// It is set to a very large value to make sure it won't introduce some performance drawback in most cases,
+// and for some extreme cases it can also provide some protection to avoid OOM
+// by too many async resolve lock goroutines.
+const AsyncResolveLockSemaphoreLimit = 10000
+
+// globalAsyncResolveLockSemaphore provides the global limits of the concurrency for async resolve lock
+// by using a counting semaphore pattern.
+var globalAsyncResolveLockSemaphore = make(chan struct{}, AsyncResolveLockSemaphoreLimit)
+
+type asyncResolveTaskPool struct {
+	mu                            sync.RWMutex
+	semaphore                     chan struct{}
+	lastSemaphoreExhaustedLogTime atomic.Pointer[time.Time]
+	gp                            *gp.Pool
+	closed                        bool
+}
+
+func newAsyncResolveTaskPool(semaphore chan struct{}) *asyncResolveTaskPool {
+	return &asyncResolveTaskPool{
+		semaphore: semaphore,
+		gp:        gp.New(cap(semaphore), 10*time.Second),
+	}
+}
+
+// tryAsyncResolve tries to resolve a lock asynchronously.
+// It returns `true` if the async resolving process is launched successfully,
+// otherwise returns `false` which means the async resolving process is not accepted
+// because of too many concurrent async resolving processes.
+func (p *asyncResolveTaskPool) tryAsyncResolve(
+	resolveFn func(),
+	runningTasksMetric prometheus.Gauge,
+) bool {
+	if !p.acquirePermit() {
+		return false
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.closed {
+		p.releasePermit()
+		return false
+	}
+
+	p.gp.Go(func() {
+		runningTasksMetric.Inc()
+		defer func() {
+			runningTasksMetric.Dec()
+			p.releasePermit()
+			// stop holding resolveFn to release memory as soon as possible.
+			resolveFn = nil
+		}()
+		resolveFn()
+	})
+	return true
+}
+
+func (p *asyncResolveTaskPool) acquirePermit() bool {
+	select {
+	case p.semaphore <- struct{}{}:
+		// acquired a permit, the async resolve is accepted.
+		return true
+	default:
+		// the semaphore is used up, the async resolve is not accepted.
+		// The WARN log rate is limited to avoid flooding.
+		if tm := p.lastSemaphoreExhaustedLogTime.Load(); tm == nil || time.Since(*tm) > 10*time.Second {
+			now := time.Now()
+			if p.lastSemaphoreExhaustedLogTime.CompareAndSwap(tm, &now) {
+				logutil.BgLogger().Warn(
+					"too many concurrent async resolving locks, async resolve lock is rejected to avoid OOM",
+				)
+			}
+		}
+		return false
+	}
+}
+
+func (p *asyncResolveTaskPool) releasePermit() {
+	select {
+	case <-p.semaphore:
+	default:
+		logutil.BgLogger().Error("asyncResolveLockSemaphore channel should never be full when releasing")
+		if intest.InTest {
+			panic("asyncResolveLockSemaphore channel should never be full when releasing")
+		}
+	}
+}
+
+// Close closes the asyncResolveTaskPool
+func (p *asyncResolveTaskPool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.closed = true
+		p.gp.Close()
+	}
 }
 
 type txnExpireTime struct {
@@ -1144,11 +1180,16 @@ func (lr *LockResolver) resolveAsyncResolveData(bo *retry.Backoffer, l *Lock, st
 		resolveBo, cancel := bo.Fork()
 		defer cancel()
 
-		go func() {
+		resolveFn := func() {
 			e := lr.resolveRegionLocks(resolveBo, l, curRegion, curLocks, status)
 			lastForkedBo.Store(resolveBo)
 			errChan <- e
-		}()
+		}
+
+		if !lr.asyncResolvePool.tryAsyncResolve(resolveFn, metrics.LockResolverAsyncRunningTasksForResolveAsyncCommitRegion) {
+			metrics.LockResolverCountWithAsyncResolveAsyncCommitRegionFallback.Inc()
+			resolveFn()
+		}
 	}
 
 	var errs []string
@@ -1200,7 +1241,7 @@ func (lr *LockResolver) resolveAsyncCommitLock(bo *retry.Backoffer, l *Lock, sta
 	doSyncResolve := false
 	if asyncResolveAll {
 		asyncBo := retry.NewBackoffer(lr.asyncResolveCtx, asyncResolveLockMaxBackoff)
-		doSyncResolve = lr.tryAsyncResolve(func() {
+		doSyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 			err := lr.resolveAsyncResolveData(asyncBo, l, status, toResolveKeys)
 			if err != nil {
 				logutil.BgLogger().Info("failed to resolve async-commit locks asynchronously",
@@ -1244,11 +1285,16 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 		checkBo, cancel := bo.Fork()
 		defer cancel()
 
-		go func() {
+		resolveFn := func() {
 			e := lr.checkSecondaries(checkBo, l.TxnID, curKeys, curRegionID, &shared)
 			lastForkedBo.Store(checkBo)
 			errChan <- e
-		}()
+		}
+
+		if !lr.asyncResolvePool.tryAsyncResolve(resolveFn, metrics.LockResolverAsyncRunningTasksForCheckSecondaries) {
+			metrics.LockResolverCountWithAsyncCheckSecondariesFallback.Inc()
+			resolveFn()
+		}
 	}
 
 	for range len(regions) {

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -708,6 +708,8 @@ func createAsyncResolveLockSemaphore(limit int) chan struct{} {
 // by using a counting semaphore pattern.
 var globalAsyncResolveLockSemaphore = createAsyncResolveLockSemaphore(AsyncResolveLockSemaphoreLimit)
 
+var lastSemaphoreExhaustedLogTime atomic.Pointer[time.Time]
+
 // tryAsyncResolve tries to resolve a lock asynchronously.
 // It returns `true` if the async resolving process is launched successfully,
 // otherwise returns `false` which means the async resolving process is not accepted
@@ -721,6 +723,15 @@ func (lr *LockResolver) tryAsyncResolve(
 		// acquired a permit, the async resolve is accepted.
 	default:
 		// the semaphore is used up, the async resolve is not accepted.
+		// The WARN log is rate is limited to avoid flooding.
+		if tm := lastSemaphoreExhaustedLogTime.Load(); tm == nil || time.Since(*tm) > 10*time.Second {
+			now := time.Now()
+			if lastSemaphoreExhaustedLogTime.CompareAndSwap(tm, &now) {
+				logutil.BgLogger().Warn(
+					"too many concurrent async resolving locks, async resolve lock is rejected to avoid OOM",
+				)
+			}
+		}
 		return false
 	}
 

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	tikverr "github.com/tikv/client-go/v2/error"
@@ -37,6 +38,7 @@ import (
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/trace"
 	"github.com/tikv/client-go/v2/util"
+	"github.com/tikv/client-go/v2/util/intest"
 	"github.com/tikv/client-go/v2/util/redact"
 	"go.uber.org/zap"
 )
@@ -61,6 +63,7 @@ type storage interface {
 // LockResolver resolves locks and also caches resolved txn status.
 type LockResolver struct {
 	store                    storage
+	asyncResolveSemaphore    chan struct{}
 	resolveLockLiteThreshold uint64
 	mu                       struct {
 		sync.RWMutex
@@ -97,6 +100,7 @@ type ResolvingLock struct {
 func NewLockResolver(store storage) *LockResolver {
 	r := &LockResolver{
 		store:                    store,
+		asyncResolveSemaphore:    globalAsyncResolveLockSemaphore,
 		resolveLockLiteThreshold: config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold,
 	}
 	r.mu.resolved = make(map[uint64]TxnStatus)
@@ -613,10 +617,11 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				err = lr.resolvePessimisticLock(bo, l, false, nil)
 			}
 		} else {
+			asyncResolve := false
 			if forRead {
 				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
 				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
-				go func() {
+				asyncResolve = lr.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
 					err := lr.resolveLock(asyncBo, l, status, lite, map[locate.RegionVerID]struct{}{})
@@ -624,8 +629,12 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 						logutil.BgLogger().Info("failed to resolve lock asynchronously",
 							zap.String("lock", l.String()), zap.Uint64("commitTS", status.CommitTS()), zap.Error(err))
 					}
-				}()
-			} else {
+				}, metrics.LockResolverAsyncRunningTasksForReadResolve)
+				if !asyncResolve {
+					metrics.LockResolverAsyncFallbackCounterForReadResolve.Inc()
+				}
+			}
+			if !asyncResolve {
 				err = lr.resolveLock(bo, l, status, lite, cleanRegions)
 			}
 		}
@@ -678,6 +687,63 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 		IgnoreLocks: canIgnore,
 		AccessLocks: canAccess,
 	}, nil
+}
+
+// AsyncResolveLockSemaphoreLimit is the max concurrency of async resolve lock.
+// It is set to a very large value to make sure it won't introduce some performance drawback in most cases,
+// and for some extreme cases it can also provide some protection to avoid OOM
+// by too many async resolve lock goroutines.
+const AsyncResolveLockSemaphoreLimit = 10000
+
+// createAsyncResolveLockSemaphore creates a `chan struct{}` with the specified limit.
+func createAsyncResolveLockSemaphore(limit int) chan struct{} {
+	ch := make(chan struct{}, limit)
+	for i := 0; i < limit; i++ {
+		select {
+		case ch <- struct{}{}:
+		default:
+			panic("asyncResolveLockSemaphore channel should never be full")
+		}
+	}
+	return ch
+}
+
+// globalAsyncResolveLockSemaphore provides the global limits of the concurrency for async resolve lock
+// by using a counting semaphore pattern.
+var globalAsyncResolveLockSemaphore = createAsyncResolveLockSemaphore(AsyncResolveLockSemaphoreLimit)
+
+// tryAsyncResolve tries to resolve a lock asynchronously.
+// It returns `true` if the async resolving process is launched successfully,
+// otherwise returns `false` which means the async resolving process is not accepted
+// because of too many concurrent async resolving processes.
+func (lr *LockResolver) tryAsyncResolve(
+	resolveFn func(),
+	runningTasksMetric prometheus.Gauge,
+) bool {
+	select {
+	case <-lr.asyncResolveSemaphore:
+		// acquired a permit, the async resolve is accepted.
+	default:
+		// the semaphore is used up, the async resolve is not accepted.
+		return false
+	}
+
+	go func() {
+		runningTasksMetric.Inc()
+		defer func() {
+			runningTasksMetric.Dec()
+			select {
+			case lr.asyncResolveSemaphore <- struct{}{}:
+			default:
+				logutil.BgLogger().Error("asyncResolveLockSemaphore channel should never be full when releasing")
+				if intest.InTest {
+					panic("asyncResolveLockSemaphore channel should never be full when releasing")
+				}
+			}
+		}()
+		resolveFn()
+	}()
+	return true
 }
 
 // Resolving returns the locks' information we are resolving currently.

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -631,7 +631,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 					}
 				}, metrics.LockResolverAsyncRunningTasksForReadResolve)
 				if !asyncResolve {
-					metrics.LockResolverAsyncFallbackCounterForReadResolve.Inc()
+					metrics.LockResolverCountWithReadAsyncResolveFallback.Inc()
 				}
 			}
 			if !asyncResolve {
@@ -1197,7 +1197,7 @@ func (lr *LockResolver) resolveAsyncCommitLock(bo *retry.Backoffer, l *Lock, sta
 			}
 		}, metrics.LockResolverAsyncRunningTasksForResolveAsyncCommit)
 		if !doSyncResolve {
-			metrics.LockResolverAsyncFallbackCounterForResolveAsyncCommit.Inc()
+			metrics.LockResolverCountWithAsyncResolveAsyncCommitFallback.Inc()
 		}
 	}
 

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -699,11 +699,7 @@ const AsyncResolveLockSemaphoreLimit = 10000
 func createAsyncResolveLockSemaphore(limit int) chan struct{} {
 	ch := make(chan struct{}, limit)
 	for i := 0; i < limit; i++ {
-		select {
-		case ch <- struct{}{}:
-		default:
-			panic("asyncResolveLockSemaphore channel should never be full")
-		}
+		ch <- struct{}{}
 	}
 	return ch
 }
@@ -1190,21 +1186,22 @@ func (lr *LockResolver) resolveAsyncCommitLock(bo *retry.Backoffer, l *Lock, sta
 		return status, nil
 	}
 	logutil.BgLogger().Info("resolve async commit locks", zap.Uint64("startTS", l.TxnID), zap.Uint64("commitTS", status.commitTS), zap.Stringer("TxnStatus", status))
+	doSyncResolve := false
 	if asyncResolveAll {
 		asyncBo := retry.NewBackoffer(lr.asyncResolveCtx, asyncResolveLockMaxBackoff)
-		asyncResolveAll = lr.tryAsyncResolve(func() {
+		doSyncResolve = lr.tryAsyncResolve(func() {
 			err := lr.resolveAsyncResolveData(asyncBo, l, status, toResolveKeys)
 			if err != nil {
 				logutil.BgLogger().Info("failed to resolve async-commit locks asynchronously",
 					zap.Uint64("startTS", l.TxnID), zap.Uint64("commitTS", status.CommitTS()), zap.Error(err))
 			}
 		}, metrics.LockResolverAsyncRunningTasksForResolveAsyncCommit)
-		if !asyncResolveAll {
+		if !doSyncResolve {
 			metrics.LockResolverAsyncFallbackCounterForResolveAsyncCommit.Inc()
 		}
 	}
 
-	if !asyncResolveAll {
+	if !doSyncResolve {
 		err := lr.resolveAsyncResolveData(bo, l, status, toResolveKeys)
 		if err != nil {
 			return TxnStatus{}, err

--- a/txnkv/txnlock/lock_resolver_test.go
+++ b/txnkv/txnlock/lock_resolver_test.go
@@ -2,10 +2,15 @@ package txnlock
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/config/retry"
 	"github.com/tikv/client-go/v2/util"
@@ -47,4 +52,116 @@ func TestLockResolverCache(t *testing.T) {
 	_, err := lockResolver.ResolveLocks(backOff, 5, []*Lock{NewLock(toResolveLock)})
 	require.NoError(t, err)
 	require.Nil(t, failpoint.Disable("tikvclient/resolveAsyncCommitLockReturn"))
+}
+
+func TestTryAsyncResolve(t *testing.T) {
+	require.Equal(t, AsyncResolveLockSemaphoreLimit, len(globalAsyncResolveLockSemaphore))
+	mockMetric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_try_async_resolve_running_tasks",
+		Help: "Test gauge for TestTryAsyncResolve",
+	})
+	checkMetricVal := func(v float64) {
+		m := &dto.Metric{}
+		require.NoError(t, mockMetric.Write(m))
+		require.Equal(t, v, m.GetGauge().GetValue())
+	}
+
+	var enter atomic.Int32
+	var exit atomic.Int32
+	waitCounter := func(c *atomic.Int32, n int) {
+		assert.Eventually(t, func() bool {
+			return c.Load() == int32(n)
+		}, 10*time.Second, 10*time.Millisecond)
+		if c == &exit {
+			// wait the goroutine exit completely and related metrics updated.
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	lockResolver := NewLockResolver(nil)
+	enterLatches := make([]chan struct{}, 0, 16)
+	exitLatches := make([]chan struct{}, 0, 16)
+	tryAsync := func() (isAsync bool) {
+		enterLatch := make(chan struct{})
+		exitLatch := make(chan struct{})
+
+		isAsync = lockResolver.tryAsyncResolve(func() {
+			enter.Add(1)
+			close(enterLatch)
+			<-exitLatch
+			exit.Add(1)
+		}, mockMetric)
+
+		if isAsync {
+			enterLatches = append(enterLatches, enterLatch)
+			exitLatches = append(exitLatches, exitLatch)
+		}
+
+		return isAsync
+	}
+
+	exitTask := func(idx int) {
+		close(exitLatches[idx])
+		exitLatches[idx] = nil
+	}
+
+	defer func() {
+		// clean up
+		for _, l := range exitLatches {
+			if l != nil {
+				close(l)
+			}
+		}
+	}()
+
+	// mock a custom asyncResolveLockSemaphore with limit 5
+	lockResolver.asyncResolveSemaphore = createAsyncResolveLockSemaphore(5)
+
+	// try to async resolve 3 times
+	require.True(t, tryAsync())
+	require.True(t, tryAsync())
+	require.True(t, tryAsync())
+	waitCounter(&enter, 3)
+	checkMetricVal(3)
+
+	// exit 1 async goroutine
+	exitTask(1)
+	waitCounter(&exit, 1)
+
+	// check 2 async goroutines are still running and related metrics updated
+	checkMetricVal(2)
+
+	// try to async resolve 3 more times, semaphore is used up.
+	require.True(t, tryAsync())
+	require.True(t, tryAsync())
+	require.True(t, tryAsync())
+	waitCounter(&enter, 6)
+	checkMetricVal(5)
+
+	// more async task will be rejected
+	require.False(t, tryAsync())
+	require.False(t, tryAsync())
+	require.False(t, tryAsync())
+	checkMetricVal(5)
+	time.Sleep(time.Millisecond)
+	checkMetricVal(5)
+
+	// exit a task
+	exitTask(3)
+	waitCounter(&exit, 2)
+	checkMetricVal(4)
+
+	// a new task will be accepted again
+	require.True(t, tryAsync())
+	waitCounter(&enter, 7)
+	checkMetricVal(5)
+
+	// clean up
+	for i := range exitLatches {
+		if exitLatches[i] != nil {
+			exitTask(i)
+		}
+	}
+	waitCounter(&exit, int(enter.Load()))
+	checkMetricVal(0)
 }

--- a/txnkv/txnlock/lock_resolver_test.go
+++ b/txnkv/txnlock/lock_resolver_test.go
@@ -2,7 +2,6 @@ package txnlock
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -66,34 +65,21 @@ func TestTryAsyncResolve(t *testing.T) {
 		require.Equal(t, v, m.GetGauge().GetValue())
 	}
 
-	var enter atomic.Int32
-	var exit atomic.Int32
-	waitCounter := func(c *atomic.Int32, n int) {
-		assert.Eventually(t, func() bool {
-			return c.Load() == int32(n)
-		}, 10*time.Second, 10*time.Millisecond)
-		if c == &exit {
-			// wait the goroutine exit completely and related metrics updated.
-			time.Sleep(5 * time.Millisecond)
-		}
-	}
-
 	lockResolver := NewLockResolver(nil)
-	enterLatches := make([]chan struct{}, 0, 16)
+	assert.Equal(t, cap(lockResolver.asyncResolveSemaphore), cap(globalAsyncResolveLockSemaphore))
+	assert.Equal(t, len(lockResolver.asyncResolveSemaphore), len(globalAsyncResolveLockSemaphore))
+
 	exitLatches := make([]chan struct{}, 0, 16)
 	tryAsync := func() (isAsync bool) {
 		enterLatch := make(chan struct{})
 		exitLatch := make(chan struct{})
 
 		isAsync = lockResolver.tryAsyncResolve(func() {
-			enter.Add(1)
 			close(enterLatch)
 			<-exitLatch
-			exit.Add(1)
 		}, mockMetric)
 
 		if isAsync {
-			enterLatches = append(enterLatches, enterLatch)
 			exitLatches = append(exitLatches, exitLatch)
 		}
 
@@ -116,17 +102,22 @@ func TestTryAsyncResolve(t *testing.T) {
 
 	// mock a custom asyncResolveLockSemaphore with limit 5
 	lockResolver.asyncResolveSemaphore = createAsyncResolveLockSemaphore(5)
+	waitSemaphoreSize := func(cnt int) {
+		assert.Eventually(t, func() bool {
+			return len(lockResolver.asyncResolveSemaphore) == cnt
+		}, 10*time.Second, 10*time.Millisecond)
+	}
 
 	// try to async resolve 3 times
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
-	waitCounter(&enter, 3)
+	waitSemaphoreSize(2)
 	checkMetricVal(3)
 
 	// exit 1 async goroutine
 	exitTask(1)
-	waitCounter(&exit, 1)
+	waitSemaphoreSize(3)
 
 	// check 2 async goroutines are still running and related metrics updated
 	checkMetricVal(2)
@@ -135,25 +126,25 @@ func TestTryAsyncResolve(t *testing.T) {
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
-	waitCounter(&enter, 6)
+	waitSemaphoreSize(0)
 	checkMetricVal(5)
 
 	// more async task will be rejected
 	require.False(t, tryAsync())
 	require.False(t, tryAsync())
 	require.False(t, tryAsync())
-	checkMetricVal(5)
+	waitSemaphoreSize(0)
 	time.Sleep(time.Millisecond)
 	checkMetricVal(5)
 
 	// exit a task
 	exitTask(3)
-	waitCounter(&exit, 2)
+	waitSemaphoreSize(1)
 	checkMetricVal(4)
 
 	// a new task will be accepted again
 	require.True(t, tryAsync())
-	waitCounter(&enter, 7)
+	waitSemaphoreSize(0)
 	checkMetricVal(5)
 
 	// clean up
@@ -162,6 +153,6 @@ func TestTryAsyncResolve(t *testing.T) {
 			exitTask(i)
 		}
 	}
-	waitCounter(&exit, int(enter.Load()))
+	waitSemaphoreSize(5)
 	checkMetricVal(0)
 }

--- a/txnkv/txnlock/lock_resolver_test.go
+++ b/txnkv/txnlock/lock_resolver_test.go
@@ -54,7 +54,7 @@ func TestLockResolverCache(t *testing.T) {
 }
 
 func TestTryAsyncResolve(t *testing.T) {
-	require.Equal(t, AsyncResolveLockSemaphoreLimit, len(globalAsyncResolveLockSemaphore))
+	require.Equal(t, AsyncResolveLockSemaphoreLimit, cap(globalAsyncResolveLockSemaphore))
 	mockMetric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "test_try_async_resolve_running_tasks",
 		Help: "Test gauge for TestTryAsyncResolve",
@@ -65,16 +65,17 @@ func TestTryAsyncResolve(t *testing.T) {
 		require.Equal(t, v, m.GetGauge().GetValue())
 	}
 
+	// default lock resolver should use the global async resolve lock semaphore
 	lockResolver := NewLockResolver(nil)
-	assert.Equal(t, cap(lockResolver.asyncResolveSemaphore), cap(globalAsyncResolveLockSemaphore))
-	assert.Equal(t, len(lockResolver.asyncResolveSemaphore), len(globalAsyncResolveLockSemaphore))
+	assert.Equal(t, cap(lockResolver.asyncResolvePool.semaphore), cap(globalAsyncResolveLockSemaphore))
+	assert.Equal(t, 0, len(globalAsyncResolveLockSemaphore))
 
 	exitLatches := make([]chan struct{}, 0, 16)
 	tryAsync := func() (isAsync bool) {
 		enterLatch := make(chan struct{})
 		exitLatch := make(chan struct{})
 
-		isAsync = lockResolver.tryAsyncResolve(func() {
+		isAsync = lockResolver.asyncResolvePool.tryAsyncResolve(func() {
 			close(enterLatch)
 			<-exitLatch
 		}, mockMetric)
@@ -98,61 +99,62 @@ func TestTryAsyncResolve(t *testing.T) {
 				close(l)
 			}
 		}
+		lockResolver.Close()
 	}()
 
-	// mock a custom asyncResolveLockSemaphore with limit 5
-	lockResolver.asyncResolveSemaphore = createAsyncResolveLockSemaphore(5)
-	waitSemaphoreSize := func(cnt int) {
+	// close old pool and mock a custom asyncResolveLockSemaphore with limit 5
+	lockResolver.asyncResolvePool.Close()
+	lockResolver.asyncResolvePool = newAsyncResolveTaskPool(make(chan struct{}, 5))
+	waitSemaphoreSizeWithCheck := func(cnt int) {
 		assert.Eventually(t, func() bool {
-			return len(lockResolver.asyncResolveSemaphore) == cnt
+			return len(lockResolver.asyncResolvePool.semaphore) == cnt
 		}, 10*time.Second, 10*time.Millisecond)
+		checkMetricVal(float64(cnt))
 	}
 
 	// try to async resolve 3 times
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
-	waitSemaphoreSize(2)
-	checkMetricVal(3)
+	waitSemaphoreSizeWithCheck(3)
 
 	// exit 1 async goroutine
 	exitTask(1)
-	waitSemaphoreSize(3)
-
-	// check 2 async goroutines are still running and related metrics updated
-	checkMetricVal(2)
+	waitSemaphoreSizeWithCheck(2)
 
 	// try to async resolve 3 more times, semaphore is used up.
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
 	require.True(t, tryAsync())
-	waitSemaphoreSize(0)
-	checkMetricVal(5)
+	waitSemaphoreSizeWithCheck(5)
 
 	// more async task will be rejected
 	require.False(t, tryAsync())
 	require.False(t, tryAsync())
 	require.False(t, tryAsync())
-	waitSemaphoreSize(0)
-	time.Sleep(time.Millisecond)
+	waitSemaphoreSizeWithCheck(5)
+	// after some time, the metric should still be correct to test pending async tasks do not cause metric change.
+	time.Sleep(10 * time.Millisecond)
 	checkMetricVal(5)
 
 	// exit a task
 	exitTask(3)
-	waitSemaphoreSize(1)
-	checkMetricVal(4)
+	waitSemaphoreSizeWithCheck(4)
 
 	// a new task will be accepted again
 	require.True(t, tryAsync())
-	waitSemaphoreSize(0)
-	checkMetricVal(5)
+	waitSemaphoreSizeWithCheck(5)
 
-	// clean up
+	// exit all tasks
 	for i := range exitLatches {
 		if exitLatches[i] != nil {
 			exitTask(i)
 		}
 	}
-	waitSemaphoreSize(5)
-	checkMetricVal(0)
+	waitSemaphoreSizeWithCheck(0)
+
+	// close resolver, then all async tasks should be rejected
+	lockResolver.Close()
+	require.False(t, tryAsync())
+	waitSemaphoreSizeWithCheck(0)
 }

--- a/txnkv/txnlock/main_test.go
+++ b/txnkv/txnlock/main_test.go
@@ -1,0 +1,25 @@
+// Copyright 2021 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnlock
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
close #1937.

## What problem does this PR solve?
Under sustained lock contention, `LockResolver` could spawn too many async resolve goroutines and keep accumulating heavy backoff errors. That amplified TiKV overload, increased memory use, and could eventually lead to OOM.

## What is changed and how does it work?
- Add a global semaphore for async lock resolution so background resolve tasks have a bounded concurrency.
- Record lock-resolver async running tasks and fallback counts with metrics.
- Change `Backoffer` error recording from unbounded growth to a fixed-size ring buffer that only keeps recent backoff errors.
- Avoid generating stack traces and heavyweight RPC-context strings for backoff-only errors, so retries are much cheaper in memory and CPU.
- Add and complete tests covering bounded async resolve behavior, backoff error retention, and lighter backoff error formatting.
- Related metrics are already added：
    - A new metric: `lock_resolver_async_running_tasks` to show how many async tasks are running.
    - Two new labels for lock resolver counter: `async_resolve_async_commit_fallback` and `read_async_resolve_fallback` . If the rate is not 0, this indicates the semaphore is used up.

## Tests
- `go test ./config/retry ./internal/locate ./txnkv/txnlock -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer backoff/retry error text that includes detailed request and region context.
  * Concurrency-limited async lock/region resolution with automatic synchronous fallback when capacity is exhausted.

* **Improvements**
  * Bounded, timestamped recent-error buffer for clearer diagnostics and consistent reporting.
  * Backoff context strings now handle nil contexts safely and produce more consistent formatting.

* **Monitoring**
  * New metrics tracking async lock-resolution tasks and fallback occurrences.

* **Tests**
  * Added unit tests validating error formatting, backoff error retention, and async-resolve concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->