### PR TITLE
internal/locate: disable replica read and stale-read feature in nextgen

### DIFF
--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -497,6 +497,9 @@ func (s *testSnapshotSuite) TestSnapshotCacheBypassMaxUint64() {
 }
 
 func (s *testSnapshotSuite) TestReplicaReadAdjuster() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	originAsyncEnable := config.GetGlobalConfig().EnableAsyncBatchGet
 	defer func() {
 		cfg := config.GetGlobalConfig()

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -479,6 +479,7 @@ func (s *RegionRequestSender) SendReqAsync(
 		cb.Invoke(re, err)
 		return
 	}
+	disableReadFeaturesForNextGen(req)
 	if err := s.validateReadTS(bo.GetCtx(), req); err != nil {
 		logutil.Logger(bo.GetCtx()).Error("validate read ts failed for request", zap.Stringer("reqType", req.Type), zap.Stringer("req", req.Req.(fmt.Stringer)), zap.Stringer("context", &req.Context), zap.Stack("stack"), zap.Error(err))
 		cb.Invoke(nil, err)
@@ -1502,6 +1503,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		return
 	}
 
+	disableReadFeaturesForNextGen(req)
 	if err = s.validateReadTS(bo.GetCtx(), req); err != nil {
 		logutil.Logger(bo.GetCtx()).Error("validate read ts failed for request", zap.Stringer("reqType", req.Type), zap.Stringer("req", req.Req.(fmt.Stringer)), zap.Stringer("context", &req.Context), zap.Stack("stack"), zap.Error(err))
 		return nil, nil, 0, err

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -375,6 +375,9 @@ func AssertRPCCtxEqual(s *testRegionRequestToThreeStoresSuite, rpcCtx *RPCContex
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestLearnerReplicaSelector() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
 	s.NotNil(regionLoc)
@@ -429,6 +432,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestLearnerReplicaSelector() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestReplicaSelector() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
 	s.NotNil(regionLoc)
@@ -931,6 +937,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestSendReqWithReplicaSelector() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestLoadBasedReplicaRead() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
 	s.NotNil(regionLoc)
@@ -1005,6 +1014,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestLoadBasedReplicaRead() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadWithFlashbackInProgress() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
 	s.NotNil(regionLoc)
@@ -1045,6 +1057,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadWithFlashbackInProg
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestAccessFollowerAfter1TiKVDown() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	var leaderAddr string
 	s.regionRequestSender.client = &fnClient{fn: func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (response *tikvrpc.Response, err error) {
 		// Returns error when accesses non-leader.
@@ -1434,6 +1449,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestDoNotTryUnreachableLeader() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestPreferLeader() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	key := []byte("key")
 	bo := retry.NewBackoffer(context.Background(), -1)
 
@@ -1602,6 +1620,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestLeaderStuck() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestTiKVRecoveredFromDown() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	s.onClosed = func() { SetRegionCacheTTLWithJitter(600, 60) }
 	SetRegionCacheTTLWithJitter(2, 0)
 
@@ -1645,6 +1666,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestTiKVRecoveredFromDown() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestStaleReadMetrics() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	readMetric := func(col prometheus.Collector) int {
 		ch := make(chan prometheus.Metric, 1)
 		col.Collect(ch)

--- a/internal/locate/region_request3_test.go
+++ b/internal/locate/region_request3_test.go
@@ -1138,6 +1138,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestAccessFollowerAfter1TiKVDown()
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestSendReqFirstTimeout() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica-read or stale-read feature")
+	}
 	leaderAddr := ""
 	reqTargetAddrs := make(map[string]struct{})
 	s.regionRequestSender.Stats = NewRegionRequestRuntimeStats()
@@ -1227,6 +1230,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestSendReqFirstTimeout() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestReplicaReadFallbackToLeaderRegionError() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica-read or stale-read feature")
+	}
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
 	s.NotNil(regionLoc)
@@ -1304,6 +1310,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestLogging() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestRetryRequestSource() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica-read or stale-read feature")
+	}
 	leaderStore, _ := s.loadAndGetLeaderStore()
 	regionLoc, err := s.cache.LocateRegionByID(s.bo, s.regionID)
 	s.Nil(err)
@@ -1383,6 +1392,9 @@ func (s *testRegionRequestToThreeStoresSuite) TestRetryRequestSource() {
 }
 
 func (s *testRegionRequestToThreeStoresSuite) TestStaleReadTryFollowerAfterTimeout() {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support stale-read feature")
+	}
 	var (
 		leaderAddr  string
 		leaderLabel []*metapb.StoreLabel

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/internal/apicodec"
@@ -569,7 +570,12 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 	_, successZone, successReadType := s.extractResp(resp)
 	find := false
 	if leaderZone {
-		s.Equal(r.leaderSuccessReadType, successReadType, msg)
+		expectedReadType := r.leaderSuccessReadType
+		if config.NextGen && expectedReadType == SuccessFollowerRead {
+			// In nextgen, stale read never falls back to replica read, so it stays as stale read.
+			expectedReadType = SuccessStaleRead
+		}
+		s.Equal(expectedReadType, successReadType, msg)
 		for _, z := range r.leaderSuccessReplica {
 			if z == successZone {
 				find = true
@@ -577,7 +583,12 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 			}
 		}
 	} else {
-		s.Equal(r.followerSuccessReadType, successReadType)
+		expectedReadType := r.followerSuccessReadType
+		if config.NextGen && expectedReadType == SuccessFollowerRead {
+			// In nextgen, stale read never falls back to replica read, so it stays as stale read.
+			expectedReadType = SuccessStaleRead
+		}
+		s.Equal(expectedReadType, successReadType)
 		for _, z := range r.followerSuccessReplica {
 			if z == successZone {
 				find = true

--- a/internal/locate/region_request_state_test.go
+++ b/internal/locate/region_request_state_test.go
@@ -254,6 +254,9 @@ func (s *testRegionCacheStaleReadSuite) setTimeout(id uint64) { //nolint: unused
 }
 
 func TestRegionCacheStaleRead(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support stale-read feature")
+	}
 	originBoTiKVServerBusy := retry.BoTiKVServerBusy
 	defer func() {
 		retry.BoTiKVServerBusy = originBoTiKVServerBusy
@@ -262,6 +265,9 @@ func TestRegionCacheStaleRead(t *testing.T) {
 }
 
 func TestRegionCacheStaleReadUsingAsyncAPI(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support stale-read feature")
+	}
 	originBoTiKVServerBusy := retry.BoTiKVServerBusy
 	failpoint.Enable("tikvclient/useSendReqAsync", `return(true)`)
 	defer func() {
@@ -570,12 +576,7 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 	_, successZone, successReadType := s.extractResp(resp)
 	find := false
 	if leaderZone {
-		expectedReadType := r.leaderSuccessReadType
-		if config.NextGen && expectedReadType == SuccessFollowerRead {
-			// In nextgen, stale read never falls back to replica read, so it stays as stale read.
-			expectedReadType = SuccessStaleRead
-		}
-		s.Equal(expectedReadType, successReadType, msg)
+		s.Equal(r.leaderSuccessReadType, successReadType, msg)
 		for _, z := range r.leaderSuccessReplica {
 			if z == successZone {
 				find = true
@@ -583,12 +584,7 @@ func testStaleRead(s *testRegionCacheStaleReadSuite, r *RegionCacheTestCase, zon
 			}
 		}
 	} else {
-		expectedReadType := r.followerSuccessReadType
-		if config.NextGen && expectedReadType == SuccessFollowerRead {
-			// In nextgen, stale read never falls back to replica read, so it stays as stale read.
-			expectedReadType = SuccessStaleRead
-		}
-		s.Equal(expectedReadType, successReadType)
+		s.Equal(r.followerSuccessReadType, successReadType)
 		for _, z := range r.followerSuccessReplica {
 			if z == successZone {
 				find = true

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -1171,7 +1171,11 @@ func (s *testRegionRequestToSingleStoreSuite) TestRegionRequestValidateReadTS() 
 	testImpl(func() uint64 { return addTS(getTS(), +time.Minute) }, false, oracle.ErrFutureTSRead{})
 	testImpl(func() uint64 { return addTS(getTS(), +time.Minute) }, true, oracle.ErrFutureTSRead{})
 	testImpl(func() uint64 { return math.MaxUint64 }, false, nil)
-	testImpl(func() uint64 { return math.MaxUint64 }, true, oracle.ErrLatestStaleRead{})
+	if config.NextGen {
+		testImpl(func() uint64 { return math.MaxUint64 }, true, nil)
+	} else {
+		testImpl(func() uint64 { return math.MaxUint64 }, true, oracle.ErrLatestStaleRead{})
+	}
 }
 
 type noCauseError struct {

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -159,7 +159,9 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 		idleTarget := mixedStrategy.next(s)
 		if idleTarget != nil {
 			s.target = idleTarget
-			req.ReplicaRead = true
+			if !config.NextGen {
+				req.ReplicaRead = true
+			}
 		} else {
 			// No threshold if all peers are too busy, remove busy threshold and still use leader.
 			s.busyThreshold = 0
@@ -173,7 +175,9 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 	mixedStrategy := ReplicaSelectMixedStrategy{leaderIdx: leaderIdx, leaderOnly: s.option.leaderOnly}
 	s.target = mixedStrategy.next(s)
 	if s.target != nil && s.isReadOnlyReq && s.replicas[leaderIdx].hasFlag(deadlineErrUsingConfTimeoutFlag) {
-		req.ReplicaRead = true
+		if !config.NextGen {
+			req.ReplicaRead = true
+		}
 		req.StaleRead = false
 	}
 }

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -42,6 +42,17 @@ type replicaSelector struct {
 	regionInvalidatedForRetry bool // set when region is hard-invalidated but this selector should still retry on leader
 }
 
+// disableReadFeaturesForNextGen disables replica-read and stale-read feature
+// flags for nextgen while keeping the request read TS unchanged.
+func disableReadFeaturesForNextGen(req *tikvrpc.Request) {
+	if req == nil || !config.NextGen {
+		return
+	}
+	req.StaleRead = false
+	req.SetReplicaReadType(kv.ReplicaReadLeader)
+	req.BusyThresholdMs = 0
+}
+
 func newReplicaSelector(
 	regionCache *RegionCache, regionID RegionVerID, req *tikvrpc.Request, opts ...StoreSelectorOption,
 ) (*replicaSelector, error) {
@@ -54,27 +65,9 @@ func newReplicaSelector(
 	for _, op := range opts {
 		op(&option)
 	}
+	disableReadFeaturesForNextGen(req)
 	if req.ReplicaReadType == kv.ReplicaReadPreferLeader {
 		WithPerferLeader()(&option)
-	}
-	if config.NextGen && !req.StaleRead {
-		// NextGen does not support replica read (non-stale-read follower read). Force leader-only.
-		req.SetReplicaReadType(kv.ReplicaReadLeader)
-		req.BusyThresholdMs = 0
-		return &replicaSelector{
-			baseReplicaSelector: baseReplicaSelector{
-				regionCache:   regionCache,
-				region:        cachedRegion,
-				replicas:      replicas,
-				busyThreshold: 0,
-			},
-			replicaReadType: kv.ReplicaReadLeader,
-			isStaleRead:     req.StaleRead,
-			isReadOnlyReq:   isReadReq(req.Type),
-			option:          option,
-			target:          nil,
-			attempts:        0,
-		}, nil
 	}
 	return &replicaSelector{
 		baseReplicaSelector: baseReplicaSelector{
@@ -166,9 +159,7 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 		idleTarget := mixedStrategy.next(s)
 		if idleTarget != nil {
 			s.target = idleTarget
-			if !config.NextGen {
-				req.ReplicaRead = true
-			}
+			req.ReplicaRead = true
 		} else {
 			// No threshold if all peers are too busy, remove busy threshold and still use leader.
 			s.busyThreshold = 0
@@ -182,19 +173,12 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 	mixedStrategy := ReplicaSelectMixedStrategy{leaderIdx: leaderIdx, leaderOnly: s.option.leaderOnly}
 	s.target = mixedStrategy.next(s)
 	if s.target != nil && s.isReadOnlyReq && s.replicas[leaderIdx].hasFlag(deadlineErrUsingConfTimeoutFlag) {
-		if !config.NextGen {
-			req.ReplicaRead = true
-			req.StaleRead = false
-		}
+		req.ReplicaRead = true
+		req.StaleRead = false
 	}
 }
 
 func (s *replicaSelector) nextForReplicaReadMixed(req *tikvrpc.Request) {
-	if config.NextGen && !s.isStaleRead {
-		// NextGen does not support replica read. Fallback to leader-only selection.
-		s.nextForReplicaReadLeader(req)
-		return
-	}
 	leaderIdx := s.region.getStore().workTiKVIdx
 	if s.isStaleRead && s.attempts == 2 {
 		// For stale read second retry, try leader by leader read.
@@ -226,11 +210,6 @@ func (s *replicaSelector) nextForReplicaReadMixed(req *tikvrpc.Request) {
 					// use replica read.
 					isStaleRead = false
 				}
-			}
-			if config.NextGen {
-				// In nextgen, replica read is not supported, so stale read should never
-				// fall back to replica read.
-				isStaleRead = true
 			}
 			if isStaleRead {
 				req.StaleRead = true

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pkg/errors"
+	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	"github.com/tikv/client-go/v2/internal/client"
 	"github.com/tikv/client-go/v2/kv"
@@ -55,6 +56,25 @@ func newReplicaSelector(
 	}
 	if req.ReplicaReadType == kv.ReplicaReadPreferLeader {
 		WithPerferLeader()(&option)
+	}
+	if config.NextGen && !req.StaleRead {
+		// NextGen does not support replica read (non-stale-read follower read). Force leader-only.
+		req.SetReplicaReadType(kv.ReplicaReadLeader)
+		req.BusyThresholdMs = 0
+		return &replicaSelector{
+			baseReplicaSelector: baseReplicaSelector{
+				regionCache:   regionCache,
+				region:        cachedRegion,
+				replicas:      replicas,
+				busyThreshold: 0,
+			},
+			replicaReadType: kv.ReplicaReadLeader,
+			isStaleRead:     req.StaleRead,
+			isReadOnlyReq:   isReadReq(req.Type),
+			option:          option,
+			target:          nil,
+			attempts:        0,
+		}, nil
 	}
 	return &replicaSelector{
 		baseReplicaSelector: baseReplicaSelector{
@@ -146,7 +166,9 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 		idleTarget := mixedStrategy.next(s)
 		if idleTarget != nil {
 			s.target = idleTarget
-			req.ReplicaRead = true
+			if !config.NextGen {
+				req.ReplicaRead = true
+			}
 		} else {
 			// No threshold if all peers are too busy, remove busy threshold and still use leader.
 			s.busyThreshold = 0
@@ -160,12 +182,19 @@ func (s *replicaSelector) nextForReplicaReadLeader(req *tikvrpc.Request) {
 	mixedStrategy := ReplicaSelectMixedStrategy{leaderIdx: leaderIdx, leaderOnly: s.option.leaderOnly}
 	s.target = mixedStrategy.next(s)
 	if s.target != nil && s.isReadOnlyReq && s.replicas[leaderIdx].hasFlag(deadlineErrUsingConfTimeoutFlag) {
-		req.ReplicaRead = true
-		req.StaleRead = false
+		if !config.NextGen {
+			req.ReplicaRead = true
+			req.StaleRead = false
+		}
 	}
 }
 
 func (s *replicaSelector) nextForReplicaReadMixed(req *tikvrpc.Request) {
+	if config.NextGen && !s.isStaleRead {
+		// NextGen does not support replica read. Fallback to leader-only selection.
+		s.nextForReplicaReadLeader(req)
+		return
+	}
 	leaderIdx := s.region.getStore().workTiKVIdx
 	if s.isStaleRead && s.attempts == 2 {
 		// For stale read second retry, try leader by leader read.
@@ -197,6 +226,11 @@ func (s *replicaSelector) nextForReplicaReadMixed(req *tikvrpc.Request) {
 					// use replica read.
 					isStaleRead = false
 				}
+			}
+			if config.NextGen {
+				// In nextgen, replica read is not supported, so stale read should never
+				// fall back to replica read.
+				isStaleRead = true
 			}
 			if isStaleRead {
 				req.StaleRead = true

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -205,6 +205,21 @@ func TestNextGenReadFeaturesDisabled(t *testing.T) {
 	s.Nil(err)
 	s.NotNil(ctx)
 	s.Equal(s.leaderPeer, ctx.Peer.Id)
+
+	// Configurable-timeout retry on the leader should not flip the request back to replica-read in nextgen.
+	req = tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("a")})
+	req.ReplicaReadType = kv.ReplicaReadLeader
+	region, err = s.cache.LocateKey(s.bo, []byte("a"))
+	s.Nil(err)
+	selector, err = newReplicaSelector(s.cache, region.Region, req)
+	s.Nil(err)
+	leaderIdx := selector.region.getStore().workTiKVIdx
+	selector.replicas[leaderIdx].addFlag(deadlineErrUsingConfTimeoutFlag)
+	ctx, err = selector.next(s.bo, req)
+	s.Nil(err)
+	s.NotNil(ctx)
+	s.False(req.ReplicaRead)
+	s.False(req.StaleRead)
 }
 
 func TestReplicaSelectorCalculateScore(t *testing.T) {

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -148,6 +148,36 @@ func TestReplicaSelectorBasic(t *testing.T) {
 	s.Nil(ctx)
 }
 
+func TestNextGenReplicaReadDisabled(t *testing.T) {
+	if !config.NextGen {
+		t.Skip("only runs under NextGen")
+	}
+	s := new(testReplicaSelectorSuite)
+	s.SetupTest(t)
+	defer s.TearDownTest()
+
+	// Even when the request is created with follower read, NextGen should force leader-only.
+	for _, readType := range []kv.ReplicaReadType{kv.ReplicaReadFollower, kv.ReplicaReadMixed, kv.ReplicaReadLearner, kv.ReplicaReadPreferLeader} {
+		req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("a")}, readType, nil, kvrpcpb.Context{})
+		req.BusyThresholdMs = 100 // set a non-zero busy threshold to ensure it's cleared
+		region, err := s.cache.LocateKey(s.bo, []byte("a"))
+		s.Nil(err)
+		selector, err := newReplicaSelector(s.cache, region.Region, req)
+		s.Nil(err)
+		s.Equal(kv.ReplicaReadLeader, selector.replicaReadType)
+		s.Equal(time.Duration(0), selector.busyThreshold)
+		s.Equal(kv.ReplicaReadLeader, req.ReplicaReadType)
+		s.False(req.ReplicaRead)
+		s.Equal(uint32(0), req.BusyThresholdMs)
+
+		ctx, err := selector.next(s.bo, req)
+		s.Nil(err)
+		s.NotNil(ctx)
+		s.Equal(s.leaderPeer, ctx.Peer.Id)
+		s.False(req.ReplicaRead)
+	}
+}
+
 func TestReplicaSelectorCalculateScore(t *testing.T) {
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
@@ -324,6 +354,9 @@ func TestReplicaReadAccessPathByCaseUsingAsyncAPI(t *testing.T) {
 }
 
 func testReplicaReadAccessPathByCase(s *testReplicaSelectorSuite) {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	fakeEpochNotMatch := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}} // fake region error, cause by no replica is available.
 	ca := replicaSelectorAccessPathCase{
 		reqType:   tikvrpc.CmdGet,
@@ -763,6 +796,9 @@ func TestReplicaReadAccessPathByCase2UsingAsyncAPI(t *testing.T) {
 }
 
 func testReplicaReadAccessPathByCase2(s *testReplicaSelectorSuite) {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	fakeEpochNotMatch := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}}
 	// Following cases are found by other test, careful.
 	ca := replicaSelectorAccessPathCase{
@@ -1042,6 +1078,9 @@ func TestReplicaReadAccessPathByBasicCaseUsingAsyncAPI(t *testing.T) {
 }
 
 func testReplicaReadAccessPathByBasicCase(s *testReplicaSelectorSuite) {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	retryableErrors := []RegionErrorType{ServerIsBusyErr, ServerIsBusyWithEstimatedWaitMsErr, StaleCommandErr, MaxTimestampNotSyncedErr, ProposalInMergingModeErr, ReadIndexNotReadyErr, RegionNotInitializedErr, DiskFullErr}
 	noRetryErrors := []RegionErrorType{RegionNotFoundErr, KeyNotInRegionErr, EpochNotMatchErr, StoreNotMatchErr, RaftEntryTooLargeErr, RecoveryInProgressErr, FlashbackNotPreparedErr, IsWitnessErr, MismatchPeerIdErr, BucketVersionNotMatchErr}
 	for _, reqType := range []tikvrpc.CmdType{tikvrpc.CmdGet, tikvrpc.CmdPrewrite} {
@@ -1546,6 +1585,9 @@ func TestReplicaReadAccessPathByFollowerCaseUsingAsyncAPI(t *testing.T) {
 }
 
 func testReplicaReadAccessPathByFollowerCase(s *testReplicaSelectorSuite) {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	fakeEpochNotMatch := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}}
 	ca := replicaSelectorAccessPathCase{
 		reqType:   tikvrpc.CmdGet,
@@ -1661,6 +1703,9 @@ func TestReplicaReadAccessPathByMixedAndPreferLeaderCaseUsingAsyncAPI(t *testing
 }
 
 func testReplicaReadAccessPathByMixedAndPreferLeaderCase(s *testReplicaSelectorSuite) {
+	if config.NextGen {
+		s.T().Skip("NextGen does not support replica read")
+	}
 	fakeEpochNotMatch := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}}
 	var ca replicaSelectorAccessPathCase
 	// since leader in store1, so ReplicaReadMixed and ReplicaReadPreferLeader will have the same access path.
@@ -1909,6 +1954,10 @@ func testReplicaReadAccessPathByMixedAndPreferLeaderCase(s *testReplicaSelectorS
 }
 
 func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
+	if config.NextGen {
+		// In nextgen, stale read never falls back to replica read, so access paths differ.
+		t.Skip("NextGen does not support replica read")
+	}
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer s.TearDownTest()
@@ -2257,6 +2306,9 @@ func TestReplicaReadAccessPathByStaleReadCase(t *testing.T) {
 }
 
 func TestReplicaReadAccessPathByTryIdleReplicaCase(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support replica read")
+	}
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer s.TearDownTest()
@@ -2368,6 +2420,9 @@ func TestReplicaReadAccessPathByTryIdleReplicaCase(t *testing.T) {
 }
 
 func TestReplicaReadAccessPathByFlashbackInProgressCase(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support replica read")
+	}
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer s.TearDownTest()
@@ -2629,6 +2684,9 @@ func TestReplicaReadAccessPathByProxyCase(t *testing.T) {
 }
 
 func TestReplicaReadAccessPathByLearnerCase(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support replica read")
+	}
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer s.TearDownTest()
@@ -2660,6 +2718,9 @@ func TestReplicaReadAccessPathByLearnerCase(t *testing.T) {
 }
 
 func TestReplicaReadAvoidSlowStore(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support replica read")
+	}
 	s := new(testReplicaSelectorSuite)
 	s.SetupTest(t)
 	defer s.TearDownTest()
@@ -3296,6 +3357,9 @@ func (s *testReplicaSelectorSuite) getRegion() *Region {
 }
 
 func TestTiKVClientReadTimeout(t *testing.T) {
+	if config.NextGen {
+		t.Skip("NextGen does not support replica read")
+	}
 	if israce.RaceEnabled {
 		t.Skip("the test run with race will failed, so skip it")
 	}

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -129,10 +129,20 @@ func TestReplicaSelectorBasic(t *testing.T) {
 	selector, err = newReplicaSelector(s.cache, rc.VerID(), req)
 	s.Nil(err)
 	s.NotNil(selector)
-	for _, reqSource := range []string{"leader", "follower", "follower", "unknown"} {
-		_, err := selector.next(s.bo, req)
-		s.Nil(err)
-		s.Equal(reqSource, selector.replicaType())
+	if config.NextGen {
+		s.False(req.StaleRead)
+		s.Equal(kv.ReplicaReadLeader, req.ReplicaReadType)
+		for i := 0; i < 4; i++ {
+			_, err := selector.next(s.bo, req)
+			s.Nil(err)
+			s.Equal("leader", selector.replicaType())
+		}
+	} else {
+		for _, reqSource := range []string{"leader", "follower", "follower", "unknown"} {
+			_, err := selector.next(s.bo, req)
+			s.Nil(err)
+			s.Equal(reqSource, selector.replicaType())
+		}
 	}
 
 	rc = s.getRegion()
@@ -148,7 +158,7 @@ func TestReplicaSelectorBasic(t *testing.T) {
 	s.Nil(ctx)
 }
 
-func TestNextGenReplicaReadDisabled(t *testing.T) {
+func TestNextGenReadFeaturesDisabled(t *testing.T) {
 	if !config.NextGen {
 		t.Skip("only runs under NextGen")
 	}
@@ -156,7 +166,7 @@ func TestNextGenReplicaReadDisabled(t *testing.T) {
 	s.SetupTest(t)
 	defer s.TearDownTest()
 
-	// Even when the request is created with follower read, NextGen should force leader-only.
+	// Even when the request is created with replica-read mode, NextGen should force leader-only.
 	for _, readType := range []kv.ReplicaReadType{kv.ReplicaReadFollower, kv.ReplicaReadMixed, kv.ReplicaReadLearner, kv.ReplicaReadPreferLeader} {
 		req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("a")}, readType, nil, kvrpcpb.Context{})
 		req.BusyThresholdMs = 100 // set a non-zero busy threshold to ensure it's cleared
@@ -176,6 +186,25 @@ func TestNextGenReplicaReadDisabled(t *testing.T) {
 		s.Equal(s.leaderPeer, ctx.Peer.Id)
 		s.False(req.ReplicaRead)
 	}
+
+	// Stale-read feature should also be downgraded to ordinary leader read.
+	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("a")}, kv.ReplicaReadMixed, nil, kvrpcpb.Context{})
+	req.EnableStaleWithMixedReplicaRead()
+	req.BusyThresholdMs = 100
+	region, err := s.cache.LocateKey(s.bo, []byte("a"))
+	s.Nil(err)
+	selector, err := newReplicaSelector(s.cache, region.Region, req)
+	s.Nil(err)
+	s.False(req.StaleRead)
+	s.Equal(kv.ReplicaReadLeader, selector.replicaReadType)
+	s.Equal(time.Duration(0), selector.busyThreshold)
+	s.Equal(kv.ReplicaReadLeader, req.ReplicaReadType)
+	s.False(req.ReplicaRead)
+	s.Equal(uint32(0), req.BusyThresholdMs)
+	ctx, err := selector.next(s.bo, req)
+	s.Nil(err)
+	s.NotNil(ctx)
+	s.Equal(s.leaderPeer, ctx.Peer.Id)
 }
 
 func TestReplicaSelectorCalculateScore(t *testing.T) {
@@ -273,7 +302,11 @@ func TestCanFastRetry(t *testing.T) {
 		_, err = selector.next(s.bo, req)
 		s.Nil(err)
 		selector.canFastRetry()
-		s.True(selector.canFastRetry())
+		if config.NextGen {
+			s.False(selector.canFastRetry())
+		} else {
+			s.True(selector.canFastRetry())
+		}
 	}
 
 	// Test for leader read.


### PR DESCRIPTION
### What is changed and how it works?

Disable the `replica read` feature and the `stale-read feature` in nextgen in `client-go`.

This change does **not** forbid ordinary reads that happen to use an older read TS. It only disables the feature flags / request modes that enable replica-read and stale-read behavior in `client-go`.

- normalize TiKV requests before validation and invariant capture in nextgen:
  - clear `req.StaleRead`
  - force `ReplicaReadType=Leader`
  - clear `BusyThresholdMs`
- keep the request's read TS unchanged, so ordinary old-TS reads still work as ordinary leader reads
- normalize requests again in `newReplicaSelector` so direct callers and tests observe the same behavior
- add / update nextgen tests to verify both replica-read mode and stale-read feature are disabled
- skip stale-read / replica-read specific tests under nextgen where the feature is no longer supported

### Related PRs

- TiDB follow-up to reject or warn on `tidb_replica_read` / stale-read feature in nextgen is planned separately and is not included in this PR.

### Check List

- Unit test
- Integration test

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * NextGen now enforces leader-only read semantics and disables replica-read and stale-read behaviors.

* **Tests**
  * Replica-read and stale-read tests updated to skip under NextGen.
  * Added a verification test asserting NextGen downgrades read requests to leader-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->