### PR TITLE
Add debug helpers for cached region/store info

### DIFF
--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -2308,6 +2308,194 @@ func (c *RegionCache) GetAllStores() []*Store {
 	})
 }
 
+// CachedRegionPeerStoreDebugInfo is the debug information of one peer-store pair in cached region.
+type CachedRegionPeerStoreDebugInfo struct {
+	Peer                *metapb.Peer
+	StoreID             uint64
+	Addr                string
+	PeerAddr            string
+	StatusAddr          string
+	StoreType           string
+	ResolveState        string
+	LivenessState       string
+	StoreEpoch          uint32
+	IsSlow              bool
+	ClientSideSlowScore int64
+	TiKVSideSlowScore   int64
+}
+
+// CachedRegionDebugInfo is the debug information of one cached region.
+type CachedRegionDebugInfo struct {
+	RegionID       uint64
+	RegionEpoch    *metapb.RegionEpoch
+	RegionVer      RegionVerID
+	StartKey       []byte
+	EndKey         []byte
+	Peers          []*metapb.Peer
+	LeaderPeerID   uint64
+	LeaderStoreID  uint64
+	TTL            int64
+	Expired        bool
+	Valid          bool
+	InvalidReason  string
+	SyncFlags      int32
+	SyncFlagNames  []string
+	BucketVersion  uint64
+	BucketKeyCount int
+	PeerStores     []CachedRegionPeerStoreDebugInfo
+}
+
+// CachedStoreDebugInfo is the debug information of one cached store.
+type CachedStoreDebugInfo struct {
+	StoreID             uint64
+	Addr                string
+	PeerAddr            string
+	StatusAddr          string
+	StoreType           string
+	ResolveState        string
+	LivenessState       string
+	Labels              []*metapb.StoreLabel
+	IsSlow              bool
+	ClientSideSlowScore int64
+	TiKVSideSlowScore   int64
+	EstimatedWaitMs     int64
+}
+
+// GetCachedRegionDebugInfoByID returns region information from cache directly.
+// It never triggers PD lookups or cache reload.
+func (c *RegionCache) GetCachedRegionDebugInfoByID(regionID uint64) (*CachedRegionDebugInfo, bool) {
+	c.mu.RLock()
+	ver, ok := c.mu.latestVersions[regionID]
+	if !ok {
+		c.mu.RUnlock()
+		return nil, false
+	}
+	region, ok := c.mu.regions[ver]
+	c.mu.RUnlock()
+	if !ok || region == nil {
+		return nil, false
+	}
+
+	rs := region.getStore()
+	meta := region.GetMeta()
+	now := time.Now().Unix()
+	ttl := atomic.LoadInt64(&region.ttl)
+	expired := region.isCacheTTLExpired(now)
+	syncFlags := region.getSyncFlags()
+	invalidReason := InvalidReason(atomic.LoadInt32((*int32)(&region.invalidReason)))
+	valid := !expired && invalidReason == Ok && syncFlags&(needReloadOnAccess|needDelayedReloadReady) == 0
+	var regionEpoch *metapb.RegionEpoch
+	if epoch := meta.GetRegionEpoch(); epoch != nil {
+		regionEpoch = proto.Clone(epoch).(*metapb.RegionEpoch)
+	}
+
+	info := &CachedRegionDebugInfo{
+		RegionID:      region.GetID(),
+		RegionEpoch:   regionEpoch,
+		RegionVer:     region.VerID(),
+		StartKey:      slices.Clone(region.StartKey()),
+		EndKey:        slices.Clone(region.EndKey()),
+		Peers:         make([]*metapb.Peer, len(meta.Peers)),
+		LeaderPeerID:  region.GetLeaderPeerID(),
+		LeaderStoreID: region.GetLeaderStoreID(),
+		TTL:           ttl,
+		Expired:       expired,
+		Valid:         valid,
+		InvalidReason: invalidReason.String(),
+		SyncFlags:     syncFlags,
+		SyncFlagNames: syncFlagNames(syncFlags),
+	}
+	for i, peer := range meta.Peers {
+		info.Peers[i] = proto.Clone(peer).(*metapb.Peer)
+	}
+
+	if rs != nil && rs.buckets != nil {
+		info.BucketVersion = rs.buckets.GetVersion()
+		info.BucketKeyCount = len(rs.buckets.GetKeys())
+	}
+
+	if rs == nil {
+		return info, true
+	}
+
+	peerStoreInfos := make([]CachedRegionPeerStoreDebugInfo, 0, len(meta.Peers))
+	for i, peer := range meta.Peers {
+		peerInfo := CachedRegionPeerStoreDebugInfo{
+			Peer: proto.Clone(peer).(*metapb.Peer),
+		}
+		if i < len(rs.stores) {
+			store := rs.stores[i]
+			healthDetail := store.GetHealthStatus().GetHealthStatusDetail()
+			peerInfo.StoreID = store.StoreID()
+			peerInfo.Addr = store.GetAddr()
+			peerInfo.PeerAddr = store.GetPeerAddr()
+			peerInfo.StatusAddr = store.GetStatusAddr()
+			peerInfo.StoreType = store.StoreType().Name()
+			peerInfo.ResolveState = store.getResolveState().String()
+			peerInfo.LivenessState = store.getLivenessState().String()
+			peerInfo.IsSlow = store.GetHealthStatus().IsSlow()
+			peerInfo.ClientSideSlowScore = healthDetail.ClientSideSlowScore
+			peerInfo.TiKVSideSlowScore = healthDetail.TiKVSideSlowScore
+		}
+		if i < len(rs.storeEpochs) {
+			peerInfo.StoreEpoch = rs.storeEpochs[i]
+		}
+		peerStoreInfos = append(peerStoreInfos, peerInfo)
+	}
+	info.PeerStores = peerStoreInfos
+	return info, true
+}
+
+// GetCachedStoreDebugInfoByID returns store information from cache directly.
+// It never triggers PD lookups or cache reload.
+func (c *RegionCache) GetCachedStoreDebugInfoByID(storeID uint64) (*CachedStoreDebugInfo, bool) {
+	store, ok := c.stores.get(storeID)
+	if !ok || store == nil {
+		return nil, false
+	}
+
+	healthDetail := store.GetHealthStatus().GetHealthStatusDetail()
+	info := &CachedStoreDebugInfo{
+		StoreID:             store.StoreID(),
+		Addr:                store.GetAddr(),
+		PeerAddr:            store.GetPeerAddr(),
+		StatusAddr:          store.GetStatusAddr(),
+		StoreType:           store.StoreType().Name(),
+		ResolveState:        store.getResolveState().String(),
+		LivenessState:       store.getLivenessState().String(),
+		IsSlow:              store.GetHealthStatus().IsSlow(),
+		ClientSideSlowScore: healthDetail.ClientSideSlowScore,
+		TiKVSideSlowScore:   healthDetail.TiKVSideSlowScore,
+		EstimatedWaitMs:     store.EstimatedWaitTime().Milliseconds(),
+	}
+	labels := store.GetLabels()
+	info.Labels = make([]*metapb.StoreLabel, 0, len(labels))
+	for _, label := range labels {
+		info.Labels = append(info.Labels, proto.Clone(label).(*metapb.StoreLabel))
+	}
+	return info, true
+}
+
+func syncFlagNames(flags int32) []string {
+	if flags == 0 {
+		return nil
+	}
+	names := make([]string, 0, 4)
+	if flags&needReloadOnAccess > 0 {
+		names = append(names, "need_reload_on_access")
+	}
+	if flags&needExpireAfterTTL > 0 {
+		names = append(names, "need_expire_after_ttl")
+	}
+	if flags&needDelayedReloadPending > 0 {
+		names = append(names, "need_delayed_reload_pending")
+	}
+	if flags&needDelayedReloadReady > 0 {
+		names = append(names, "need_delayed_reload_ready")
+	}
+	return names
+}
+
 var loadRegionCounters sync.Map
 
 const (

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -397,6 +397,45 @@ func (s *testRegionCacheSuite) TestSimple() {
 	s.NotNil(r)
 }
 
+func (s *testRegionCacheSuite) TestGetCachedRegionDebugInfoByID() {
+	r := s.getRegion([]byte("a"))
+	info, ok := s.cache.GetCachedRegionDebugInfoByID(r.GetID())
+	s.True(ok)
+	s.NotNil(info)
+	s.Equal(r.GetID(), info.RegionID)
+	s.Equal(r.VerID(), info.RegionVer)
+	s.Equal(r.GetLeaderStoreID(), info.LeaderStoreID)
+	s.False(info.Expired)
+	s.True(info.Valid)
+	s.Equal(2, len(info.Peers))
+	s.Equal(2, len(info.PeerStores))
+
+	r.setSyncFlags(needReloadOnAccess)
+	info, ok = s.cache.GetCachedRegionDebugInfoByID(r.GetID())
+	s.True(ok)
+	s.NotNil(info)
+	s.False(info.Valid)
+	s.Contains(info.SyncFlagNames, "need_reload_on_access")
+
+	_, ok = s.cache.GetCachedRegionDebugInfoByID(0)
+	s.False(ok)
+}
+
+func (s *testRegionCacheSuite) TestGetCachedStoreDebugInfoByID() {
+	s.getRegion([]byte("a"))
+
+	storeInfo, ok := s.cache.GetCachedStoreDebugInfoByID(s.store1)
+	s.True(ok)
+	s.NotNil(storeInfo)
+	s.Equal(s.store1, storeInfo.StoreID)
+	s.Equal(s.storeAddr(s.store1), storeInfo.Addr)
+	s.Equal("resolved", storeInfo.ResolveState)
+	s.NotEmpty(storeInfo.StoreType)
+
+	_, ok = s.cache.GetCachedStoreDebugInfoByID(0)
+	s.False(ok)
+}
+
 // TestResolveStateTransition verifies store's resolve state transition. For example,
 // a newly added store is in unresolved state and will be resolved soon if it's an up store,
 // or in tombstone state if it's a tombstone.

--- a/internal/locate/store_cache.go
+++ b/internal/locate/store_cache.go
@@ -312,6 +312,13 @@ func (s *Store) GetPeerAddr() string {
 	return s.peerAddr
 }
 
+// GetStatusAddr returns the status address of the store.
+func (s *Store) GetStatusAddr() string {
+	s.metaMu.RLock()
+	defer s.metaMu.RUnlock()
+	return s.saddr
+}
+
 // GetLabels returns the labels of the store, it is not safe to modify the returned labels.
 func (s *Store) GetLabels() []*metapb.StoreLabel {
 	s.metaMu.RLock()

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -60,6 +60,15 @@ type RegionVerID = locate.RegionVerID
 // RegionCache caches Regions loaded from PD.
 type RegionCache = locate.RegionCache
 
+// CachedRegionPeerStoreDebugInfo is the debug information of one peer-store pair in cached region.
+type CachedRegionPeerStoreDebugInfo = locate.CachedRegionPeerStoreDebugInfo
+
+// CachedRegionDebugInfo is the debug information of one cached region.
+type CachedRegionDebugInfo = locate.CachedRegionDebugInfo
+
+// CachedStoreDebugInfo is the debug information of one cached store.
+type CachedStoreDebugInfo = locate.CachedStoreDebugInfo
+
 // TiFlashRPCContextUnavailableReason explains why GetTiFlashRPCContext returns a nil RPCContext.
 type TiFlashRPCContextUnavailableReason = locate.TiFlashRPCContextUnavailableReason
 type TiFlashRPCContextUnavailableDetail = locate.TiFlashRPCContextUnavailableDetail
@@ -172,6 +181,18 @@ func NewRPCanceller() *RPCCanceller {
 // NewRegionVerID creates a region ver id, which used for invalidating regions.
 func NewRegionVerID(id, confVer, ver uint64) RegionVerID {
 	return locate.NewRegionVerID(id, confVer, ver)
+}
+
+// GetCachedRegionDebugInfoByID returns region debug information from cache directly.
+// It never triggers PD lookups or cache reload.
+func GetCachedRegionDebugInfoByID(cache *RegionCache, regionID uint64) (*CachedRegionDebugInfo, bool) {
+	return cache.GetCachedRegionDebugInfoByID(regionID)
+}
+
+// GetCachedStoreDebugInfoByID returns store debug information from cache directly.
+// It never triggers PD lookups or cache reload.
+func GetCachedStoreDebugInfoByID(cache *RegionCache, storeID uint64) (*CachedStoreDebugInfo, bool) {
+	return cache.GetCachedStoreDebugInfoByID(storeID)
 }
 
 // GetStoreTypeByMeta gets store type by store meta pb.


### PR DESCRIPTION
This PR adds two debug helper functions, `GetCachedRegionDebugInfoByID` and `GetCachedStoreDebugInfoByID`, to get cached region/store information by ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced debug inspection APIs for querying cached region and store information directly without external lookups.
  * Added method to retrieve store status addresses.

* **Tests**
  * Added test cases validating cache debug information retrieval functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/client-go/pull/1962)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->