### PR TITLE
tikv: keep txn safe point updater interval fixed

### DIFF
--- a/tikv/kv.go
+++ b/tikv/kv.go
@@ -428,17 +428,17 @@ func (s *KVStore) runTxnSafePointUpdater() {
 	if _, e := util.EvalFailpoint("noBuiltInTxnSafePointUpdater"); e == nil {
 		return
 	}
-	d := pollTxnSafePointInterval
 	for {
 		select {
-		case now := <-time.After(d):
+		case now := <-time.After(pollTxnSafePointInterval):
 			txnSafePoint, err := s.loadTxnSafePoint(context.Background())
-			if err == nil {
-				s.UpdateTxnSafePointCache(txnSafePoint, now)
-				d = pollTxnSafePointInterval
-			} else {
-				d = pollTxnSafePointQuickRepeatInterval
+			if err != nil {
+				// Intentionally ignore the error here. loadTxnSafePoint already logs it,
+				// and the updater retries on the next fixed poll interval to avoid
+				// potentially adding unnecessary load to PD.
+				continue
 			}
+			s.UpdateTxnSafePointCache(txnSafePoint, now)
 		case <-s.ctx.Done():
 			return
 		}
@@ -456,9 +456,7 @@ func (s *KVStore) Begin(opts ...TxnOption) (txn *transaction.KVTxn, err error) {
 	if options.TxnScope == "" {
 		options.TxnScope = oracle.GlobalTxnScope
 	}
-	var (
-		startTS uint64
-	)
+	var startTS uint64
 	if options.StartTS != nil {
 		startTS = *options.StartTS
 	} else {

--- a/tikv/safepoint.go
+++ b/tikv/safepoint.go
@@ -58,10 +58,9 @@ const (
 	// Deprecated: All use this is no longer recommended and should be replaced by using the txn safe point.
 	GcSavedSafePoint = "/tidb/store/gcworker/saved_safe_point"
 
-	GcStateCacheInterval                = time.Second * 100
-	gcCPUTimeInaccuracyBound            = time.Second * 10
-	pollTxnSafePointInterval            = time.Second * 10
-	pollTxnSafePointQuickRepeatInterval = time.Second
+	GcStateCacheInterval     = time.Second * 100
+	gcCPUTimeInaccuracyBound = time.Second * 10
+	pollTxnSafePointInterval = time.Second * 10
 )
 
 // SafePointKV is used for a seamingless integration for mockTest and runtime.


### PR DESCRIPTION
## Summary

Remove the previous 1s quick retry behavior and keeping the txn safe point updater interval fixed at `pollTxnSafePointInterval` even after load failures to avoid potentially adding unnecessary load to PD.

## Test Plan

- `go test ./tikv -run '^$' -count=1`
- `git diff --check -- tikv/kv.go tikv/safepoint.go tikv/kv_test.go`
