### PR TITLE
txnkv: always fire commit callback for zero session id

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -39,6 +39,7 @@ package tikv_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	stderrs "errors"
 	"fmt"
 	"math"
@@ -63,6 +64,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnlock"
+	"github.com/tikv/client-go/v2/util"
 )
 
 var (
@@ -236,6 +238,38 @@ func (s *testCommitterSuite) TestCommitOnTiKVDiskFullOpt() {
 	err = txn.Commit(ctx)
 	s.NotNil(err)
 	s.Nil(failpoint.Disable("tikvclient/rpcAllowedOnAlmostFull"))
+}
+
+func (s *testCommitterSuite) TestCommitCallbackWithZeroSessionID() {
+	testCommit := func(key string) {
+		txn := s.begin()
+		err := txn.Set([]byte(key), []byte("v"))
+		s.Require().NoError(err)
+
+		var (
+			callbackCalled bool
+			info           transaction.TxnInfo
+			callbackErr    error
+		)
+		txn.SetCommitCallback(func(infoStr string, err error) {
+			callbackCalled = true
+			callbackErr = err
+			s.Require().NoError(json.Unmarshal([]byte(infoStr), &info))
+		})
+
+		ctx := context.WithValue(context.Background(), util.SessionID, uint64(0))
+		err = txn.Commit(ctx)
+		s.Require().NoError(err)
+		s.True(callbackCalled)
+		s.NoError(callbackErr)
+		s.Greater(info.CommitTS, uint64(0))
+		s.Equal(txn.GetCommitTS(), info.CommitTS)
+	}
+
+	testCommit("zero-session-id-with-latches")
+
+	s.store.ClearTxnLatches()
+	testCommit("zero-session-id-without-latches")
 }
 
 func (s *testCommitterSuite) TestPrewriteRollback() {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -758,9 +758,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	// transaction with pipelined memdb should also bypass latch.
 	if txn.store.TxnLatches() == nil || txn.IsPessimistic() || txn.IsPipelined() {
 		err = committer.execute(ctx)
-		if val == nil || sessionID > 0 {
-			txn.onCommitted(err)
-		}
+		txn.onCommitted(err)
 		logutil.Logger(ctx).Debug("[kv] txnLatches disabled, 2pc directly", zap.Error(err))
 		return err
 	}
@@ -779,9 +777,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 		return &tikverr.ErrWriteConflictInLatch{StartTS: txn.startTS}
 	}
 	err = committer.execute(ctx)
-	if val == nil || sessionID > 0 {
-		txn.onCommitted(err)
-	}
+	txn.onCommitted(err)
 	if err == nil {
 		lock.SetCommitTS(committer.commitTS)
 	}


### PR DESCRIPTION
Currently, the commit callback is called only if
* session_id is set, and session_id > 0
* session_id is not set

https://github.com/tikv/client-go/blob/2d8a6e6ec9f9593f0aba81d8f36c1b085a7d6347/txnkv/transaction/txn.go#L761-L763
And
https://github.com/tikv/client-go/blob/2d8a6e6ec9f9593f0aba81d8f36c1b085a7d6347/txnkv/transaction/txn.go#L782-L784

For all internal session, the session_id is 0, so internal sql can not get last_txn_info

There wasn't really a strong reason for the original restriction. It looks like it got added just as an offhand comment during code review:
https://github.com/pingcap/tidb/pull/19949#discussion_r486954059

This pr remove this restriction because in materialized view refresh, it is executed in internal session, while we want to get the commit_ts.