### PR TITLE
[DO NOT MERGE / test bundle] resourcecontrol: PredictedReadBytes hint for paging pre-charge

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -38,10 +38,8 @@ type RequestInfo struct {
 	replicaNumber int64
 	requestSize   uint64
 	accessType    controller.AccessLocationType
-	// predictedReadBytes is an optional learned estimate (e.g. from a
-	// per-logical-scan EMA in TiDB) of how many bytes this request will
-	// read. When > 0, PD's resource control uses it as the byte basis for
-	// RC paging pre-charge.
+	// predictedReadBytes is an optional caller-supplied read-bytes
+	// estimate; when > 0 it is the basis for RC paging pre-charge.
 	predictedReadBytes uint64
 	// bypass indicates whether the request should be bypassed.
 	// some internal request should be bypassed, such as Privilege request.
@@ -92,15 +90,11 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 	storeID := req.Context.GetPeer().GetStoreId()
 	if !req.IsTxnWriteRequest() && !req.IsRawWriteRequest() {
 		return &RequestInfo{
-			writeBytes:  -1,
-			storeID:     storeID,
-			bypass:      bypass,
-			requestSize: uint64(req.GetSize()),
-			accessType:  toPDAccessLocationType(req.AccessLocation),
-			// PredictedReadBytes is a client-go-internal hint set by the
-			// caller (e.g. TiDB) before the RPC is dispatched; the resource
-			// control layer uses it as the byte basis for RC paging
-			// pre-charge when non-zero.
+			writeBytes:         -1,
+			storeID:            storeID,
+			bypass:             bypass,
+			requestSize:        uint64(req.GetSize()),
+			accessType:         toPDAccessLocationType(req.AccessLocation),
 			predictedReadBytes: req.PredictedReadBytes,
 		}
 	}
@@ -165,13 +159,8 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
 }
 
-// PredictedReadBytes returns an optional learned estimate of how many bytes
-// the request will read. When > 0, PD's resource control uses this as the
-// byte basis for RC paging pre-charge; when zero the request is not
-// pre-charged and is billed at settlement time by actual read bytes only.
-//
-// This satisfies the optional predictedReadBytesProvider interface on
-// PD's controller.RequestInfo side via duck-typing.
+// PredictedReadBytes satisfies PD's optional predictedReadBytesProvider
+// interface via duck-typing.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
 }

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -159,8 +159,8 @@ func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
 }
 
-// PredictedReadBytes satisfies PD's optional predictedReadBytesProvider
-// interface via duck-typing.
+// PredictedReadBytes implements PD's controller.RequestInfo interface,
+// supplying the read-bytes hint used for RC paging pre-charge.
 func (req *RequestInfo) PredictedReadBytes() uint64 {
 	return req.predictedReadBytes
 }

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -38,6 +38,11 @@ type RequestInfo struct {
 	replicaNumber int64
 	requestSize   uint64
 	accessType    controller.AccessLocationType
+	// predictedReadBytes is an optional learned estimate (e.g. from a
+	// per-logical-scan EMA in TiDB) of how many bytes this request will
+	// read. When > 0, PD's resource control uses it as the byte basis for
+	// RC paging pre-charge.
+	predictedReadBytes uint64
 	// bypass indicates whether the request should be bypassed.
 	// some internal request should be bypassed, such as Privilege request.
 	bypass bool
@@ -92,6 +97,11 @@ func MakeRequestInfo(req *tikvrpc.Request) *RequestInfo {
 			bypass:      bypass,
 			requestSize: uint64(req.GetSize()),
 			accessType:  toPDAccessLocationType(req.AccessLocation),
+			// PredictedReadBytes is a client-go-internal hint set by the
+			// caller (e.g. TiDB) before the RPC is dispatched; the resource
+			// control layer uses it as the byte basis for RC paging
+			// pre-charge when non-zero.
+			predictedReadBytes: req.PredictedReadBytes,
 		}
 	}
 
@@ -153,6 +163,17 @@ func (req *RequestInfo) RequestSize() uint64 {
 
 func (req *RequestInfo) AccessLocationType() controller.AccessLocationType {
 	return req.accessType
+}
+
+// PredictedReadBytes returns an optional learned estimate of how many bytes
+// the request will read. When > 0, PD's resource control uses this as the
+// byte basis for RC paging pre-charge; when zero the request is not
+// pre-charged and is billed at settlement time by actual read bytes only.
+//
+// This satisfies the optional predictedReadBytesProvider interface on
+// PD's controller.RequestInfo side via duck-typing.
+func (req *RequestInfo) PredictedReadBytes() uint64 {
+	return req.predictedReadBytes
 }
 
 // ResponseInfo contains information about a response that is able to calculate the RU cost

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -49,6 +49,30 @@ func TestMakeRequestInfo(t *testing.T) {
 	assert.Equal(t, uint64(0), info.StoreID())
 }
 
+func TestMakeRequestInfoPredictedReadBytes(t *testing.T) {
+	// A read request may carry an optional PredictedReadBytes hint on
+	// tikvrpc.Request; MakeRequestInfo should propagate it to RequestInfo.
+	req := &tikvrpc.Request{
+		Req:                &kvrpcpb.BatchGetRequest{},
+		Context:            kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 7}},
+		PredictedReadBytes: 256 * 1024,
+	}
+	info := MakeRequestInfo(req)
+	assert.False(t, info.IsWrite())
+	assert.Equal(t, uint64(256*1024), info.PredictedReadBytes(),
+		"predictedReadBytes should propagate from tikvrpc.Request")
+
+	// Without a hint, PredictedReadBytes defaults to 0 so PD skips
+	// pre-charge and bills at settlement time by actual read bytes only.
+	reqNoHint := &tikvrpc.Request{
+		Req:     &kvrpcpb.BatchGetRequest{},
+		Context: kvrpcpb.Context{Peer: &metapb.Peer{StoreId: 7}},
+	}
+	infoNoHint := MakeRequestInfo(reqNoHint)
+	assert.Equal(t, uint64(0), infoNoHint.PredictedReadBytes(),
+		"zero hint on the request means zero on RequestInfo")
+}
+
 func TestResponseInfoReadBytes(t *testing.T) {
 	resp := &tikvrpc.Response{
 		Resp: &coprocessor.Response{

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -267,6 +267,17 @@ type Request struct {
 	InputRequestSource string
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
+	// PredictedReadBytes is an optional hint (e.g. from a per-logical-scan
+	// EMA maintained in TiDB across multiple paging cop RPCs) predicting how
+	// many bytes this request will read. When non-zero, resource control
+	// uses it as the byte basis for RC paging pre-charge. Zero means the
+	// caller has no prediction (e.g. cold start) and the request is not
+	// pre-charged; it is still billed at settlement time by actual read
+	// bytes.
+	//
+	// This is a client-go-internal field, not carried in the proto; it is
+	// only consumed by the resource-control layer before the RPC is sent.
+	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32
 }

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -267,16 +267,11 @@ type Request struct {
 	InputRequestSource string
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
-	// PredictedReadBytes is an optional hint (e.g. from a per-logical-scan
-	// EMA maintained in TiDB across multiple paging cop RPCs) predicting how
-	// many bytes this request will read. When non-zero, resource control
-	// uses it as the byte basis for RC paging pre-charge. Zero means the
-	// caller has no prediction (e.g. cold start) and the request is not
-	// pre-charged; it is still billed at settlement time by actual read
-	// bytes.
-	//
-	// This is a client-go-internal field, not carried in the proto; it is
-	// only consumed by the resource-control layer before the RPC is sent.
+	// PredictedReadBytes is an optional caller-supplied estimate of this
+	// request's read bytes (e.g. from a TiDB per-scan EMA). When > 0, the
+	// resource-control layer uses it as the RC paging pre-charge basis;
+	// when 0, the request is not pre-charged and is billed by actual read
+	// bytes at settlement.
 	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -268,10 +268,9 @@ type Request struct {
 	// AccessLocationAttr indicates the request is sent to a different zone.
 	AccessLocation kv.AccessLocationType
 	// PredictedReadBytes is an optional caller-supplied estimate of this
-	// request's read bytes (e.g. from a TiDB per-scan EMA). When > 0, the
-	// resource-control layer uses it as the RC paging pre-charge basis;
-	// when 0, the request is not pre-charged and is billed by actual read
-	// bytes at settlement.
+	// request's read bytes. When > 0, the resource-control layer uses it
+	// as the RC paging pre-charge basis; when 0, the request is not
+	// pre-charged and is billed by actual read bytes at settlement.
 	PredictedReadBytes uint64
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32


### PR DESCRIPTION
Draft / test-bundle PR for the `rc-precharge-premium-test` integration bundle (Premium / TiDB X variant of the RC paging pre-charge feature).

## Summary
- `resourcecontrol`: add `PredictedReadBytes` hint to `RequestInfo`
- `tikvrpc`: tighten `PredictedReadBytes` field comment

## Sibling PRs (test bundle)
- pingcap/kvproto `rc-precharge-premium-test`
- tikv/pd `rc-precharge-premium-test`
- pingcap/tidb `rc-precharge-premium-test`
- tidbcloud/cloud-storage-engine `rc-precharge-premium-test`

This branch exists for upstream CI / cross-repo integration testing. Not intended to be merged as-is.