### PR TITLE
config: increase default RUScale from 1.40 to 2.10

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -145,7 +145,7 @@ type RUV2TiKVConfig struct {
 // Keep RUScale and the per-counter weights in sync with that fitting procedure when updating them.
 func DefaultRUV2TiKVConfig() RUV2TiKVConfig {
 	return RUV2TiKVConfig{
-		RUScale: 1.40,
+		RUScale: 2.10,
 
 		TiKVKVEngineCacheMiss:             0.45975389,
 		ResourceManagerWriteCntTiKV:       0.09642181,

--- a/config/ruv2_test.go
+++ b/config/ruv2_test.go
@@ -52,7 +52,7 @@ func TestUpdateTiKVRUV2FromExecDetailsV2(t *testing.T) {
 		},
 	}, 0, 0)
 
-	require.InDelta(t, 38.64481334, ruDetails.TiKVRUV2(), 1e-9)
+	require.InDelta(t, 57.96722001, ruDetails.TiKVRUV2(), 1e-9)
 	drained := ruDetails.DrainRUV2()
 	require.NotNil(t, drained)
 	require.Equal(t, uint64(43), drained.KvEngineCacheMiss)


### PR DESCRIPTION
Increase the default RUScale factor from 1.40 to 2.10 (1.5x) to adjust TiKV-side RU v2 calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated RU v2 TiKV weight scaling to improve accuracy of resource consumption metrics and capacity planning. Recalibration ensures more precise performance tracking and billing calculations for database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->