### PR TITLE
region_cache: return nil reason from GetTiFlashRPCContext

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -91,7 +91,7 @@ type TiFlashRPCContextUnavailableReason string
 
 const (
 	TiFlashRPCContextAvailable                       TiFlashRPCContextUnavailableReason = ""
-	TiFlashRPCContextUnavailableError				 TiFlashRPCContextUnavailableReason = "error"
+	TiFlashRPCContextUnavailableError                TiFlashRPCContextUnavailableReason = "error"
 	TiFlashRPCContextUnavailableCachedRegionMissing  TiFlashRPCContextUnavailableReason = "cached_region_missing"
 	TiFlashRPCContextUnavailableNeedReloadOnAccess   TiFlashRPCContextUnavailableReason = "need_reload_on_access"
 	TiFlashRPCContextUnavailableTTLExpired           TiFlashRPCContextUnavailableReason = "ttl_expired"

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -1113,12 +1113,9 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 	for i := 0; i < accessStoreNum; i++ {
 		accessIdx := AccessIndex((sIdx + i) % accessStoreNum)
 		storeIdx, store := regionStore.accessStore(tiFlashOnly, accessIdx)
+		peer := cachedRegion.meta.Peers[storeIdx]
 		storeIDs = append(storeIDs, store.storeID)
-		peerID := uint64(0)
-		if storeIdx < len(cachedRegion.meta.GetPeers()) {
-			peerID = cachedRegion.meta.GetPeers()[storeIdx].GetId()
-		}
-		peerIDs = append(peerIDs, peerID)
+		peerIDs = append(peerIDs, peer.GetId())
 		if !labelFilter(store.GetLabels()) {
 			labelFilteredCount++
 			continue
@@ -1128,7 +1125,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			return nil, TiFlashRPCContextUnavailableDetail{
 				Reason:   TiFlashRPCContextUnavailableError,
 				StoreIDs: []uint64{store.storeID},
-				PeerIDs:  []uint64{peerID},
+				PeerIDs:  []uint64{peer.GetId()},
 			}, err
 		}
 		if len(addr) == 0 {
@@ -1136,7 +1133,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			return nil, TiFlashRPCContextUnavailableDetail{
 				Reason:   TiFlashRPCContextUnavailableStoreAddrEmpty,
 				StoreIDs: []uint64{store.storeID},
-				PeerIDs:  []uint64{peerID},
+				PeerIDs:  []uint64{peer.GetId()},
 			}, nil
 		}
 		if store.getResolveState() == needCheck {
@@ -1144,7 +1141,6 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			tikverr.Log(err)
 		}
 		regionStore.workTiFlashIdx.Store(int32(accessIdx))
-		peer := cachedRegion.meta.Peers[storeIdx]
 		storeFailEpoch := atomic.LoadUint32(&store.epoch)
 		if storeFailEpoch != regionStore.storeEpochs[storeIdx] {
 			cachedRegion.invalidate(Other)

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -86,6 +86,26 @@ const (
 // LabelFilter returns false means label doesn't match, and will ignore this store.
 type LabelFilter = func(labels []*metapb.StoreLabel) bool
 
+// TiFlashRPCContextUnavailableReason is the reason why GetTiFlashRPCContext returns a nil RPCContext.
+type TiFlashRPCContextUnavailableReason string
+
+const (
+	TiFlashRPCContextAvailable                       TiFlashRPCContextUnavailableReason = ""
+	TiFlashRPCContextUnavailableError				 TiFlashRPCContextUnavailableReason = "error"
+	TiFlashRPCContextUnavailableCachedRegionMissing  TiFlashRPCContextUnavailableReason = "cached_region_missing"
+	TiFlashRPCContextUnavailableNeedReloadOnAccess   TiFlashRPCContextUnavailableReason = "need_reload_on_access"
+	TiFlashRPCContextUnavailableTTLExpired           TiFlashRPCContextUnavailableReason = "ttl_expired"
+	TiFlashRPCContextUnavailableNoTiFlashAccessStore TiFlashRPCContextUnavailableReason = "no_tiflash_access_store"
+	TiFlashRPCContextUnavailableStoreAddrEmpty       TiFlashRPCContextUnavailableReason = "store_addr_empty"
+	TiFlashRPCContextUnavailableAllStoresFiltered    TiFlashRPCContextUnavailableReason = "all_tiflash_stores_filtered_by_label"
+	TiFlashRPCContextUnavailableAllStoresEpochStale  TiFlashRPCContextUnavailableReason = "all_tiflash_stores_epoch_mismatch"
+	TiFlashRPCContextUnavailableNoAvailableStore     TiFlashRPCContextUnavailableReason = "no_available_tiflash_store"
+)
+
+func (r TiFlashRPCContextUnavailableReason) String() string {
+	return string(r)
+}
+
 // LabelFilterOnlyTiFlashWriteNode will only select stores whose label contains: <engine, tiflash> and <engine_role, write>.
 // Only used for tiflash_compute node.
 var LabelFilterOnlyTiFlashWriteNode = func(labels []*metapb.StoreLabel) bool {
@@ -1046,17 +1066,28 @@ func (c *RegionCache) GetAllValidTiFlashStores(id RegionVerID, currentStore *Sto
 	return allStores, nonPendingStores
 }
 
-// GetTiFlashRPCContext returns RPCContext for a region must access flash store. If it returns nil, the region
-// must be out of date and already dropped from cache or not flash store found.
+// GetTiFlashRPCContext returns RPCContext for a region must access flash store. If it returns nil, the returned
+// TiFlashRPCContextUnavailableReason explains why the region cannot access TiFlash.
 // `loadBalance` is an option. For batch cop, it is pointless and might cause try the failed store repeatly.
-func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, error) {
+func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, TiFlashRPCContextUnavailableReason, error) {
 
 	cachedRegion := c.GetCachedRegionWithRLock(id)
 	if !cachedRegion.isValid() {
-		return nil, nil
+		if cachedRegion == nil {
+			return nil, TiFlashRPCContextUnavailableCachedRegionMissing, nil
+		}
+		if cachedRegion.checkSyncFlags(needReloadOnAccess) {
+			return nil, TiFlashRPCContextUnavailableNeedReloadOnAccess, nil
+		}
+		return nil, TiFlashRPCContextUnavailableTTLExpired, nil
 	}
 
 	regionStore := cachedRegion.getStore()
+	accessStoreNum := regionStore.accessStoreNum(tiFlashOnly)
+	if accessStoreNum == 0 {
+		cachedRegion.invalidate(Other)
+		return nil, TiFlashRPCContextUnavailableNoTiFlashAccessStore, nil
+	}
 
 	// sIdx is for load balance of TiFlash store.
 	var sIdx int
@@ -1065,19 +1096,22 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 	} else {
 		sIdx = int(regionStore.workTiFlashIdx.Load())
 	}
-	for i := 0; i < regionStore.accessStoreNum(tiFlashOnly); i++ {
-		accessIdx := AccessIndex((sIdx + i) % regionStore.accessStoreNum(tiFlashOnly))
+	labelFilteredCount := 0
+	epochMismatchCount := 0
+	for i := 0; i < accessStoreNum; i++ {
+		accessIdx := AccessIndex((sIdx + i) % accessStoreNum)
 		storeIdx, store := regionStore.accessStore(tiFlashOnly, accessIdx)
 		if !labelFilter(store.GetLabels()) {
+			labelFilteredCount++
 			continue
 		}
 		addr, err := c.getStoreAddr(bo, cachedRegion, store)
 		if err != nil {
-			return nil, err
+			return nil, TiFlashRPCContextUnavailableError, err
 		}
 		if len(addr) == 0 {
 			cachedRegion.invalidate(StoreNotFound)
-			return nil, nil
+			return nil, TiFlashRPCContextUnavailableStoreAddrEmpty, nil
 		}
 		if store.getResolveState() == needCheck {
 			_, err := store.reResolve(c.stores)
@@ -1088,6 +1122,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 		storeFailEpoch := atomic.LoadUint32(&store.epoch)
 		if storeFailEpoch != regionStore.storeEpochs[storeIdx] {
 			cachedRegion.invalidate(Other)
+			epochMismatchCount++
 			logutil.Logger(bo.GetCtx()).Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
 				zap.String("store", store.GetAddr()))
@@ -1104,11 +1139,17 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			Addr:       addr,
 			AccessMode: tiFlashOnly,
 			TiKVNum:    regionStore.accessStoreNum(tiKVOnly),
-		}, nil
+		}, TiFlashRPCContextAvailable, nil
 	}
 
 	cachedRegion.invalidate(Other)
-	return nil, nil
+	if labelFilteredCount == accessStoreNum {
+		return nil, TiFlashRPCContextUnavailableAllStoresFiltered, nil
+	}
+	if epochMismatchCount == accessStoreNum {
+		return nil, TiFlashRPCContextUnavailableAllStoresEpochStale, nil
+	}
+	return nil, TiFlashRPCContextUnavailableNoAvailableStore, nil
 }
 
 // KeyLocation is the region and range that a key is located.

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -106,6 +106,15 @@ func (r TiFlashRPCContextUnavailableReason) String() string {
 	return string(r)
 }
 
+type TiFlashRPCContextUnavailableDetail struct {
+	Reason   TiFlashRPCContextUnavailableReason
+	StoreIDs []uint64
+}
+
+func (d TiFlashRPCContextUnavailableDetail) String() string {
+	return d.Reason.String()
+}
+
 // LabelFilterOnlyTiFlashWriteNode will only select stores whose label contains: <engine, tiflash> and <engine_role, write>.
 // Only used for tiflash_compute node.
 var LabelFilterOnlyTiFlashWriteNode = func(labels []*metapb.StoreLabel) bool {
@@ -1067,26 +1076,26 @@ func (c *RegionCache) GetAllValidTiFlashStores(id RegionVerID, currentStore *Sto
 }
 
 // GetTiFlashRPCContext returns RPCContext for a region must access flash store. If it returns nil, the returned
-// TiFlashRPCContextUnavailableReason explains why the region cannot access TiFlash.
+// TiFlashRPCContextUnavailableDetail explains why the region cannot access TiFlash.
 // `loadBalance` is an option. For batch cop, it is pointless and might cause try the failed store repeatly.
-func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, TiFlashRPCContextUnavailableReason, error) {
+func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, loadBalance bool, labelFilter LabelFilter) (*RPCContext, TiFlashRPCContextUnavailableDetail, error) {
 
 	cachedRegion := c.GetCachedRegionWithRLock(id)
 	if !cachedRegion.isValid() {
 		if cachedRegion == nil {
-			return nil, TiFlashRPCContextUnavailableCachedRegionMissing, nil
+			return nil, TiFlashRPCContextUnavailableDetail{Reason: TiFlashRPCContextUnavailableCachedRegionMissing}, nil
 		}
 		if cachedRegion.checkSyncFlags(needReloadOnAccess) {
-			return nil, TiFlashRPCContextUnavailableNeedReloadOnAccess, nil
+			return nil, TiFlashRPCContextUnavailableDetail{Reason: TiFlashRPCContextUnavailableNeedReloadOnAccess}, nil
 		}
-		return nil, TiFlashRPCContextUnavailableTTLExpired, nil
+		return nil, TiFlashRPCContextUnavailableDetail{Reason: TiFlashRPCContextUnavailableTTLExpired}, nil
 	}
 
 	regionStore := cachedRegion.getStore()
 	accessStoreNum := regionStore.accessStoreNum(tiFlashOnly)
 	if accessStoreNum == 0 {
 		cachedRegion.invalidate(Other)
-		return nil, TiFlashRPCContextUnavailableNoTiFlashAccessStore, nil
+		return nil, TiFlashRPCContextUnavailableDetail{Reason: TiFlashRPCContextUnavailableNoTiFlashAccessStore}, nil
 	}
 
 	// sIdx is for load balance of TiFlash store.
@@ -1098,20 +1107,28 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 	}
 	labelFilteredCount := 0
 	epochMismatchCount := 0
+	storeIDs := make([]uint64, 0, accessStoreNum)
 	for i := 0; i < accessStoreNum; i++ {
 		accessIdx := AccessIndex((sIdx + i) % accessStoreNum)
 		storeIdx, store := regionStore.accessStore(tiFlashOnly, accessIdx)
+		storeIDs = append(storeIDs, store.storeID)
 		if !labelFilter(store.GetLabels()) {
 			labelFilteredCount++
 			continue
 		}
 		addr, err := c.getStoreAddr(bo, cachedRegion, store)
 		if err != nil {
-			return nil, TiFlashRPCContextUnavailableError, err
+			return nil, TiFlashRPCContextUnavailableDetail{
+				Reason:   TiFlashRPCContextUnavailableError,
+				StoreIDs: []uint64{store.storeID},
+			}, err
 		}
 		if len(addr) == 0 {
 			cachedRegion.invalidate(StoreNotFound)
-			return nil, TiFlashRPCContextUnavailableStoreAddrEmpty, nil
+			return nil, TiFlashRPCContextUnavailableDetail{
+				Reason:   TiFlashRPCContextUnavailableStoreAddrEmpty,
+				StoreIDs: []uint64{store.storeID},
+			}, nil
 		}
 		if store.getResolveState() == needCheck {
 			_, err := store.reResolve(c.stores)
@@ -1125,6 +1142,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			epochMismatchCount++
 			logutil.Logger(bo.GetCtx()).Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
+				zap.Uint64("store_id", store.storeID),
 				zap.String("store", store.GetAddr()))
 			// TiFlash will always try to find out a valid peer, avoiding to retry too many times.
 			continue
@@ -1139,17 +1157,26 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			Addr:       addr,
 			AccessMode: tiFlashOnly,
 			TiKVNum:    regionStore.accessStoreNum(tiKVOnly),
-		}, TiFlashRPCContextAvailable, nil
+		}, TiFlashRPCContextUnavailableDetail{Reason: TiFlashRPCContextAvailable}, nil
 	}
 
 	cachedRegion.invalidate(Other)
 	if labelFilteredCount == accessStoreNum {
-		return nil, TiFlashRPCContextUnavailableAllStoresFiltered, nil
+		return nil, TiFlashRPCContextUnavailableDetail{
+			Reason:   TiFlashRPCContextUnavailableAllStoresFiltered,
+			StoreIDs: storeIDs,
+		}, nil
 	}
 	if epochMismatchCount == accessStoreNum {
-		return nil, TiFlashRPCContextUnavailableAllStoresEpochStale, nil
+		return nil, TiFlashRPCContextUnavailableDetail{
+			Reason:   TiFlashRPCContextUnavailableAllStoresEpochStale,
+			StoreIDs: storeIDs,
+		}, nil
 	}
-	return nil, TiFlashRPCContextUnavailableNoAvailableStore, nil
+	return nil, TiFlashRPCContextUnavailableDetail{
+		Reason:   TiFlashRPCContextUnavailableNoAvailableStore,
+		StoreIDs: storeIDs,
+	}, nil
 }
 
 // KeyLocation is the region and range that a key is located.

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -109,6 +109,7 @@ func (r TiFlashRPCContextUnavailableReason) String() string {
 type TiFlashRPCContextUnavailableDetail struct {
 	Reason   TiFlashRPCContextUnavailableReason
 	StoreIDs []uint64
+	PeerIDs  []uint64
 }
 
 func (d TiFlashRPCContextUnavailableDetail) String() string {
@@ -1108,10 +1109,16 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 	labelFilteredCount := 0
 	epochMismatchCount := 0
 	storeIDs := make([]uint64, 0, accessStoreNum)
+	peerIDs := make([]uint64, 0, accessStoreNum)
 	for i := 0; i < accessStoreNum; i++ {
 		accessIdx := AccessIndex((sIdx + i) % accessStoreNum)
 		storeIdx, store := regionStore.accessStore(tiFlashOnly, accessIdx)
 		storeIDs = append(storeIDs, store.storeID)
+		peerID := uint64(0)
+		if storeIdx < len(cachedRegion.meta.GetPeers()) {
+			peerID = cachedRegion.meta.GetPeers()[storeIdx].GetId()
+		}
+		peerIDs = append(peerIDs, peerID)
 		if !labelFilter(store.GetLabels()) {
 			labelFilteredCount++
 			continue
@@ -1121,6 +1128,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			return nil, TiFlashRPCContextUnavailableDetail{
 				Reason:   TiFlashRPCContextUnavailableError,
 				StoreIDs: []uint64{store.storeID},
+				PeerIDs:  []uint64{peerID},
 			}, err
 		}
 		if len(addr) == 0 {
@@ -1128,6 +1136,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			return nil, TiFlashRPCContextUnavailableDetail{
 				Reason:   TiFlashRPCContextUnavailableStoreAddrEmpty,
 				StoreIDs: []uint64{store.storeID},
+				PeerIDs:  []uint64{peerID},
 			}, nil
 		}
 		if store.getResolveState() == needCheck {
@@ -1143,6 +1152,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 			logutil.Logger(bo.GetCtx()).Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
 				zap.Uint64("store_id", store.storeID),
+				zap.Uint64("peer_id", peer.GetId()),
 				zap.String("store", store.GetAddr()))
 			// TiFlash will always try to find out a valid peer, avoiding to retry too many times.
 			continue
@@ -1165,17 +1175,20 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *retry.Backoffer, id RegionVerID, 
 		return nil, TiFlashRPCContextUnavailableDetail{
 			Reason:   TiFlashRPCContextUnavailableAllStoresFiltered,
 			StoreIDs: storeIDs,
+			PeerIDs:  peerIDs,
 		}, nil
 	}
 	if epochMismatchCount == accessStoreNum {
 		return nil, TiFlashRPCContextUnavailableDetail{
 			Reason:   TiFlashRPCContextUnavailableAllStoresEpochStale,
 			StoreIDs: storeIDs,
+			PeerIDs:  peerIDs,
 		}, nil
 	}
 	return nil, TiFlashRPCContextUnavailableDetail{
 		Reason:   TiFlashRPCContextUnavailableNoAvailableStore,
 		StoreIDs: storeIDs,
+		PeerIDs:  peerIDs,
 	}, nil
 }
 

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -599,7 +599,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	s.Nil(err)
 	s.Equal(loc.Region.id, s.region1)
-	ctx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+	ctx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 	s.Nil(err)
 	s.NotNil(ctx)
 	region := s.cache.GetCachedRegionWithRLock(loc.Region)
@@ -617,7 +617,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 		time.Sleep(1 * time.Second)
 		loc, err = s.cache.LocateKey(s.bo, []byte("a"))
 		s.Nil(err)
-		rpcCtx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 		s.Nil(err)
 		if rpcCtx != nil {
 			s.NotEqual(s.storeAddr(store3), rpcCtx.Addr, "should not access peer3 when it is down")
@@ -635,7 +635,7 @@ func (s *testRegionCacheSuite) TestTiFlashRecoveredFromDown() {
 		}
 		loc, err = s.cache.LocateKey(s.bo, []byte("a"))
 		s.Nil(err)
-		rpcCtx, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc.Region, true, LabelFilterNoTiFlashWriteNode)
 		s.Nil(err)
 		if rpcCtx != nil && rpcCtx.Addr == s.storeAddr(store3) {
 			break
@@ -1351,7 +1351,7 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash() {
 	s.Equal(lctx.Peer.Id, peer3)
 
 	// epoch-not-match on tiflash
-	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region, true, LabelFilterNoTiFlashWriteNode)
+	ctxTiFlash, _, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region, true, LabelFilterNoTiFlashWriteNode)
 	s.Nil(err)
 	s.Equal(ctxTiFlash.Peer.Id, s.peer1)
 	ctxTiFlash.Peer.Role = metapb.PeerRole_Learner

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -852,7 +852,8 @@ func (s *RegionRequestSender) getRPCContext(
 		return s.replicaSelector.next(bo, req)
 	case tikvrpc.TiFlash:
 		// Should ignore WN, because in disaggregated tiflash mode, TiDB will build rpcCtx itself.
-		return s.regionCache.GetTiFlashRPCContext(bo, regionID, true, LabelFilterNoTiFlashWriteNode)
+		rpcCtx, _, err := s.regionCache.GetTiFlashRPCContext(bo, regionID, true, LabelFilterNoTiFlashWriteNode)
+		return rpcCtx, err
 	case tikvrpc.TiDB:
 		return &RPCContext{Addr: s.storeAddr}, nil
 	case tikvrpc.TiFlashCompute:

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -60,6 +60,22 @@ type RegionVerID = locate.RegionVerID
 // RegionCache caches Regions loaded from PD.
 type RegionCache = locate.RegionCache
 
+// TiFlashRPCContextUnavailableReason explains why GetTiFlashRPCContext returns a nil RPCContext.
+type TiFlashRPCContextUnavailableReason = locate.TiFlashRPCContextUnavailableReason
+
+const (
+	TiFlashRPCContextAvailable                       = locate.TiFlashRPCContextAvailable
+	TiFlashRPCContextUnavailableError				 = locate.TiFlashRPCContextUnavailableError
+	TiFlashRPCContextUnavailableCachedRegionMissing  = locate.TiFlashRPCContextUnavailableCachedRegionMissing
+	TiFlashRPCContextUnavailableNeedReloadOnAccess   = locate.TiFlashRPCContextUnavailableNeedReloadOnAccess
+	TiFlashRPCContextUnavailableTTLExpired           = locate.TiFlashRPCContextUnavailableTTLExpired
+	TiFlashRPCContextUnavailableNoTiFlashAccessStore = locate.TiFlashRPCContextUnavailableNoTiFlashAccessStore
+	TiFlashRPCContextUnavailableStoreAddrEmpty       = locate.TiFlashRPCContextUnavailableStoreAddrEmpty
+	TiFlashRPCContextUnavailableAllStoresFiltered    = locate.TiFlashRPCContextUnavailableAllStoresFiltered
+	TiFlashRPCContextUnavailableAllStoresEpochStale  = locate.TiFlashRPCContextUnavailableAllStoresEpochStale
+	TiFlashRPCContextUnavailableNoAvailableStore     = locate.TiFlashRPCContextUnavailableNoAvailableStore
+)
+
 // KeyLocation is the region and range that a key is located.
 type KeyLocation = locate.KeyLocation
 

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -62,10 +62,11 @@ type RegionCache = locate.RegionCache
 
 // TiFlashRPCContextUnavailableReason explains why GetTiFlashRPCContext returns a nil RPCContext.
 type TiFlashRPCContextUnavailableReason = locate.TiFlashRPCContextUnavailableReason
+type TiFlashRPCContextUnavailableDetail = locate.TiFlashRPCContextUnavailableDetail
 
 const (
 	TiFlashRPCContextAvailable                       = locate.TiFlashRPCContextAvailable
-	TiFlashRPCContextUnavailableError				 = locate.TiFlashRPCContextUnavailableError
+	TiFlashRPCContextUnavailableError                = locate.TiFlashRPCContextUnavailableError
 	TiFlashRPCContextUnavailableCachedRegionMissing  = locate.TiFlashRPCContextUnavailableCachedRegionMissing
 	TiFlashRPCContextUnavailableNeedReloadOnAccess   = locate.TiFlashRPCContextUnavailableNeedReloadOnAccess
 	TiFlashRPCContextUnavailableTTLExpired           = locate.TiFlashRPCContextUnavailableTTLExpired


### PR DESCRIPTION
Return a reason when GetTiFlashRPCContext returns nil to help callers know why the TiFlash RPC context is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed detailed TiFlash RPC-context unavailability reasons and structured details for clearer diagnostics.

* **Improvements**
  * More explicit handling and reporting when TiFlash contexts are unavailable (including store lists and specific causes).
  * Improved TiFlash store selection with better load-balancing and label-based filtering for more reliable routing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/client-go/pull/1959)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->