### PR TITLE
[DO NOT MERGE / test bundle] resourcecontrol: PredictedReadBytes hint for paging pre-charge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,14 +15,14 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53
+	github.com/pingcap/kvproto v0.0.0-20260511034003-fc9e0458a359
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/stretchr/testify v1.9.0
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71
+	github.com/tikv/pd/client v0.0.0-20260622085717-f7fea05dfc4f
 	github.com/twmb/murmur3 v1.1.3
 	go.etcd.io/etcd/api/v3 v3.5.10
 	go.etcd.io/etcd/client/v3 v3.5.10
@@ -61,4 +61,4 @@ require (
 )
 
 // Temporary: pin to feature branch. Revert once tikv/pd#10611 is merged and tagged.
-replace github.com/tikv/pd/client => github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de
+replace github.com/tikv/pd/client => github.com/YuhaoZhang00/pd/client v0.0.0-20260622085717-f7fea05dfc4f

--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Temporary: pin to feature branch. Revert once tikv/pd#10611 is merged and tagged.
+replace github.com/tikv/pd/client => github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
-github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de h1:iYVX9orSalHNGTgo2IIWhZngZ7RMPlca52M8zIF8F1w=
-github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de/go.mod h1:I2yRx/Yf8Y8kgM5f3VNp4a8fWpnjPC4TxWk554AY8bM=
+github.com/YuhaoZhang00/pd/client v0.0.0-20260622085717-f7fea05dfc4f h1:F7iqMCuqD+LDHgnuW7OMlf0HlqXksGndrSGydVSRJd0=
+github.com/YuhaoZhang00/pd/client v0.0.0-20260622085717-f7fea05dfc4f/go.mod h1:I6LzwZgaSbT7h2C74QwM9DgEbla7vLkVPIGeDKYpuoE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -83,8 +83,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 h1:wjhJRzyeRKpJqMg6XmqQ7cJdhEhE5mSoCh94rWdTVOk=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260511034003-fc9e0458a359 h1:oteLtLuoWZN3uvfH836U0IIJ+s3UOk11q7GaQ0Tk+wc=
+github.com/pingcap/kvproto v0.0.0-20260511034003-fc9e0458a359/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de h1:iYVX9orSalHNGTgo2IIWhZngZ7RMPlca52M8zIF8F1w=
+github.com/YuhaoZhang00/pd/client v0.0.0-20260518130251-22b311d178de/go.mod h1:I2yRx/Yf8Y8kgM5f3VNp4a8fWpnjPC4TxWk554AY8bM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -115,8 +117,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a h1:J/YdBZ46WKpXsxsW93SG+q0F8KI+yFrcIDT4c/RNoc4=
 github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
-github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 h1:5hCQ6J2fwUpYqIgQGR625bW98wvYS9FUpTiVszIbVSg=
-github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71/go.mod h1:4kxXuAQAREpH+lVbydVwGNNDmcwdj0RG4Ofwky08W/k=
 github.com/twmb/murmur3 v1.1.3 h1:D83U0XYKcHRYwYIpBKf3Pks91Z0Byda/9SJ8B6EMRcA=
 github.com/twmb/murmur3 v1.1.3/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/client/client_interceptor.go
+++ b/internal/client/client_interceptor.go
@@ -73,14 +73,21 @@ func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *ti
 		})(addr, req)
 	}
 
-	if resourceControlInterceptor != nil && resp != nil {
-		respInfo := resourcecontrol.MakeResponseInfo(resp)
-		consumption, waitDuration, err := resourceControlInterceptor.OnResponseWait(ctx, resourceGroupName, reqInfo, respInfo)
-		if err != nil {
-			return nil, err
-		}
-		if ruDetails != nil {
-			ruDetails.Update(consumption, waitDuration)
+	if resourceControlInterceptor != nil {
+		if resp != nil {
+			respInfo := resourcecontrol.MakeResponseInfo(resp)
+			consumption, waitDuration, err := resourceControlInterceptor.OnResponseWait(ctx, resourceGroupName, reqInfo, respInfo)
+			if err != nil {
+				return nil, err
+			}
+			if ruDetails != nil {
+				ruDetails.Update(consumption, waitDuration)
+			}
+		} else {
+			// Transport-level failure produced no response — the settlement
+			// path will not run. Cancel the pre-charge so the predicted RU
+			// debited in OnRequestWait is refunded to the limiter.
+			resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
 		}
 	}
 
@@ -130,6 +137,10 @@ func (r interceptedClient) SendRequestAsync(ctx context.Context, addr string, re
 				if ruDetails != nil {
 					ruDetails.Update(consumption, waitDuration)
 				}
+			} else {
+				// Transport-level failure produced no response — cancel the
+				// pre-charge so the predicted RU is refunded to the limiter.
+				resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
 			}
 			return resp, err
 		})

--- a/internal/client/client_interceptor.go
+++ b/internal/client/client_interceptor.go
@@ -45,7 +45,6 @@ func NewInterceptedClient(client Client) Client {
 
 func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
 	var ruDetails *util.RUDetails
-	var requestConsumption *rmpb.Consumption
 
 	resourceGroupName, resourceControlInterceptor, reqInfo := getResourceControlInfo(ctx, req)
 	if resourceControlInterceptor != nil {
@@ -53,7 +52,6 @@ func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *ti
 		if err != nil {
 			return nil, err
 		}
-		requestConsumption = consumption
 		req.GetResourceControlContext().Penalty = penalty
 		// override request priority with resource group priority if it's not set.
 		// Get the priority at tikv side has some performance issue, so we pass it
@@ -87,11 +85,12 @@ func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *ti
 				ruDetails.Update(consumption, waitDuration)
 			}
 		} else {
-			// Transport-level failure produced no response — the settlement
-			// path will not run. Cancel the pre-charge so the predicted RU
-			// debited in OnRequestWait is refunded to the limiter.
-			resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
-			rollbackRUDetailsForCanceledRequest(ruDetails, requestConsumption)
+			// Transport-level failure produced no response, so let PD's
+			// controller decide the signed no-response delta.
+			cancelDelta := onRequestCancel(ctx, resourceGroupName, resourceControlInterceptor, reqInfo)
+			if ruDetails != nil {
+				ruDetails.Update(cancelDelta, 0)
+			}
 		}
 	}
 
@@ -142,10 +141,12 @@ func (r interceptedClient) SendRequestAsync(ctx context.Context, addr string, re
 					ruDetails.Update(consumption, waitDuration)
 				}
 			} else {
-				// Transport-level failure produced no response — cancel the
-				// pre-charge so the predicted RU is refunded to the limiter.
-				resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
-				rollbackRUDetailsForCanceledRequest(ruDetails, consumption)
+				// Transport-level failure produced no response, so let PD's
+				// controller decide the signed no-response delta.
+				cancelDelta := onRequestCancel(ctx, resourceGroupName, resourceControlInterceptor, reqInfo)
+				if ruDetails != nil {
+					ruDetails.Update(cancelDelta, 0)
+				}
 			}
 			return resp, err
 		})
@@ -154,14 +155,21 @@ func (r interceptedClient) SendRequestAsync(ctx context.Context, addr string, re
 	r.Client.SendRequestAsync(ctx, addr, req, cb)
 }
 
-func rollbackRUDetailsForCanceledRequest(ruDetails *util.RUDetails, consumption *rmpb.Consumption) {
-	if ruDetails == nil || consumption == nil {
-		return
+type resourceControlCancelDeltaInterceptor interface {
+	OnRequestCancelWithDelta(context.Context, string, resourceControlClient.RequestInfo) *rmpb.Consumption
+}
+
+func onRequestCancel(
+	ctx context.Context,
+	resourceGroupName string,
+	resourceControlInterceptor resourceControlClient.ResourceGroupKVInterceptor,
+	reqInfo resourceControlClient.RequestInfo,
+) *rmpb.Consumption {
+	if cancelWithDelta, ok := resourceControlInterceptor.(resourceControlCancelDeltaInterceptor); ok {
+		return cancelWithDelta.OnRequestCancelWithDelta(ctx, resourceGroupName, reqInfo)
 	}
-	ruDetails.Update(&rmpb.Consumption{
-		RRU: -consumption.RRU,
-		WRU: -consumption.WRU,
-	}, 0)
+	resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
+	return nil
 }
 
 var (
@@ -266,6 +274,12 @@ func buildResourceControlInterceptor( //nolint:unused
 				if ruDetails != nil {
 					detail := ruDetails.(*util.RUDetails)
 					detail.Update(consumption, waitDuration)
+				}
+			} else {
+				cancelDelta := onRequestCancel(ctx, resourceGroupName, resourceControlInterceptor, reqInfo)
+				if ruDetails != nil {
+					detail := ruDetails.(*util.RUDetails)
+					detail.Update(cancelDelta, 0)
 				}
 			}
 			return resp, err

--- a/internal/client/client_interceptor.go
+++ b/internal/client/client_interceptor.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/tikv/client-go/v2/internal/resourcecontrol"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
@@ -44,6 +45,7 @@ func NewInterceptedClient(client Client) Client {
 
 func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
 	var ruDetails *util.RUDetails
+	var requestConsumption *rmpb.Consumption
 
 	resourceGroupName, resourceControlInterceptor, reqInfo := getResourceControlInfo(ctx, req)
 	if resourceControlInterceptor != nil {
@@ -51,6 +53,7 @@ func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *ti
 		if err != nil {
 			return nil, err
 		}
+		requestConsumption = consumption
 		req.GetResourceControlContext().Penalty = penalty
 		// override request priority with resource group priority if it's not set.
 		// Get the priority at tikv side has some performance issue, so we pass it
@@ -88,6 +91,7 @@ func (r interceptedClient) SendRequest(ctx context.Context, addr string, req *ti
 			// path will not run. Cancel the pre-charge so the predicted RU
 			// debited in OnRequestWait is refunded to the limiter.
 			resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
+			rollbackRUDetailsForCanceledRequest(ruDetails, requestConsumption)
 		}
 	}
 
@@ -141,12 +145,23 @@ func (r interceptedClient) SendRequestAsync(ctx context.Context, addr string, re
 				// Transport-level failure produced no response — cancel the
 				// pre-charge so the predicted RU is refunded to the limiter.
 				resourceControlInterceptor.OnRequestCancel(ctx, resourceGroupName, reqInfo)
+				rollbackRUDetailsForCanceledRequest(ruDetails, consumption)
 			}
 			return resp, err
 		})
 	}
 
 	r.Client.SendRequestAsync(ctx, addr, req, cb)
+}
+
+func rollbackRUDetailsForCanceledRequest(ruDetails *util.RUDetails, consumption *rmpb.Consumption) {
+	if ruDetails == nil || consumption == nil {
+		return
+	}
+	ruDetails.Update(&rmpb.Consumption{
+		RRU: -consumption.RRU,
+		WRU: -consumption.WRU,
+	}, 0)
 }
 
 var (

--- a/internal/client/client_interceptor_test.go
+++ b/internal/client/client_interceptor_test.go
@@ -117,7 +117,10 @@ type recordingInterceptor struct {
 	cancelCalls int
 }
 
-var recordingRequestConsumption = &rmpb.Consumption{RRU: 11, WRU: 3}
+var (
+	recordingRequestConsumption = &rmpb.Consumption{RRU: 11, WRU: 3}
+	recordingCancelDelta        = &rmpb.Consumption{RRU: -7}
+)
 
 func (r *recordingInterceptor) OnRequestWait(
 	context.Context, string, resourceControlClient.RequestInfo,
@@ -145,11 +148,58 @@ func (r *recordingInterceptor) OnRequestCancel(
 	r.cancelCalls++
 }
 
+func (r *recordingInterceptor) OnRequestCancelWithDelta(
+	context.Context, string, resourceControlClient.RequestInfo,
+) *rmpb.Consumption {
+	r.cancelCalls++
+	return recordingCancelDelta
+}
+
 func (r *recordingInterceptor) IsBackgroundRequest(context.Context, string, string) bool {
 	return false
 }
 
 func (r *recordingInterceptor) GetRUVersion() resourceControlClient.RUVersion {
+	return resourceControlClient.DefaultRUVersion
+}
+
+type legacyRecordingInterceptor struct {
+	waitCalls   int
+	respCalls   int
+	cancelCalls int
+}
+
+func (r *legacyRecordingInterceptor) OnRequestWait(
+	context.Context, string, resourceControlClient.RequestInfo,
+) (*rmpb.Consumption, *rmpb.Consumption, time.Duration, uint32, error) {
+	r.waitCalls++
+	return recordingRequestConsumption, &rmpb.Consumption{}, 0, 0, nil
+}
+
+func (r *legacyRecordingInterceptor) OnResponse(
+	string, resourceControlClient.RequestInfo, resourceControlClient.ResponseInfo,
+) (*rmpb.Consumption, error) {
+	return &rmpb.Consumption{}, nil
+}
+
+func (r *legacyRecordingInterceptor) OnResponseWait(
+	context.Context, string, resourceControlClient.RequestInfo, resourceControlClient.ResponseInfo,
+) (*rmpb.Consumption, time.Duration, error) {
+	r.respCalls++
+	return &rmpb.Consumption{}, 0, nil
+}
+
+func (r *legacyRecordingInterceptor) OnRequestCancel(
+	context.Context, string, resourceControlClient.RequestInfo,
+) {
+	r.cancelCalls++
+}
+
+func (r *legacyRecordingInterceptor) IsBackgroundRequest(context.Context, string, string) bool {
+	return false
+}
+
+func (r *legacyRecordingInterceptor) GetRUVersion() resourceControlClient.RUVersion {
 	return resourceControlClient.DefaultRUVersion
 }
 
@@ -183,6 +233,19 @@ func withRecordingInterceptor(t *testing.T) *recordingInterceptor {
 	return rec
 }
 
+func withLegacyRecordingInterceptor(t *testing.T) *legacyRecordingInterceptor {
+	t.Helper()
+	rec := &legacyRecordingInterceptor{}
+	var iface resourceControlClient.ResourceGroupKVInterceptor = rec
+	ResourceControlSwitch.Store(true)
+	ResourceControlInterceptor.Store(&iface)
+	t.Cleanup(func() {
+		ResourceControlSwitch.Store(false)
+		ResourceControlInterceptor.Store(nil)
+	})
+	return rec
+}
+
 func newRGRequest() *tikvrpc.Request {
 	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{})
 	req.ResourceControlContext = &kvrpcpb.ResourceControlContext{ResourceGroupName: "test-rg"}
@@ -202,7 +265,7 @@ func TestSendRequestCancelsPreChargeOnTransportFailure(t *testing.T) {
 		"OnRequestCancel must run when the inner client returns no response")
 }
 
-func TestSendRequestRollsBackRUDetailsOnTransportFailure(t *testing.T) {
+func TestSendRequestAppliesCancelDeltaToRUDetailsOnTransportFailure(t *testing.T) {
 	withRecordingInterceptor(t)
 	client := NewInterceptedClient(failingClient{})
 	ruDetails := util.NewRUDetails()
@@ -211,10 +274,26 @@ func TestSendRequestRollsBackRUDetailsOnTransportFailure(t *testing.T) {
 	resp, err := client.SendRequest(ctx, "", newRGRequest(), 0)
 	assert.Nil(t, resp)
 	assert.Error(t, err)
-	assert.Equal(t, 0.0, ruDetails.RRU(),
-		"failed no-response requests must not leave request-side RRU in runtime stats")
-	assert.Equal(t, 0.0, ruDetails.WRU(),
-		"failed no-response requests must not leave request-side WRU in runtime stats")
+	assert.Equal(t, recordingRequestConsumption.RRU+recordingCancelDelta.RRU, ruDetails.RRU(),
+		"failed no-response requests must apply PD's signed cancel delta to runtime stats")
+	assert.Equal(t, recordingRequestConsumption.WRU, ruDetails.WRU(),
+		"failed no-response requests must not locally roll back write RU")
+}
+
+func TestSendRequestLegacyCancelDoesNotRollbackRUDetails(t *testing.T) {
+	rec := withLegacyRecordingInterceptor(t)
+	client := NewInterceptedClient(failingClient{})
+	ruDetails := util.NewRUDetails()
+	ctx := context.WithValue(context.Background(), util.RUDetailsCtxKey, ruDetails)
+
+	resp, err := client.SendRequest(ctx, "", newRGRequest(), 0)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Equal(t, 1, rec.cancelCalls)
+	assert.Equal(t, recordingRequestConsumption.RRU, ruDetails.RRU(),
+		"legacy cancel has no signed delta, so client-go must not guess a local RRU rollback")
+	assert.Equal(t, recordingRequestConsumption.WRU, ruDetails.WRU(),
+		"legacy cancel has no signed delta, so client-go must not guess a local WRU rollback")
 }
 
 func TestSendRequestDoesNotCancelOnSuccess(t *testing.T) {
@@ -254,7 +333,7 @@ func TestSendRequestAsyncCancelsPreChargeOnTransportFailure(t *testing.T) {
 		"OnRequestCancel must run on the async path too when resp is nil")
 }
 
-func TestSendRequestAsyncRollsBackRUDetailsOnTransportFailure(t *testing.T) {
+func TestSendRequestAsyncAppliesCancelDeltaToRUDetailsOnTransportFailure(t *testing.T) {
 	withRecordingInterceptor(t)
 	client := NewInterceptedClient(failingClient{})
 	ruDetails := util.NewRUDetails()
@@ -273,10 +352,10 @@ func TestSendRequestAsyncRollsBackRUDetailsOnTransportFailure(t *testing.T) {
 
 	assert.Nil(t, gotResp)
 	assert.Error(t, gotErr)
-	assert.Equal(t, 0.0, ruDetails.RRU(),
-		"failed async no-response requests must not leave request-side RRU in runtime stats")
-	assert.Equal(t, 0.0, ruDetails.WRU(),
-		"failed async no-response requests must not leave request-side WRU in runtime stats")
+	assert.Equal(t, recordingRequestConsumption.RRU+recordingCancelDelta.RRU, ruDetails.RRU(),
+		"failed async no-response requests must apply PD's signed cancel delta to runtime stats")
+	assert.Equal(t, recordingRequestConsumption.WRU, ruDetails.WRU(),
+		"failed async no-response requests must not locally roll back write RU")
 }
 
 // respondingClient yields a non-nil empty response so the interceptor settles

--- a/internal/client/client_interceptor_test.go
+++ b/internal/client/client_interceptor_test.go
@@ -21,12 +21,13 @@ import (
 	"testing"
 	"time"
 
-	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/internal/resourcecontrol"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
+	"github.com/tikv/client-go/v2/util"
 	"github.com/tikv/client-go/v2/util/async"
 	resourceControlClient "github.com/tikv/pd/client/resource_group/controller"
 )
@@ -116,11 +117,13 @@ type recordingInterceptor struct {
 	cancelCalls int
 }
 
+var recordingRequestConsumption = &rmpb.Consumption{RRU: 11, WRU: 3}
+
 func (r *recordingInterceptor) OnRequestWait(
 	context.Context, string, resourceControlClient.RequestInfo,
 ) (*rmpb.Consumption, *rmpb.Consumption, time.Duration, uint32, error) {
 	r.waitCalls++
-	return &rmpb.Consumption{}, &rmpb.Consumption{}, 0, 0, nil
+	return recordingRequestConsumption, &rmpb.Consumption{}, 0, 0, nil
 }
 
 func (r *recordingInterceptor) OnResponse(
@@ -199,6 +202,21 @@ func TestSendRequestCancelsPreChargeOnTransportFailure(t *testing.T) {
 		"OnRequestCancel must run when the inner client returns no response")
 }
 
+func TestSendRequestRollsBackRUDetailsOnTransportFailure(t *testing.T) {
+	withRecordingInterceptor(t)
+	client := NewInterceptedClient(failingClient{})
+	ruDetails := util.NewRUDetails()
+	ctx := context.WithValue(context.Background(), util.RUDetailsCtxKey, ruDetails)
+
+	resp, err := client.SendRequest(ctx, "", newRGRequest(), 0)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, ruDetails.RRU(),
+		"failed no-response requests must not leave request-side RRU in runtime stats")
+	assert.Equal(t, 0.0, ruDetails.WRU(),
+		"failed no-response requests must not leave request-side WRU in runtime stats")
+}
+
 func TestSendRequestDoesNotCancelOnSuccess(t *testing.T) {
 	rec := withRecordingInterceptor(t)
 	// Inner client returns a non-nil response (default emptyClient yields
@@ -234,6 +252,31 @@ func TestSendRequestAsyncCancelsPreChargeOnTransportFailure(t *testing.T) {
 	assert.Equal(t, 0, rec.respCalls)
 	assert.Equal(t, 1, rec.cancelCalls,
 		"OnRequestCancel must run on the async path too when resp is nil")
+}
+
+func TestSendRequestAsyncRollsBackRUDetailsOnTransportFailure(t *testing.T) {
+	withRecordingInterceptor(t)
+	client := NewInterceptedClient(failingClient{})
+	ruDetails := util.NewRUDetails()
+	ctx := context.WithValue(context.Background(), util.RUDetailsCtxKey, ruDetails)
+
+	done := make(chan struct{})
+	var gotResp *tikvrpc.Response
+	var gotErr error
+	cb := async.NewCallback(nil, func(resp *tikvrpc.Response, err error) {
+		gotResp = resp
+		gotErr = err
+		close(done)
+	})
+	client.SendRequestAsync(ctx, "", newRGRequest(), cb)
+	<-done
+
+	assert.Nil(t, gotResp)
+	assert.Error(t, gotErr)
+	assert.Equal(t, 0.0, ruDetails.RRU(),
+		"failed async no-response requests must not leave request-side RRU in runtime stats")
+	assert.Equal(t, 0.0, ruDetails.WRU(),
+		"failed async no-response requests must not leave request-side WRU in runtime stats")
 }
 
 // respondingClient yields a non-nil empty response so the interceptor settles

--- a/internal/client/client_interceptor_test.go
+++ b/internal/client/client_interceptor_test.go
@@ -16,16 +16,19 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/tikv/client-go/v2/internal/resourcecontrol"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/tikvrpc/interceptor"
 	"github.com/tikv/client-go/v2/util/async"
+	resourceControlClient "github.com/tikv/pd/client/resource_group/controller"
 )
 
 type emptyClient struct{}
@@ -102,6 +105,145 @@ func TestAppendChainedInterceptor(t *testing.T) {
 	// add duplciated
 	chain = interceptor.ChainRPCInterceptors(chain, mkInterceptorFn(1))
 	checkChained(chain, 5, []int{0, 2, 3, 4, 1})
+}
+
+// recordingInterceptor counts OnRequestWait / OnResponseWait / OnRequestCancel
+// invocations and returns benign zero values so the interceptor wiring can be
+// exercised end-to-end without touching real PD state.
+type recordingInterceptor struct {
+	waitCalls   int
+	respCalls   int
+	cancelCalls int
+}
+
+func (r *recordingInterceptor) OnRequestWait(
+	context.Context, string, resourceControlClient.RequestInfo,
+) (*rmpb.Consumption, *rmpb.Consumption, time.Duration, uint32, error) {
+	r.waitCalls++
+	return &rmpb.Consumption{}, &rmpb.Consumption{}, 0, 0, nil
+}
+
+func (r *recordingInterceptor) OnResponse(
+	string, resourceControlClient.RequestInfo, resourceControlClient.ResponseInfo,
+) (*rmpb.Consumption, error) {
+	return &rmpb.Consumption{}, nil
+}
+
+func (r *recordingInterceptor) OnResponseWait(
+	context.Context, string, resourceControlClient.RequestInfo, resourceControlClient.ResponseInfo,
+) (*rmpb.Consumption, time.Duration, error) {
+	r.respCalls++
+	return &rmpb.Consumption{}, 0, nil
+}
+
+func (r *recordingInterceptor) OnRequestCancel(
+	context.Context, string, resourceControlClient.RequestInfo,
+) {
+	r.cancelCalls++
+}
+
+func (r *recordingInterceptor) IsBackgroundRequest(context.Context, string, string) bool {
+	return false
+}
+
+func (r *recordingInterceptor) GetRUVersion() resourceControlClient.RUVersion {
+	return resourceControlClient.DefaultRUVersion
+}
+
+// failingClient simulates a transport-level RPC failure: SendRequest returns
+// (nil, err) so the interceptor's OnResponseWait path is skipped and the
+// cancel path must take over.
+type failingClient struct{ emptyClient }
+
+func (c failingClient) SendRequest(
+	context.Context, string, *tikvrpc.Request, time.Duration,
+) (*tikvrpc.Response, error) {
+	return nil, errors.New("simulated transport failure")
+}
+
+func (c failingClient) SendRequestAsync(
+	_ context.Context, _ string, _ *tikvrpc.Request, cb async.Callback[*tikvrpc.Response],
+) {
+	cb.Invoke(nil, errors.New("simulated transport failure"))
+}
+
+func withRecordingInterceptor(t *testing.T) *recordingInterceptor {
+	t.Helper()
+	rec := &recordingInterceptor{}
+	var iface resourceControlClient.ResourceGroupKVInterceptor = rec
+	ResourceControlSwitch.Store(true)
+	ResourceControlInterceptor.Store(&iface)
+	t.Cleanup(func() {
+		ResourceControlSwitch.Store(false)
+		ResourceControlInterceptor.Store(nil)
+	})
+	return rec
+}
+
+func newRGRequest() *tikvrpc.Request {
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{})
+	req.ResourceControlContext = &kvrpcpb.ResourceControlContext{ResourceGroupName: "test-rg"}
+	return req
+}
+
+func TestSendRequestCancelsPreChargeOnTransportFailure(t *testing.T) {
+	rec := withRecordingInterceptor(t)
+	client := NewInterceptedClient(failingClient{})
+
+	resp, err := client.SendRequest(context.Background(), "", newRGRequest(), 0)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Equal(t, 1, rec.waitCalls, "OnRequestWait must run once")
+	assert.Equal(t, 0, rec.respCalls, "OnResponseWait must be skipped when resp is nil")
+	assert.Equal(t, 1, rec.cancelCalls,
+		"OnRequestCancel must run when the inner client returns no response")
+}
+
+func TestSendRequestDoesNotCancelOnSuccess(t *testing.T) {
+	rec := withRecordingInterceptor(t)
+	// Inner client returns a non-nil response (default emptyClient yields
+	// nil but its purpose here is to NOT yield nil — wrap it).
+	client := NewInterceptedClient(respondingClient{})
+
+	resp, err := client.SendRequest(context.Background(), "", newRGRequest(), 0)
+	assert.NotNil(t, resp)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rec.waitCalls)
+	assert.Equal(t, 1, rec.respCalls, "settlement path must run when resp is non-nil")
+	assert.Equal(t, 0, rec.cancelCalls, "cancel must not run when resp is non-nil")
+}
+
+func TestSendRequestAsyncCancelsPreChargeOnTransportFailure(t *testing.T) {
+	rec := withRecordingInterceptor(t)
+	client := NewInterceptedClient(failingClient{})
+
+	done := make(chan struct{})
+	var gotResp *tikvrpc.Response
+	var gotErr error
+	cb := async.NewCallback(nil, func(resp *tikvrpc.Response, err error) {
+		gotResp = resp
+		gotErr = err
+		close(done)
+	})
+	client.SendRequestAsync(context.Background(), "", newRGRequest(), cb)
+	<-done
+
+	assert.Nil(t, gotResp)
+	assert.Error(t, gotErr)
+	assert.Equal(t, 1, rec.waitCalls)
+	assert.Equal(t, 0, rec.respCalls)
+	assert.Equal(t, 1, rec.cancelCalls,
+		"OnRequestCancel must run on the async path too when resp is nil")
+}
+
+// respondingClient yields a non-nil empty response so the interceptor settles
+// through OnResponseWait rather than the cancel path.
+type respondingClient struct{ emptyClient }
+
+func (c respondingClient) SendRequest(
+	context.Context, string, *tikvrpc.Request, time.Duration,
+) (*tikvrpc.Response, error) {
+	return &tikvrpc.Response{}, nil
 }
 
 func TestBypassRUV2FollowsRequestInfoBypass(t *testing.T) {

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -38,10 +38,8 @@ type RequestInfo struct {
 	replicaNumber int64
 	requestSize   uint64
 	accessType    controller.AccessLocationType
-	// predictedReadBytes is an optional learned estimate (e.g. from a
-	// per-logical-scan EMA in TiDB) of how many bytes this request will
-	// read. When > 0, PD's resource control uses it as the byte basis for
-	// RC paging pre-charge.
+	// predictedReadBytes is an optional caller-supplied read-bytes
+	// estimate; when > 0 it is the basis for RC paging pre-charge.
 	predictedReadBytes uint64
 	// bypass indicates whether the request should be bypassed.
 	// some internal request should be bypassed, such as Privilege request.
@@ -92,15 +90,11 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 	storeID := req.Context.GetPeer().GetStoreId()
 	if !req.IsTxnWriteRequest() && !req.IsRawWriteRequest() {
 		return &RequestInfo{
-			writeBytes:  -1,
-			storeID:     storeID,
-			bypass:      bypass,
-			requestSize: uint64(req.GetSize()),
-			accessType:  toPDAccessLocationType(req.AccessLocation),
-			// PredictedReadBytes is a client-go-internal hint set by the
-			// caller (e.g. TiDB) before the RPC is dispatched; the resource
-			// control layer uses it as the byte basis for RC paging
-			// pre-charge when non-zero.
+			writeBytes:         -1,
+			storeID:            storeID,
+			bypass:             bypass,
+			requestSize:        uint64(req.GetSize()),
+			accessType:         toPDAccessLocationType(req.AccessLocation),
 			predictedReadBytes: req.PredictedReadBytes,
 		}
 	}
@@ -165,13 +159,8 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
 }
 
-// PredictedReadBytes returns an optional learned estimate of how many bytes
-// the request will read. When > 0, PD's resource control uses this as the
-// byte basis for RC paging pre-charge; when zero the request is not
-// pre-charged and is billed at settlement time by actual read bytes only.
-//
-// This satisfies the optional predictedReadBytesProvider interface on
-// PD's controller.RequestInfo side via duck-typing.
+// PredictedReadBytes satisfies PD's optional predictedReadBytesProvider
+// interface via duck-typing.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
 }

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -159,8 +159,8 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
 }
 
-// PredictedReadBytes satisfies PD's optional predictedReadBytesProvider
-// interface via duck-typing.
+// PredictedReadBytes implements PD's controller.RequestInfo interface,
+// supplying the read-bytes hint used for RC paging pre-charge.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
 }

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -38,6 +38,11 @@ type RequestInfo struct {
 	replicaNumber int64
 	requestSize   uint64
 	accessType    controller.AccessLocationType
+	// predictedReadBytes is an optional learned estimate (e.g. from a
+	// per-logical-scan EMA in TiDB) of how many bytes this request will
+	// read. When > 0, PD's resource control uses it as the byte basis for
+	// RC paging pre-charge.
+	predictedReadBytes uint64
 	// bypass indicates whether the request should be bypassed.
 	// some internal request should be bypassed, such as Privilege request.
 	bypass bool
@@ -92,6 +97,11 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 			bypass:      bypass,
 			requestSize: uint64(req.GetSize()),
 			accessType:  toPDAccessLocationType(req.AccessLocation),
+			// PredictedReadBytes is a client-go-internal hint set by the
+			// caller (e.g. TiDB) before the RPC is dispatched; the resource
+			// control layer uses it as the byte basis for RC paging
+			// pre-charge when non-zero.
+			predictedReadBytes: req.PredictedReadBytes,
 		}
 	}
 
@@ -153,6 +163,17 @@ func (req *RequestInfo) RequestSize() uint64 {
 
 func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
+}
+
+// PredictedReadBytes returns an optional learned estimate of how many bytes
+// the request will read. When > 0, PD's resource control uses this as the
+// byte basis for RC paging pre-charge; when zero the request is not
+// pre-charged and is billed at settlement time by actual read bytes only.
+//
+// This satisfies the optional predictedReadBytesProvider interface on
+// PD's controller.RequestInfo side via duck-typing.
+func (req *RequestInfo) PredictedReadBytes() uint64 {
+	return req.predictedReadBytes
 }
 
 // ResponseInfo contains information about a response that is able to calculate the RU cost

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -41,6 +41,10 @@ type RequestInfo struct {
 	// predictedReadBytes is an optional caller-supplied read-bytes
 	// estimate; when > 0 it is the basis for RC paging pre-charge.
 	predictedReadBytes uint64
+	// isCop is true when the underlying tikvrpc.Request targets the
+	// coprocessor endpoint (CmdCop / CmdCopStream). PD uses this to
+	// scope paging_* metrics to coprocessor reads only.
+	isCop bool
 	// bypass indicates whether the request should be bypassed.
 	// some internal request should be bypassed, such as Privilege request.
 	bypass bool
@@ -96,6 +100,7 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 			requestSize:        uint64(req.GetSize()),
 			accessType:         toPDAccessLocationType(req.AccessLocation),
 			predictedReadBytes: req.PredictedReadBytes,
+			isCop:              isCopRequest(req),
 		}
 	}
 
@@ -163,6 +168,20 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 // supplying the read-bytes hint used for RC paging pre-charge.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
+}
+
+// IsCop implements PD's controller.RequestInfo interface. It reports whether
+// the underlying tikvrpc.Request targets the coprocessor endpoint, so that
+// PD can scope paging_* metrics to coprocessor reads and ignore point gets,
+// batch gets, scans, and other bounded-size reads that share the same RC
+// interceptor path.
+func (req *RequestInfo) IsCop() bool {
+	return req.isCop
+}
+
+// isCopRequest reports whether req is a coprocessor read RPC.
+func isCopRequest(req *tikvrpc.Request) bool {
+	return req.Type == tikvrpc.CmdCop || req.Type == tikvrpc.CmdCopStream
 }
 
 // ResponseInfo contains information about a response that is able to calculate the RU cost

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -39,7 +39,8 @@ type RequestInfo struct {
 	requestSize   uint64
 	accessType    controller.AccessLocationType
 	// predictedReadBytes is an optional caller-supplied read-bytes
-	// estimate; when > 0 it is the basis for RC paging pre-charge.
+	// estimate. The PD controller decides whether to use it for paging
+	// accounting based on request type; non-cop hints may be ignored.
 	predictedReadBytes uint64
 	// isCop is true when the underlying tikvrpc.Request targets the
 	// coprocessor endpoint (CmdCop / CmdCopStream). PD uses this to
@@ -165,7 +166,8 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 }
 
 // PredictedReadBytes implements PD's controller.RequestInfo interface,
-// supplying the read-bytes hint used for RC paging pre-charge.
+// supplying the read-bytes hint. The PD controller decides whether the hint is
+// eligible for paging accounting based on the request type.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
 }

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -49,6 +49,30 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(0), info.StoreID())
 }
 
+func TestMakeRequestInfoPredictedReadBytes(t *testing.T) {
+	// A read request may carry an optional PredictedReadBytes hint on
+	// tikvrpc.Request; MakeRequestInfo should propagate it to RequestInfo.
+	req := &tikvrpc.Request{
+		Req:                &kvrpcpb.BatchGetRequest{},
+		Context:            kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 7}},
+		PredictedReadBytes: 256 * 1024,
+	}
+	info := MakeRequestInfo(req)
+	assert.False(t, info.IsWrite())
+	assert.Equal(t, uint64(256*1024), info.PredictedReadBytes(),
+		"predictedReadBytes should propagate from tikvrpc.Request")
+
+	// Without a hint, PredictedReadBytes defaults to 0 so PD skips
+	// pre-charge and bills at settlement time by actual read bytes only.
+	reqNoHint := &tikvrpc.Request{
+		Req:     &kvrpcpb.BatchGetRequest{},
+		Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 7}},
+	}
+	infoNoHint := MakeRequestInfo(reqNoHint)
+	assert.Equal(t, uint64(0), infoNoHint.PredictedReadBytes(),
+		"zero hint on the request means zero on RequestInfo")
+}
+
 func TestResponseInfoReadBytes(t *testing.T) {
 	resp := &tikvrpc.Response{
 		Resp: &coprocessor.Response{

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -62,8 +62,8 @@ func TestMakeRequestInfoPredictedReadBytes(t *testing.T) {
 	assert.Equal(t, uint64(256*1024), info.PredictedReadBytes(),
 		"predictedReadBytes should propagate from tikvrpc.Request")
 
-	// Without a hint, PredictedReadBytes defaults to 0 so PD skips
-	// pre-charge and bills at settlement time by actual read bytes only.
+	// Without a hint, PredictedReadBytes defaults to 0. This test only
+	// checks client-go propagation; PD still decides request eligibility.
 	reqNoHint := &tikvrpc.Request{
 		Req:     &kvrpcpb.BatchGetRequest{},
 		Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 7}},

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -73,6 +73,35 @@ func TestMakeRequestInfoPredictedReadBytes(t *testing.T) {
 		"zero hint on the request means zero on RequestInfo")
 }
 
+func TestMakeRequestInfoIsCop(t *testing.T) {
+	// Coprocessor requests must carry IsCop()==true so PD can scope
+	// paging_* metrics to them.
+	copReq := &tikvrpc.Request{
+		Type:    tikvrpc.CmdCop,
+		Req:     &coprocessor.Request{},
+		Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}},
+	}
+	assert.True(t, MakeRequestInfo(copReq).IsCop())
+
+	copStreamReq := &tikvrpc.Request{
+		Type:    tikvrpc.CmdCopStream,
+		Req:     &coprocessor.Request{},
+		Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}},
+	}
+	assert.True(t, MakeRequestInfo(copStreamReq).IsCop())
+
+	// Non-cop reads (Get, BatchGet, Scan) must carry IsCop()==false so
+	// PD ignores them in the paging accounting branch.
+	for _, req := range []*tikvrpc.Request{
+		{Type: tikvrpc.CmdGet, Req: &kvrpcpb.GetRequest{}, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}}},
+		{Type: tikvrpc.CmdBatchGet, Req: &kvrpcpb.BatchGetRequest{}, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}}},
+		{Type: tikvrpc.CmdScan, Req: &kvrpcpb.ScanRequest{}, Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 1}}},
+	} {
+		assert.False(t, MakeRequestInfo(req).IsCop(),
+			"non-cop cmd type %v must report IsCop()==false", req.Type)
+	}
+}
+
 func TestResponseInfoReadBytes(t *testing.T) {
 	resp := &tikvrpc.Response{
 		Resp: &coprocessor.Response{

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -267,6 +267,17 @@ type Request struct {
 	InputRequestSource string
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
+	// PredictedReadBytes is an optional hint (e.g. from a per-logical-scan
+	// EMA maintained in TiDB across multiple paging cop RPCs) predicting how
+	// many bytes this request will read. When non-zero, resource control
+	// uses it as the byte basis for RC paging pre-charge. Zero means the
+	// caller has no prediction (e.g. cold start) and the request is not
+	// pre-charged; it is still billed at settlement time by actual read
+	// bytes.
+	//
+	// This is a client-go-internal field, not carried in the proto; it is
+	// only consumed by the resource-control layer before the RPC is sent.
+	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32
 }

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -267,16 +267,11 @@ type Request struct {
 	InputRequestSource string
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
-	// PredictedReadBytes is an optional hint (e.g. from a per-logical-scan
-	// EMA maintained in TiDB across multiple paging cop RPCs) predicting how
-	// many bytes this request will read. When non-zero, resource control
-	// uses it as the byte basis for RC paging pre-charge. Zero means the
-	// caller has no prediction (e.g. cold start) and the request is not
-	// pre-charged; it is still billed at settlement time by actual read
-	// bytes.
-	//
-	// This is a client-go-internal field, not carried in the proto; it is
-	// only consumed by the resource-control layer before the RPC is sent.
+	// PredictedReadBytes is an optional caller-supplied estimate of this
+	// request's read bytes (e.g. from a TiDB per-scan EMA). When > 0, the
+	// resource-control layer uses it as the RC paging pre-charge basis;
+	// when 0, the request is not pre-charged and is billed by actual read
+	// bytes at settlement.
 	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -268,10 +268,9 @@ type Request struct {
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
 	// PredictedReadBytes is an optional caller-supplied estimate of this
-	// request's read bytes (e.g. from a TiDB per-scan EMA). When > 0, the
-	// resource-control layer uses it as the RC paging pre-charge basis;
-	// when 0, the request is not pre-charged and is billed by actual read
-	// bytes at settlement.
+	// request's read bytes. When > 0, the resource-control layer uses it
+	// as the RC paging pre-charge basis; when 0, the request is not
+	// pre-charged and is billed by actual read bytes at settlement.
 	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -268,9 +268,9 @@ type Request struct {
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
 	// PredictedReadBytes is an optional caller-supplied estimate of this
-	// request's read bytes. When > 0, the resource-control layer uses it
-	// as the RC paging pre-charge basis; when 0, the request is not
-	// pre-charged and is billed by actual read bytes at settlement.
+	// request's read bytes. The resource-control layer passes it to PD's
+	// controller, which decides whether the request type is eligible for
+	// paging pre-charge; non-cop hints may be ignored.
 	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32


### PR DESCRIPTION
Draft / test-bundle PR for the `rc-precharge-classic-test` integration bundle (classic / non-Premium variant of the RC paging pre-charge feature).

## Summary
- `resourcecontrol`: add `PredictedReadBytes` hint to `RequestInfo`
- `tikvrpc`: tighten `PredictedReadBytes` field comment

## Sibling PRs (test bundle)
- pingcap/kvproto `rc-precharge-classic-test`
- tikv/pd `rc-precharge-classic-test`
- pingcap/tidb `rc-precharge-classic-test`
- tikv/tikv `rc-precharge-classic-test`

This branch exists for upstream CI / cross-repo integration testing. Not intended to be merged as-is.