### PR TITLE
txnkv: batch async resolve lock logs in LockResolver

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -738,6 +738,7 @@ func (s *testCommitterSuite) TestPessimisticTTL() {
 	s.GreaterOrEqual(msBeforeLockExpired, int64(100))
 
 	lr := s.store.NewLockResolver()
+	defer lr.Close()
 	bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
 	status, err := lr.GetTxnStatus(bo, txn.StartTS(), key2, 0, txn.StartTS(), true, false, nil)
 	s.Nil(err)

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -257,6 +257,7 @@ func (s *testLockSuite) TestCheckTxnStatusTTL() {
 
 	bo := tikv.NewBackofferWithVars(context.Background(), int(transaction.PrewriteMaxBackoff.Load()), nil)
 	lr := s.store.NewLockResolver()
+	defer lr.Close()
 	callerStartTS, err := s.store.GetOracle().GetTimestamp(bo.GetCtx(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 	s.Nil(err)
 
@@ -270,7 +271,9 @@ func (s *testLockSuite) TestCheckTxnStatusTTL() {
 	// Rollback the txn.
 	lock := s.mustGetLock([]byte("key"))
 
-	err = s.store.NewLockResolver().ForceResolveLock(context.Background(), lock)
+	lr2 := s.store.NewLockResolver()
+	defer lr2.Close()
+	err = lr2.ForceResolveLock(context.Background(), lock)
 	s.Nil(err)
 
 	// Check its status is rollbacked.
@@ -303,7 +306,9 @@ func (s *testLockSuite) TestTxnHeartBeat() {
 	s.Equal(newTTL, uint64(6666))
 
 	lock := s.mustGetLock([]byte("key"))
-	err = s.store.NewLockResolver().ForceResolveLock(context.Background(), lock)
+	lr := s.store.NewLockResolver()
+	defer lr.Close()
+	err = lr.ForceResolveLock(context.Background(), lock)
 	s.Nil(err)
 
 	newTTL, err = s.store.SendTxnHeartbeat(context.Background(), []byte("key"), txn.StartTS(), 6666)
@@ -325,6 +330,7 @@ func (s *testLockSuite) TestCheckTxnStatus() {
 
 	bo := tikv.NewBackofferWithVars(context.Background(), int(transaction.PrewriteMaxBackoff.Load()), nil)
 	resolver := s.store.NewLockResolver()
+	defer resolver.Close()
 	// Call getTxnStatus to check the lock status.
 	status, err := resolver.GetTxnStatus(bo, txn.StartTS(), []byte("key"), currentTS, currentTS, true, false, nil)
 	s.Nil(err)
@@ -348,7 +354,9 @@ func (s *testLockSuite) TestCheckTxnStatus() {
 	// Then call getTxnStatus again and check the lock status.
 	currentTS, err = o.GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 	s.Nil(err)
-	status, err = s.store.NewLockResolver().GetTxnStatus(bo, txn.StartTS(), []byte("key"), currentTS, 0, true, false, nil)
+	lr := s.store.NewLockResolver()
+	defer lr.Close()
+	status, err = lr.GetTxnStatus(bo, txn.StartTS(), []byte("key"), currentTS, 0, true, false, nil)
 	s.Nil(err)
 	s.Equal(status.TTL(), uint64(0))
 	s.Equal(status.CommitTS(), uint64(0))
@@ -356,7 +364,9 @@ func (s *testLockSuite) TestCheckTxnStatus() {
 
 	// Call getTxnStatus on a committed transaction.
 	startTS, commitTS := s.putKV([]byte("a"), []byte("a"))
-	status, err = s.store.NewLockResolver().GetTxnStatus(bo, startTS, []byte("a"), currentTS, currentTS, true, false, nil)
+	lr2 := s.store.NewLockResolver()
+	defer lr2.Close()
+	status, err = lr2.GetTxnStatus(bo, startTS, []byte("a"), currentTS, currentTS, true, false, nil)
 	s.Nil(err)
 	s.Equal(status.TTL(), uint64(0))
 	s.Equal(status.CommitTS(), commitTS)
@@ -382,6 +392,7 @@ func (s *testLockSuite) TestCheckTxnStatusNoWait() {
 	s.Nil(err)
 	bo := tikv.NewBackofferWithVars(context.Background(), int(transaction.PrewriteMaxBackoff.Load()), nil)
 	resolver := s.store.NewLockResolver()
+	defer resolver.Close()
 
 	// Call getTxnStatus for the TxnNotFound case.
 	_, err = resolver.GetTxnStatus(bo, txn.StartTS(), []byte("key"), currentTS, currentTS, false, false, nil)
@@ -539,6 +550,7 @@ func (s *testLockSuite) TestBatchResolveLocks() {
 	s.Greater(msBeforeLockExpired, int64(0))
 
 	lr := s.store.NewLockResolver()
+	defer lr.Close()
 	bo := tikv.NewGcResolveLockMaxBackoffer(context.Background())
 	loc, err := s.store.GetRegionCache().LocateKey(bo, locks[0].Primary)
 	s.Nil(err)
@@ -585,19 +597,25 @@ func (s *testLockSuite) TestZeroMinCommitTS() {
 	s.Nil(failpoint.Disable("tikvclient/mockZeroCommitTS"))
 
 	lock := s.mustGetLock([]byte("key"))
-	expire, pushed, _, err := s.store.NewLockResolver().ResolveLocksForRead(bo, 0, []*txnkv.Lock{lock}, true)
+	lr := s.store.NewLockResolver()
+	defer lr.Close()
+	expire, pushed, _, err := lr.ResolveLocksForRead(bo, 0, []*txnkv.Lock{lock}, true)
 	s.Nil(err)
 	s.Len(pushed, 0)
 	s.Greater(expire, int64(0))
 
-	expire, pushed, _, err = s.store.NewLockResolver().ResolveLocksForRead(bo, math.MaxUint64, []*txnkv.Lock{lock}, true)
+	lr2 := s.store.NewLockResolver()
+	defer lr2.Close()
+	expire, pushed, _, err = lr2.ResolveLocksForRead(bo, math.MaxUint64, []*txnkv.Lock{lock}, true)
 	s.Nil(err)
 	s.Len(pushed, 1)
 	s.Equal(expire, int64(0))
 
 	// Clean up this test.
 	lock.TTL = uint64(0)
-	expire, err = s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+	lr3 := s.store.NewLockResolver()
+	defer lr3.Close()
+	expire, err = lr3.ResolveLocks(bo, 0, []*txnkv.Lock{lock})
 	s.Nil(err)
 	s.Equal(expire, int64(0))
 }
@@ -635,6 +653,7 @@ func (s *testLockSuite) TestCheckLocksFallenBackFromAsyncCommit() {
 	s.True(lock.UseAsyncCommit)
 	bo := tikv.NewBackoffer(context.Background(), getMaxBackoff)
 	lr := s.store.NewLockResolver()
+	defer lr.Close()
 	status, err := lr.GetTxnStatusFromLock(bo, lock, 0, false)
 	s.Nil(err)
 	s.Equal(txnlock.LockProbe{}.GetPrimaryKeyFromTxnStatus(status), []byte("fb1"))
@@ -667,7 +686,9 @@ func (s *testLockSuite) TestResolveTxnFallenBackFromAsyncCommit() {
 
 	resolveStarted := time.Now()
 	for {
-		expire, err := s.store.NewLockResolver().ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+		lr := s.store.NewLockResolver()
+		expire, err := lr.ResolveLocks(bo, 0, []*txnkv.Lock{lock})
+		lr.Close()
 		s.Nil(err)
 		if expire == 0 {
 			break
@@ -693,7 +714,9 @@ func (s *testLockSuite) TestBatchResolveTxnFallenBackFromAsyncCommit() {
 	bo := tikv.NewBackoffer(context.Background(), getMaxBackoff)
 	loc, err := s.store.GetRegionCache().LocateKey(bo, []byte("fb1"))
 	s.Nil(err)
-	ok, err := s.store.NewLockResolver().BatchResolveLocks(bo, []*txnkv.Lock{lock}, loc.Region)
+	lr := s.store.NewLockResolver()
+	defer lr.Close()
+	ok, err := lr.BatchResolveLocks(bo, []*txnkv.Lock{lock}, loc.Region)
 	s.Nil(err)
 	s.True(ok)
 
@@ -854,6 +877,7 @@ func (s *testLockSuite) TestStartHeartBeatAfterLockingPrimary() {
 	// Check the TTL should have been updated
 	lr := s.store.NewLockResolver()
 	status, err := lr.LockResolver.GetTxnStatus(txn.StartTS(), 0, []byte("a"))
+	lr.Close()
 	s.Nil(err)
 	s.False(status.IsCommitted())
 	s.Greater(status.TTL(), uint64(600))
@@ -873,6 +897,7 @@ func (s *testLockSuite) TestStartHeartBeatAfterLockingPrimary() {
 	// The original primary key "a" should be rolled back because its TTL is not updated
 	lr = s.store.NewLockResolver()
 	status, err = lr.LockResolver.GetTxnStatus(txn.StartTS(), 0, []byte("a"))
+	lr.Close()
 	s.Nil(err)
 	s.False(status.IsCommitted())
 	s.Equal(status.TTL(), uint64(0))
@@ -880,6 +905,7 @@ func (s *testLockSuite) TestStartHeartBeatAfterLockingPrimary() {
 	// The TTL of the new primary lock should be updated.
 	lr = s.store.NewLockResolver()
 	status, err = lr.LockResolver.GetTxnStatus(txn.StartTS(), 0, []byte("c"))
+	lr.Close()
 	s.Nil(err)
 	s.False(status.IsCommitted())
 	s.Greater(status.TTL(), uint64(1200))
@@ -939,7 +965,9 @@ func (s *testLockSuite) TestResolveLocksForRead() {
 	// rolled back
 	startTS, _ = s.lockKey([]byte("k2"), []byte("v2"), []byte("k22"), []byte("v22"), 3000, false, false)
 	lock = s.mustGetLock([]byte("k22"))
-	err := s.store.NewLockResolver().ForceResolveLock(ctx, lock)
+	lr := s.store.NewLockResolver()
+	defer lr.Close()
+	err := lr.ForceResolveLock(ctx, lock)
 	s.Nil(err)
 	resolvedLocks = append(resolvedLocks, startTS)
 	lock = s.mustGetLock([]byte("k2"))
@@ -989,12 +1017,12 @@ func (s *testLockSuite) TestResolveLocksForRead() {
 	}
 
 	bo := tikv.NewBackoffer(context.Background(), getMaxBackoff)
-	lr := s.store.NewLockResolver()
-	defer lr.Close()
+	lr2 := s.store.NewLockResolver()
+	defer lr2.Close()
 
 	// Sleep for a while to make sure the async commit lock "k5" expires, so it could be resolve commit.
 	time.Sleep(500 * time.Millisecond)
-	msBeforeExpired, resolved, committed, err := lr.ResolveLocksForRead(bo, readStartTS, locks, false)
+	msBeforeExpired, resolved, committed, err := lr2.ResolveLocksForRead(bo, readStartTS, locks, false)
 	s.Nil(err)
 	s.Greater(msBeforeExpired, int64(0))
 	s.Equal(resolvedLocks, resolved)

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -334,6 +334,7 @@ func (s *testSharedLockSuite) TestGCSharedLock() {
 	s.True(txn3.GetCommitter().IsTTLRunning(), "txn3's TTL manager should still be running after sleep")
 
 	lr := s.store.NewLockResolver()
+	defer lr.Close()
 	bo := tikv.NewGcResolveLockMaxBackoffer(context.Background())
 	ttl, err := lr.ResolveLocks(bo, 0, locks)
 	s.Nil(err)

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -39,6 +39,7 @@ import (
 	"github.com/tikv/client-go/v2/util"
 	"github.com/tikv/client-go/v2/util/redact"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // ResolvedCacheSize is max number of cached txn status.
@@ -47,6 +48,12 @@ const ResolvedCacheSize = 2048
 const (
 	getTxnStatusMaxBackoff     = 20000
 	asyncResolveLockMaxBackoff = 40000
+)
+
+var (
+	resolveLockLogBatchSize     = 20
+	resolveLockLogFlushInterval = 5 * time.Second
+	resolveLockLogChannelSize   = 1024
 )
 
 type storage interface {
@@ -79,10 +86,14 @@ type LockResolver struct {
 		meetLock func(locks []*Lock)
 	}
 
-	// LockResolver may have some goroutines resolving locks in the background.
+	// LockResolver may have some goroutines resolving locks or logging in the background.
 	// The Cancel function is to cancel these goroutines for passing goleak test.
-	asyncResolveCtx    context.Context
-	asyncResolveCancel func()
+	asyncCtx    context.Context
+	asyncCancel func()
+
+	asyncLogCh        chan resolveLockLogEntry
+	asyncLogRunning   sync.Once
+	missedResolveLogs atomic.Uint64
 }
 
 // ResolvingLock stands for current resolving locks' information
@@ -103,13 +114,14 @@ func NewLockResolver(store storage) *LockResolver {
 	r.mu.resolving = make(map[uint64][][]Lock)
 	r.mu.resolvingConcurrency = make(map[uint64]int)
 	r.mu.recentResolved = list.New()
-	r.asyncResolveCtx, r.asyncResolveCancel = context.WithCancel(context.Background())
+	r.asyncCtx, r.asyncCancel = context.WithCancel(context.Background())
+	r.asyncLogCh = make(chan resolveLockLogEntry, resolveLockLogChannelSize)
 	return r
 }
 
 // Close cancels all background goroutines.
 func (lr *LockResolver) Close() {
-	lr.asyncResolveCancel()
+	lr.asyncCancel()
 }
 
 // TxnStatus represents a txn's final status. It should be Lock or Commit or Rollback.
@@ -231,6 +243,156 @@ func NewLock(l *kvrpcpb.LockInfo) *Lock {
 		UseAsyncCommit:  l.UseAsyncCommit,
 		LockForUpdateTS: l.LockForUpdateTs,
 		MinCommitTS:     l.MinCommitTs,
+	}
+}
+
+type resolveLockLogEntry struct {
+	resolveType              string
+	lock                     Lock
+	action                   string
+	txnStartTS               uint64
+	commitTS                 uint64
+	forUpdateTS              uint64
+	regionID                 uint64
+	regionResolve            bool
+	resolvedByCheckTxnStatus bool
+}
+
+func (e resolveLockLogEntry) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("resolveType", e.resolveType)
+	enc.AddString("lock", e.lock.String())
+	enc.AddString("action", e.action)
+	enc.AddUint64("txnStartTS", e.txnStartTS)
+	if e.commitTS > 0 {
+		enc.AddUint64("commitTS", e.commitTS)
+	}
+	if e.forUpdateTS > 0 {
+		enc.AddUint64("forUpdateTS", e.forUpdateTS)
+	}
+	if e.regionID > 0 {
+		enc.AddUint64("regionID", e.regionID)
+	}
+	enc.AddBool("regionResolve", e.regionResolve)
+	enc.AddBool("resolvedByCheckTxnStatus", e.resolvedByCheckTxnStatus)
+	return nil
+}
+
+type resolveLockLogEntries []resolveLockLogEntry
+
+func (entries resolveLockLogEntries) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, entry := range entries {
+		if err := enc.AppendObject(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (lr *LockResolver) recordResolveLockLogEntry(entry resolveLockLogEntry) {
+	if lr.asyncCtx.Err() != nil {
+		return
+	}
+
+	lr.asyncLogRunning.Do(func() {
+		go lr.collectResolveLockLogsLoop()
+	})
+
+	select {
+	case lr.asyncLogCh <- entry:
+	default:
+		lr.missedResolveLogs.Add(1)
+	}
+}
+
+func (lr *LockResolver) recordResolveLock(
+	l *Lock,
+	resolveAction string,
+	commitTS uint64,
+	regionID uint64,
+	resolveLite bool,
+	resolvedByCheckTxnStatus bool,
+) {
+	lr.recordResolveLockLogEntry(resolveLockLogEntry{
+		resolveType:              l.LockType.String(),
+		lock:                     *l,
+		action:                   resolveAction,
+		txnStartTS:               l.TxnID,
+		commitTS:                 commitTS,
+		regionID:                 regionID,
+		regionResolve:            !resolveLite,
+		resolvedByCheckTxnStatus: resolvedByCheckTxnStatus,
+	})
+}
+
+func (lr *LockResolver) recordResolvePessimisticLock(
+	l *Lock,
+	forUpdateTS uint64,
+	regionResolve bool,
+	resolvedByCheckTxnStatus bool,
+) {
+	lr.recordResolveLockLogEntry(resolveLockLogEntry{
+		resolveType:              l.LockType.String(),
+		lock:                     *l,
+		action:                   "rollback",
+		txnStartTS:               l.TxnID,
+		forUpdateTS:              forUpdateTS,
+		regionResolve:            regionResolve,
+		resolvedByCheckTxnStatus: resolvedByCheckTxnStatus,
+	})
+}
+
+func (lr *LockResolver) collectResolveLockLogsLoop() {
+	ticker := time.NewTicker(resolveLockLogFlushInterval)
+	defer ticker.Stop()
+
+	batch := make(resolveLockLogEntries, 0, resolveLockLogBatchSize)
+	flushLogs := func() {
+		if missed := lr.missedResolveLogs.Swap(0); missed > 0 {
+			logutil.BgLogger().Warn(
+				"missed resolve lock logs due to log channel full, some resolve lock operations may not be logged",
+				zap.Uint64("missed", missed),
+			)
+		}
+
+		if len(batch) > 0 {
+			logutil.BgLogger().Info(
+				"txn resolve locks",
+				zap.Int("count", len(batch)),
+				zap.Array("resolve", batch),
+			)
+			batch = batch[:0]
+		}
+	}
+
+	appendEntry := func(entry resolveLockLogEntry) {
+		batch = append(batch, entry)
+		if len(batch) >= cap(batch) {
+			flushLogs()
+		}
+	}
+
+	defer func() {
+		// flush channels
+		for {
+			select {
+			case entry := <-lr.asyncLogCh:
+				appendEntry(entry)
+			default:
+				flushLogs()
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-lr.asyncCtx.Done():
+			return
+		case entry := <-lr.asyncLogCh:
+			appendEntry(entry)
+		case <-ticker.C:
+			flushLogs()
+		}
 	}
 }
 
@@ -614,7 +776,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			}
 		} else {
 			if forRead {
-				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
+				asyncCtx := context.WithValue(lr.asyncCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
 				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
 				go func() {
 					// Pass an empty cleanRegions here to avoid data race and
@@ -1125,7 +1287,7 @@ func (lr *LockResolver) resolveAsyncCommitLock(bo *retry.Backoffer, l *Lock, sta
 	}
 	logutil.BgLogger().Info("resolve async commit locks", zap.Uint64("startTS", l.TxnID), zap.Uint64("commitTS", status.commitTS), zap.Stringer("TxnStatus", status))
 	if asyncResolveAll {
-		asyncBo := retry.NewBackoffer(lr.asyncResolveCtx, asyncResolveLockMaxBackoff)
+		asyncBo := retry.NewBackoffer(lr.asyncCtx, asyncResolveLockMaxBackoff)
 		go func() {
 			err := lr.resolveAsyncResolveData(asyncBo, l, status, toResolveKeys)
 			if err != nil {
@@ -1266,14 +1428,7 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 	resolveAction := resolveActionLabel(status)
 	// The lock has been resolved by getTxnStatusFromLock.
 	if resolveLite && bytes.Equal(l.Key, l.Primary) {
-		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-lock skipped rpc (resolved by check txn status)",
-			zap.Stringer("lock", l),
-			zap.String("action", resolveAction),
-			zap.Uint64("txnStartTS", l.TxnID),
-			zap.Uint64("commitTS", status.CommitTS()),
-			zap.Bool("resolveLite", resolveLite),
-			zap.Bool("resolvedByCheckTxnStatus", true),
-		)
+		lr.recordResolveLock(l, resolveAction, status.CommitTS(), 0, resolveLite, true)
 		return nil
 	}
 	for {
@@ -1335,15 +1490,7 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 		if !resolveLite {
 			cleanRegions[loc.Region] = struct{}{}
 		}
-		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-lock rpc finished",
-			zap.Stringer("lock", l),
-			zap.String("action", resolveAction),
-			zap.Uint64("txnStartTS", l.TxnID),
-			zap.Uint64("commitTS", lreq.CommitVersion),
-			zap.Uint64("regionID", loc.Region.GetID()),
-			zap.Bool("resolveLite", resolveLite),
-			zap.Bool("resolvedByCheckTxnStatus", false),
-		)
+		lr.recordResolveLock(l, resolveAction, lreq.CommitVersion, loc.Region.GetID(), resolveLite, false)
 		return nil
 	}
 }
@@ -1357,12 +1504,7 @@ func (lr *LockResolver) resolvePessimisticLock(bo *retry.Backoffer, l *Lock, pes
 	metrics.LockResolverCountWithResolveLocks.Inc()
 	// The lock has been resolved by getTxnStatusFromLock.
 	if bytes.Equal(l.Key, l.Primary) {
-		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-pessimistic-lock skipped rpc (resolved by check txn status)",
-			zap.String("action", "rollback"),
-			zap.Uint64("txnStartTS", l.TxnID),
-			zap.Bool("regionResolve", pessimisticRegionResolve),
-			zap.Bool("resolvedByCheckTxnStatus", true),
-		)
+		lr.recordResolvePessimisticLock(l, l.LockForUpdateTS, pessimisticRegionResolve, true)
 		return nil
 	}
 	for {
@@ -1419,14 +1561,8 @@ func (lr *LockResolver) resolvePessimisticLock(bo *retry.Backoffer, l *Lock, pes
 		if pessimisticRegionResolve && pessimisticCleanRegions != nil {
 			pessimisticCleanRegions[loc.Region] = struct{}{}
 		}
-		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-pessimistic-lock rpc finished",
-			zap.String("action", "rollback"),
-			zap.Uint64("txnStartTS", l.TxnID),
-			zap.Uint64("forUpdateTS", forUpdateTS),
-			zap.Uint64("regionID", loc.Region.GetID()),
-			zap.Bool("regionResolve", pessimisticRegionResolve),
-			zap.Bool("resolvedByCheckTxnStatus", false),
-		)
+
+		lr.recordResolvePessimisticLock(l, forUpdateTS, pessimisticRegionResolve, false)
 		return nil
 	}
 }

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1267,6 +1267,7 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 	// The lock has been resolved by getTxnStatusFromLock.
 	if resolveLite && bytes.Equal(l.Key, l.Primary) {
 		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-lock skipped rpc (resolved by check txn status)",
+			zap.Stringer("lock", l),
 			zap.String("action", resolveAction),
 			zap.Uint64("txnStartTS", l.TxnID),
 			zap.Uint64("commitTS", status.CommitTS()),
@@ -1335,6 +1336,7 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 			cleanRegions[loc.Region] = struct{}{}
 		}
 		logutil.Logger(bo.GetCtx()).Info("txn lock cleanup resolve-lock rpc finished",
+			zap.Stringer("lock", l),
 			zap.String("action", resolveAction),
 			zap.Uint64("txnStartTS", l.TxnID),
 			zap.Uint64("commitTS", lreq.CommitVersion),

--- a/txnkv/txnlock/lock_resolver_test.go
+++ b/txnkv/txnlock/lock_resolver_test.go
@@ -3,18 +3,23 @@ package txnlock
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/config/retry"
 	"github.com/tikv/client-go/v2/util"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // TestLockResolverCache is used to cover the issue https://github.com/pingcap/tidb/issues/59494.
 func TestLockResolverCache(t *testing.T) {
 	util.EnableFailpoints()
 	lockResolver := NewLockResolver(nil)
+	t.Cleanup(lockResolver.Close)
 	lock := func(key, primary string, startTS uint64, useAsyncCommit bool, secondaries [][]byte) *kvrpcpb.LockInfo {
 		return &kvrpcpb.LockInfo{
 			Key:            []byte(key),
@@ -47,4 +52,139 @@ func TestLockResolverCache(t *testing.T) {
 	_, err := lockResolver.ResolveLocks(backOff, 5, []*Lock{NewLock(toResolveLock)})
 	require.NoError(t, err)
 	require.Nil(t, failpoint.Disable("tikvclient/resolveAsyncCommitLockReturn"))
+}
+
+func TestResolveLockLoggerBatchesEntries(t *testing.T) {
+	restoreConfig := overrideResolveLockLogConfig(2, time.Hour, 16)
+	defer restoreConfig()
+
+	core, observedLogs := observer.New(zap.InfoLevel)
+	restoreLogger := log.ReplaceGlobals(zap.New(core), nil)
+	defer restoreLogger()
+
+	lockResolver := NewLockResolver(nil)
+	t.Cleanup(lockResolver.Close)
+	lockResolver.saveResolved(1, TxnStatus{commitTS: 10})
+	lockResolver.saveResolved(2, TxnStatus{action: kvrpcpb.Action_NoAction})
+
+	bo := retry.NewBackoffer(context.Background(), asyncResolveLockMaxBackoff)
+	locks := []*Lock{
+		{
+			Key:      []byte("k1"),
+			Primary:  []byte("k1"),
+			TxnID:    1,
+			TxnSize:  1,
+			LockType: kvrpcpb.Op_Put,
+		},
+		{
+			Key:             []byte("k2"),
+			Primary:         []byte("k2"),
+			TxnID:           2,
+			LockForUpdateTS: 20,
+			LockType:        kvrpcpb.Op_PessimisticLock,
+		},
+	}
+
+	_, err := lockResolver.ResolveLocksWithOpts(bo, ResolveLocksOptions{
+		CallerStartTS: 123,
+		Locks:         locks,
+		Lite:          true,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(observedLogs.FilterMessage("txn resolve locks").AllUntimed()) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	entries := observedLogs.FilterMessage("txn resolve locks").AllUntimed()
+	require.Len(t, entries, 1)
+
+	fields := entries[0].ContextMap()
+	require.Equal(t, int64(2), fields["count"])
+
+	resolvedLocks, ok := fields["resolve"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, resolvedLocks, 2)
+
+	resolveLockEntry, ok := resolvedLocks[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "Put", resolveLockEntry["resolveType"])
+	require.Equal(t, "commit", resolveLockEntry["action"])
+	require.Equal(t, uint64(1), resolveLockEntry["txnStartTS"])
+	require.Equal(t, uint64(10), resolveLockEntry["commitTS"])
+	require.Equal(t, false, resolveLockEntry["regionResolve"])
+	require.Equal(t, true, resolveLockEntry["resolvedByCheckTxnStatus"])
+
+	resolvePessimisticLockEntry, ok := resolvedLocks[1].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "PessimisticLock", resolvePessimisticLockEntry["resolveType"])
+	require.Equal(t, "rollback", resolvePessimisticLockEntry["action"])
+	require.Equal(t, uint64(2), resolvePessimisticLockEntry["txnStartTS"])
+	require.Equal(t, uint64(20), resolvePessimisticLockEntry["forUpdateTS"])
+	require.Equal(t, false, resolvePessimisticLockEntry["regionResolve"])
+	require.Equal(t, true, resolvePessimisticLockEntry["resolvedByCheckTxnStatus"])
+}
+
+func TestResolveLockLoggerReportsMissedEntries(t *testing.T) {
+	restoreConfig := overrideResolveLockLogConfig(20, 10*time.Millisecond, 1)
+	defer restoreConfig()
+
+	core, observedLogs := observer.New(zap.InfoLevel)
+	restoreLogger := log.ReplaceGlobals(zap.New(core), nil)
+	defer restoreLogger()
+
+	lockResolver := NewLockResolver(nil)
+	t.Cleanup(lockResolver.Close)
+
+	// exhaust asyncLogRunning to make sure `recordResolveLockLogEntry` the background loop will not consume.
+	lockResolver.asyncLogRunning.Do(func() {})
+	lockResolver.recordResolveLockLogEntry(resolveLockLogEntry{
+		resolveType: "Put",
+		lock: Lock{
+			Key:     []byte("k1"),
+			Primary: []byte("k1"),
+			TxnID:   1,
+		},
+		action:     "commit",
+		txnStartTS: 1,
+	})
+	lockResolver.recordResolveLockLogEntry(resolveLockLogEntry{
+		resolveType: "Pessimistic",
+		lock: Lock{
+			Key:     []byte("k2"),
+			Primary: []byte("k2"),
+			TxnID:   2,
+		},
+		action:     "commit",
+		txnStartTS: 2,
+	})
+
+	go lockResolver.collectResolveLockLogsLoop()
+
+	require.Eventually(t, func() bool {
+		return len(observedLogs.FilterMessage("missed resolve lock logs due to log channel full, some resolve lock operations may not be logged").AllUntimed()) == 1 &&
+			len(observedLogs.FilterMessage("txn resolve locks").AllUntimed()) == 1
+	}, time.Second, 100*time.Millisecond)
+
+	missedEntries := observedLogs.FilterMessage("missed resolve lock logs due to log channel full, some resolve lock operations may not be logged").AllUntimed()
+	require.Len(t, missedEntries, 1)
+	require.Equal(t, uint64(1), missedEntries[0].ContextMap()["missed"])
+
+	logEntries := observedLogs.FilterMessage("txn resolve locks").AllUntimed()
+	require.Len(t, logEntries, 1)
+	require.Equal(t, int64(1), logEntries[0].ContextMap()["count"])
+}
+
+func overrideResolveLockLogConfig(batchSize int, flushInterval time.Duration, channelSize int) func() {
+	oldBatchSize := resolveLockLogBatchSize
+	oldFlushInterval := resolveLockLogFlushInterval
+	oldChannelSize := resolveLockLogChannelSize
+	resolveLockLogBatchSize = batchSize
+	resolveLockLogFlushInterval = flushInterval
+	resolveLockLogChannelSize = channelSize
+	return func() {
+		resolveLockLogBatchSize = oldBatchSize
+		resolveLockLogFlushInterval = oldFlushInterval
+		resolveLockLogChannelSize = oldChannelSize
+	}
 }


### PR DESCRIPTION
This PR follows up #1901 by improving how resolve-lock related information is logged in `LockResolver`.

Instead of emitting one log line for every `resolveLock` / `resolvePessimisticLock` call, this change introduces an asynchronous batched logger inside `LockResolver`. The resolve path only records structured log entries and sends them to a background goroutine, which reduces log spam while still preserving per-lock details.

### What changed

- add a background log collector to `LockResolver`
- collect structured log entries for both `resolveLock` and `resolvePessimisticLock`
- emit a single aggregated `txn resolve locks` log for a batch of resolved locks
- keep lock-specific fields in each entry, including:
  - lock info
  - resolve type
  - action
  - txn start TS
  - commit TS / forUpdateTS
  - region ID
  - region-level resolve flag
  - whether the lock was already resolved by `CheckTxnStatus`
- flush logs when the batch reaches 20 entries or after the flush interval
- avoid blocking the foreground resolve path when the log channel is full; instead, count dropped entries and report them in a warning log on the next flush

### Tests

- add unit tests for batched resolve-lock logging
- add unit tests for dropped-log reporting when the async log channel is full
- update integration tests to close temporary `LockResolver` instances explicitly, so background logging goroutines are cleaned up correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup for lock resolver instances to prevent leaks

* **Improvements**
  * Implemented asynchronous batched logging for lock resolution operations with buffering and overflow protection
  * Added structured logging with detailed metadata (transaction timestamps, region IDs) for lock resolution events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->