### PR TITLE
txn: reject unsupported shared lock transaction paths

### DIFF
--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -567,6 +567,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 	c.mutations = newMemBufferMutations(sizeHint, memBuf)
 	c.isPessimistic = txn.IsPessimistic()
 	filter := txn.kvFilter
+	primaryKeyIsSharedLock := false
 
 	var err error
 	var assertionError error
@@ -648,6 +649,9 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 		}
 		if op == kvrpcpb.Op_SharedLock {
 			sharedLockCnt++
+			if bytes.Equal(c.primaryKey, key) {
+				primaryKeyIsSharedLock = true
+			}
 		}
 		c.mutations.Push(op, isPessimistic, mustExist, mustNotExist, flags.HasNeedConstraintCheckInPrewrite(), it.Handle())
 		size += len(key) + len(value)
@@ -701,12 +705,12 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 
 	if c.mutations.Len() == 0 {
 		return nil
-	} else if len(c.primaryKey) == 0 && sharedLockCnt > 0 {
+	} else if primaryKeyIsSharedLock || len(c.primaryKey) == 0 && sharedLockCnt > 0 {
 		// A shared-locked key is not allowed to be the primary key for now. `LockKeys` already guarantees
 		// that (it's the only place that sets `flagKeyLockedInShareMode`). Here we just double check it.
 		// Only report error when there are shared locks - if all keys are CheckNotExists (delete-your-writes),
 		// we allow the transaction to continue and use the first key as primary via the primary() fallback.
-		msg := "no suitable primary key found for the transaction"
+		msg := "shared lock key cannot be used as transaction primary key"
 		logutil.BgLogger().Warn(msg,
 			zap.Uint64("session", c.sessionID),
 			zap.Int("keys", c.mutations.Len()),
@@ -1545,6 +1549,9 @@ func sendTxnHeartBeat(
 
 // checkAsyncCommit checks if async commit protocol is available for current transaction commit, true is returned if possible.
 func (c *twoPhaseCommitter) checkAsyncCommit() bool {
+	if c.hasSharedLocks {
+		return false
+	}
 	// Disable async commit in local transactions
 	if c.txn.GetScope() != oracle.GlobalTxnScope {
 		return false
@@ -1576,6 +1583,9 @@ func (c *twoPhaseCommitter) checkAsyncCommit() bool {
 
 // checkOnePC checks if 1PC protocol is available for current transaction.
 func (c *twoPhaseCommitter) checkOnePC() bool {
+	if c.hasSharedLocks {
+		return false
+	}
 	// Disable 1PC in local transactions
 	if c.txn.GetScope() != oracle.GlobalTxnScope {
 		return false
@@ -1755,6 +1765,10 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 
 	commitDetail := c.getDetail()
 	commitTSMayBeCalculated := false
+	if c.hasSharedLocks {
+		c.setAsyncCommit(false)
+		c.setOnePC(false)
+	}
 	if !c.txn.isPipelined && !c.hasSharedLocks {
 		// Check async commit is available or not.
 		if c.checkAsyncCommit() {

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -338,6 +338,11 @@ func (c CommitterProbe) CheckAsyncCommit() bool {
 	return c.checkAsyncCommit()
 }
 
+// CheckOnePC returns if 1PC is available.
+func (c CommitterProbe) CheckOnePC() bool {
+	return c.checkOnePC()
+}
+
 // GetOnePCCommitTS returns the commit ts of one pc.
 func (c CommitterProbe) GetOnePCCommitTS() uint64 {
 	return c.onePCCommitTS

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -677,7 +677,9 @@ func (txn *KVTxn) InitPipelinedMemDB() error {
 			var value []byte
 			var op kvrpcpb.Op
 
-			// TODO(slock): pipelined DML do not prewrite shared lock even when flags.HasLockedInShareMode() is true.
+			if flags.HasLockedInShareMode() {
+				return errors.New("shared lock is not supported in pipelined transaction")
+			}
 			if !it.HasValue() {
 				if !flags.HasLocked() {
 					continue
@@ -1351,7 +1353,13 @@ func (txn *KVTxn) collectAggressiveLockingStats(lockCtx *tikv.LockCtx, keys int,
 }
 
 func (txn *KVTxn) exitAggressiveLockingIfInapplicable(ctx context.Context, lockCtx *tikv.LockCtx, keys [][]byte) error {
-	if (len(keys) > 1 || lockCtx.InShareMode) && txn.IsInAggressiveLockingMode() {
+	if !txn.IsInAggressiveLockingMode() {
+		return nil
+	}
+	if lockCtx.InShareMode {
+		return errors.New("shared lock is not supported in aggressive/fair locking mode")
+	}
+	if len(keys) > 1 {
 		// Only allow fair locking if it only needs to lock one key. Considering that it's possible that a
 		// statement causes multiple calls to `LockKeys` (which means some keys may have been locked in fair
 		// locking mode), here we exit fair locking mode by calling DoneFairLocking instead of cancelling.
@@ -1427,6 +1435,9 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	if !txn.IsPessimistic() && txn.IsInAggressiveLockingMode() {
 		return errors.New("trying to perform aggressive locking in optimistic transaction")
 	}
+	if lockCtx.InShareMode && txn.IsPipelined() {
+		return errors.New("shared lock is not supported in pipelined transaction")
+	}
 
 	if lockCtx.InShareMode {
 		// create shared lock span in tracing.
@@ -1438,7 +1449,7 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 
 		// Shared lock in aggressive locking mode is not supported.
 		if txn.IsInAggressiveLockingMode() {
-			txn.DoneAggressiveLocking(ctx)
+			return errors.New("shared lock is not supported in aggressive/fair locking mode")
 		}
 	}
 

--- a/txnkv/transaction/txn_test.go
+++ b/txnkv/transaction/txn_test.go
@@ -100,12 +100,16 @@ type testTxn struct {
 }
 
 func newTestTxn(t *testing.T, startTS uint64) *testTxn {
+	return newTestTxnWithOptions(t, startTS, &TxnOptions{StartTS: &startTS})
+}
+
+func newTestTxnWithOptions(t *testing.T, startTS uint64, options *TxnOptions) *testTxn {
 	pd := &mockPDClient{}
 	cache := locate.NewTestRegionCache()
 	cache.SetPDClient(pd)
 	store := &mockStore{cache: cache}
 	snapshot := txnsnapshot.NewTiKVSnapshot(store, startTS, 0)
-	txn, err := NewTiKVTxn(store, snapshot, startTS, &TxnOptions{StartTS: &startTS})
+	txn, err := NewTiKVTxn(store, snapshot, startTS, options)
 	require.NoError(t, err)
 	return &testTxn{
 		KVTxn:    txn,
@@ -204,6 +208,45 @@ func TestLockKeys(t *testing.T) {
 		require.True(t, flags.HasLockedInShareMode())
 	})
 
+	t.Run("PessimisticSharedRejectsAggressiveLocking", func(t *testing.T) {
+		key1 := []byte("k1")
+		key2 := []byte("k2")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.store.client.onSend = handlePessimisticLock
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key2))
+
+		txn.StartAggressiveLocking()
+		lockCtx.InShareMode = true
+		err := txn.lockKeys(context.TODO(), lockCtx, nil, key1)
+		require.ErrorContains(t, err, "shared lock is not supported in aggressive/fair locking mode")
+		require.True(t, txn.IsInAggressiveLockingMode())
+		txn.CancelAggressiveLocking(context.Background())
+	})
+
+	t.Run("PessimisticSharedRejectsPipelinedTxn", func(t *testing.T) {
+		startTS := uint64(1)
+		key := []byte("k")
+		txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+			StartTS: &startTS,
+			PipelinedTxn: PipelinedTxnOptions{
+				Enable:                 true,
+				FlushConcurrency:       1,
+				ResolveLockConcurrency: 1,
+			},
+		})
+		txn.store.client.onSend = requireNoRequest
+		defer txn.pipelinedCancel()
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		lockCtx.InShareMode = true
+		err := txn.lockKeys(context.TODO(), lockCtx, nil, key)
+		require.ErrorContains(t, err, "shared lock is not supported in pipelined transaction")
+	})
+
 	t.Run("UpgradeSharedToExclusive", func(t *testing.T) {
 		key1 := []byte("k1")
 		key2 := []byte("k2")
@@ -243,5 +286,70 @@ func TestLockKeys(t *testing.T) {
 		case <-time.After(time.Second):
 			require.FailNow(t, "lockKeys holds rlock after returning error")
 		}
+	})
+}
+
+func TestSharedLockCommitterIncompatibilities(t *testing.T) {
+	t.Run("RejectSharedLockPrimaryKey", func(t *testing.T) {
+		key := []byte("shared-key")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.GetMemBuffer().UpdateFlags(key, kv.SetKeyLocked, kv.SetKeyLockedInShareMode)
+
+		committer, err := newTwoPhaseCommitter(txn.KVTxn, 1)
+		require.NoError(t, err)
+		committer.primaryKey = key
+		err = committer.initKeysAndMutations(context.Background())
+		require.ErrorContains(t, err, "shared lock key cannot be used as transaction primary key")
+	})
+
+	t.Run("DisableAsyncCommitAndOnePC", func(t *testing.T) {
+		startTS := uint64(1)
+		newGlobalTxn := func() *testTxn {
+			txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+				TxnScope: oracle.GlobalTxnScope,
+				StartTS:  &startTS,
+			})
+			txn.SetPessimistic(true)
+			txn.SetEnableAsyncCommit(true)
+			txn.SetEnable1PC(true)
+			return txn
+		}
+
+		plainTxn := newGlobalTxn()
+		plainTxn.GetMemBuffer().UpdateFlags([]byte("primary-key"), kv.SetKeyLocked)
+		plainCommitter, err := TxnProbe{KVTxn: plainTxn.KVTxn}.NewCommitter(1)
+		require.NoError(t, err)
+		require.True(t, plainCommitter.CheckAsyncCommit())
+		require.True(t, plainCommitter.CheckOnePC())
+
+		sharedTxn := newGlobalTxn()
+		sharedTxn.GetMemBuffer().UpdateFlags([]byte("primary-key"), kv.SetKeyLocked)
+		sharedTxn.GetMemBuffer().UpdateFlags([]byte("shared-key"), kv.SetKeyLocked, kv.SetKeyLockedInShareMode)
+		sharedCommitter, err := TxnProbe{KVTxn: sharedTxn.KVTxn}.NewCommitter(1)
+		require.NoError(t, err)
+		require.False(t, sharedCommitter.CheckAsyncCommit())
+		require.False(t, sharedCommitter.CheckOnePC())
+	})
+
+	t.Run("RejectPipelinedFlush", func(t *testing.T) {
+		startTS := uint64(1)
+		key := []byte("shared-key")
+		txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+			StartTS: &startTS,
+			PipelinedTxn: PipelinedTxnOptions{
+				Enable:                 true,
+				FlushConcurrency:       1,
+				ResolveLockConcurrency: 1,
+			},
+		})
+		defer txn.pipelinedCancel()
+		require.NoError(t, txn.GetMemBuffer().SetWithFlags(key, []byte("value"), kv.SetKeyLocked, kv.SetKeyLockedInShareMode))
+
+		flushed, err := txn.GetMemBuffer().Flush(true)
+		require.NoError(t, err)
+		require.True(t, flushed)
+		err = txn.GetMemBuffer().FlushWait()
+		require.ErrorContains(t, err, "shared lock is not supported in pipelined transaction")
 	})
 }


### PR DESCRIPTION
Issue Number: close #1955

Problem Summary:

Shared lock transactions should not enter commit or lock paths that are incompatible with shared locks. TiDB issue: https://github.com/pingcap/tidb/issues/66154

What is changed:

- Reject a shared-lock key if it is selected or pre-set as the transaction primary key.
- Keep async commit and 1PC disabled for transactions that contain shared locks.
- Reject shared-lock requests in aggressive/fair locking mode.
- Reject shared-lock use in pipelined transactions and pipelined flush.
- Add focused regression tests for the unsupported combinations.

Tests:

- `go test ./txnkv/transaction -run "TestLockKeys|TestSharedLockCommitterIncompatibilities"`
- `go test ./txnkv/transaction`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted certain lock configurations from using commit optimizations.
  * Prevented specific lock types from being designated as transaction primary keys.
  * Added validation to block lock mode conflicts in pipelined and aggressive locking contexts.

* **Tests**
  * Extended test coverage for transaction lock configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->