### PR TITLE
region_cache: return nil reason from GetTiFlashRPCContext in 8.5

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -81,6 +81,26 @@ const (
 // LabelFilter returns false means label doesn't match, and will ignore this store.
 type LabelFilter = func(labels []*metapb.StoreLabel) bool
 
+// TiFlashRPCContextUnavailableReason is the reason why GetTiFlashRPCContext returns a nil RPCContext.
+type TiFlashRPCContextUnavailableReason string
+
+const (
+	TiFlashRPCContextAvailable                       TiFlashRPCContextUnavailableReason = ""
+	TiFlashRPCContextUnavailableError				 TiFlashRPCContextUnavailableReason = "error"
+	TiFlashRPCContextUnavailableCachedRegionMissing  TiFlashRPCContextUnavailableReason = "cached_region_missing"
+	TiFlashRPCContextUnavailableNeedReloadOnAccess   TiFlashRPCContextUnavailableReason = "need_reload_on_access"
+	TiFlashRPCContextUnavailableTTLExpired           TiFlashRPCContextUnavailableReason = "ttl_expired"
+	TiFlashRPCContextUnavailableNoTiFlashAccessStore TiFlashRPCContextUnavailableReason = "no_tiflash_access_store"
+	TiFlashRPCContextUnavailableStoreAddrEmpty       TiFlashRPCContextUnavailableReason = "store_addr_empty"
+	TiFlashRPCContextUnavailableAllStoresFiltered    TiFlashRPCContextUnavailableReason = "all_tiflash_stores_filtered_by_label"
+	TiFlashRPCContextUnavailableAllStoresEpochStale  TiFlashRPCContextUnavailableReason = "all_tiflash_stores_epoch_mismatch"
+	TiFlashRPCContextUnavailableNoAvailableStore     TiFlashRPCContextUnavailableReason = "no_available_tiflash_store"
+)
+
+func (r TiFlashRPCContextUnavailableReason) String() string {
+	return string(r)
+}
+
 // LabelFilterOnlyTiFlashWriteNode will only select stores whose label contains: <engine, tiflash> and <engine_role, write>.
 // Only used for tiflash_compute node.
 var LabelFilterOnlyTiFlashWriteNode = func(labels []*metapb.StoreLabel) bool {
@@ -993,17 +1013,28 @@ func (c *RegionCache) GetAllValidTiFlashStores(id RegionVerID, currentStore *Sto
 	return allStores, nonPendingStores
 }
 
-// GetTiFlashRPCContext returns RPCContext for a region must access flash store. If it returns nil, the region
-// must be out of date and already dropped from cache or not flash store found.
+// GetTiFlashRPCContext returns RPCContext for a region must access flash store. If it returns nil, the returned
+// TiFlashRPCContextUnavailableReason explains why the region cannot access TiFlash.
 // `loadBalance` is an option. For batch cop, it is pointless and might cause try the failed store repeatly.
-func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, error) {
+func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, TiFlashRPCContextUnavailableReason, error) {
 
 	cachedRegion := c.GetCachedRegionWithRLock(id)
 	if !cachedRegion.isValid() {
-		return nil, nil
+		if cachedRegion == nil {
+			return nil, TiFlashRPCContextUnavailableCachedRegionMissing, nil
+		}
+		if cachedRegion.checkSyncFlags(needReloadOnAccess) {
+			return nil, TiFlashRPCContextUnavailableNeedReloadOnAccess, nil
+		}
+		return nil, TiFlashRPCContextUnavailableTTLExpired, nil
 	}
 
 	regionStore := cachedRegion.getStore()
+	accessStoreNum := regionStore.accessStoreNum(tiFlashOnly)
+	if accessStoreNum == 0 {
+		cachedRegion.invalidate(Other)
+		return nil, TiFlashRPCContextUnavailableNoTiFlashAccessStore, nil
+	}
 
 	// sIdx is for load balance of TiFlash store.
 	var sIdx int
@@ -1012,19 +1043,22 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 	} else {
 		sIdx = int(regionStore.workTiFlashIdx.Load())
 	}
-	for i := 0; i < regionStore.accessStoreNum(tiFlashOnly); i++ {
-		accessIdx := AccessIndex((sIdx + i) % regionStore.accessStoreNum(tiFlashOnly))
+	labelFilteredCount := 0
+	epochMismatchCount := 0
+	for i := 0; i < accessStoreNum; i++ {
+		accessIdx := AccessIndex((sIdx + i) % accessStoreNum)
 		storeIdx, store := regionStore.accessStore(tiFlashOnly, accessIdx)
 		if !labelFilter(store.labels) {
+			labelFilteredCount++
 			continue
 		}
 		addr, err := c.getStoreAddr(bo, cachedRegion, store)
 		if err != nil {
-			return nil, err
+			return nil, TiFlashRPCContextUnavailableError, err
 		}
 		if len(addr) == 0 {
 			cachedRegion.invalidate(StoreNotFound)
-			return nil, nil
+			return nil, TiFlashRPCContextUnavailableStoreAddrEmpty, nil
 		}
 		if store.getResolveState() == needCheck {
 			_, err := store.reResolve(c.stores, c.bg)
@@ -1035,6 +1069,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 		storeFailEpoch := atomic.LoadUint32(&store.epoch)
 		if storeFailEpoch != regionStore.storeEpochs[storeIdx] {
 			cachedRegion.invalidate(Other)
+			epochMismatchCount++
 			logutil.Logger(bo.GetCtx()).Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
 				zap.String("store", store.addr))
@@ -1051,11 +1086,17 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			Addr:       addr,
 			AccessMode: tiFlashOnly,
 			TiKVNum:    regionStore.accessStoreNum(tiKVOnly),
-		}, nil
+		}, TiFlashRPCContextAvailable, nil
 	}
 
 	cachedRegion.invalidate(Other)
-	return nil, nil
+	if labelFilteredCount == accessStoreNum {
+		return nil, TiFlashRPCContextUnavailableAllStoresFiltered, nil
+	}
+	if epochMismatchCount == accessStoreNum {
+		return nil, TiFlashRPCContextUnavailableAllStoresEpochStale, nil
+	}
+	return nil, TiFlashRPCContextUnavailableNoAvailableStore, nil
 }
 
 // KeyLocation is the region and range that a key is located.

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -577,7 +577,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	s.Nil(err)
 	s.Equal(loc.Region.id, s.region1)
-	ctx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+	ctx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 	s.Nil(err)
 	s.NotNil(ctx)
 	region := s.cache.GetCachedRegionWithRLock(loc.Region)
@@ -595,7 +595,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 		time.Sleep(1 * time.Second)
 		loc, err = s.cache.LocateKey(s.bo, []byte("a"))
 		s.Nil(err)
-		rpcCtx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 		s.Nil(err)
 		if rpcCtx != nil {
 			s.NotEqual(s.storeAddr(store3), rpcCtx.Addr, "should not access peer3 when it is down")
@@ -613,7 +613,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 		}
 		loc, err = s.cache.LocateKey(s.bo, []byte("a"))
 		s.Nil(err)
-		rpcCtx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 		s.Nil(err)
 		if rpcCtx != nil && rpcCtx.Addr == s.storeAddr(store3) {
 			break
@@ -1329,7 +1329,7 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash() {
 	s.Equal(lctx.Peer.Id, peer3)
 
 	// epoch-not-match on tiflash
-	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region, true, LabelFilterNoTiFlashWriteNode)
+	ctxTiFlash, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region, true, LabelFilterNoTiFlashWriteNode)
 	s.Nil(err)
 	s.Equal(ctxTiFlash.Peer.Id, s.peer1)
 	ctxTiFlash.Peer.Role = metapb.PeerRole_Learner

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -709,7 +709,8 @@ func (s *RegionRequestSender) getRPCContext(
 		return s.replicaSelector.next(bo, req)
 	case tikvrpc.TiFlash:
 		// Should ignore WN, because in disaggregated tiflash mode, TiDB will build rpcCtx itself.
-		return s.regionCache.GetTiFlashRPCContext(bo, regionID, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.regionCache.GetTiFlashRPCContext(bo, regionID, true, LabelFilterNoTiFlashWriteNode)
+		return rpcCtx, err
 	case tikvrpc.TiDB:
 		return &RPCContext{Addr: s.storeAddr}, nil
 	case tikvrpc.TiFlashCompute:

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -59,6 +59,22 @@ type RegionVerID = locate.RegionVerID
 // RegionCache caches Regions loaded from PD.
 type RegionCache = locate.RegionCache
 
+// TiFlashRPCContextUnavailableReason explains why GetTiFlashRPCContext returns a nil RPCContext.
+type TiFlashRPCContextUnavailableReason = locate.TiFlashRPCContextUnavailableReason
+
+const (
+	TiFlashRPCContextAvailable                       = locate.TiFlashRPCContextAvailable
+	TiFlashRPCContextUnavailableError				 = locate.TiFlashRPCContextUnavailableError
+	TiFlashRPCContextUnavailableCachedRegionMissing  = locate.TiFlashRPCContextUnavailableCachedRegionMissing
+	TiFlashRPCContextUnavailableNeedReloadOnAccess   = locate.TiFlashRPCContextUnavailableNeedReloadOnAccess
+	TiFlashRPCContextUnavailableTTLExpired           = locate.TiFlashRPCContextUnavailableTTLExpired
+	TiFlashRPCContextUnavailableNoTiFlashAccessStore = locate.TiFlashRPCContextUnavailableNoTiFlashAccessStore
+	TiFlashRPCContextUnavailableStoreAddrEmpty       = locate.TiFlashRPCContextUnavailableStoreAddrEmpty
+	TiFlashRPCContextUnavailableAllStoresFiltered    = locate.TiFlashRPCContextUnavailableAllStoresFiltered
+	TiFlashRPCContextUnavailableAllStoresEpochStale  = locate.TiFlashRPCContextUnavailableAllStoresEpochStale
+	TiFlashRPCContextUnavailableNoAvailableStore     = locate.TiFlashRPCContextUnavailableNoAvailableStore
+)
+
 // KeyLocation is the region and range that a key is located.
 type KeyLocation = locate.KeyLocation
 


### PR DESCRIPTION
Return a reason when GetTiFlashRPCContext returns nil to help callers know why the TiFlash RPC context is unavailable.