### PR TITLE
locate: fail fast on TLS authentication errors instead of backoffer retry

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -1780,6 +1780,11 @@ func (s *RegionRequestSender) onSendFail(bo *retry.Backoffer, ctx *RPCContext, r
 		return err
 	}
 
+	// TLS certificate errors are permanent configuration issues; retrying will not help.
+	if isTLSAuthError(err) {
+		return errors.WithStack(err)
+	}
+
 	if ctx.Store != nil && ctx.Store.StoreType() == tikvrpc.TiFlashCompute {
 		s.regionCache.InvalidateTiFlashComputeStoresIfGRPCError(err)
 	} else if ctx.Meta != nil {
@@ -1812,6 +1817,14 @@ func isCauseByDeadlineExceeded(err error) bool {
 	causeErr := errors.Cause(err)
 	return causeErr == context.DeadlineExceeded || // batch-client will return this error.
 		status.Code(causeErr) == codes.DeadlineExceeded // when batch-client is disabled, grpc will return this error.
+}
+
+func isTLSAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "x509:") || strings.Contains(msg, "authentication handshake failed")
 }
 
 // NeedReloadRegion checks is all peers has sent failed, if so need reload.

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -73,6 +73,8 @@ import (
 	pd "github.com/tikv/pd/client"
 	pderr "github.com/tikv/pd/client/errs"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestRegionRequestToSingleStore(t *testing.T) {
@@ -1252,6 +1254,48 @@ func TestRPCContextString(t *testing.T) {
 		require.Contains(t, ctx.String(), ", proxy store id: 2, proxy addr: tikv-2")
 		require.Contains(t, ctx.ToBackoffReasonString(), ", proxy store id: 2, proxy addr: tikv-2")
 	})
+}
+
+func (s *testRegionRequestToSingleStoreSuite) TestSendReqTLSFailFast() {
+	req := tikvrpc.NewRequest(tikvrpc.CmdCop, &coprocessor.Request{
+		Tp:      0,
+		Data:    []byte("test"),
+		Ranges:  nil,
+		Context: &kvrpcpb.Context{},
+	})
+	region, err := s.cache.LocateRegionByID(s.bo, s.region)
+	s.Nil(err)
+	s.NotNil(region)
+
+	test := func() {
+		oc := s.regionRequestSender.client
+		defer func() {
+			s.regionRequestSender.client = oc
+		}()
+
+		// Simulate the gRPC error produced when TLS ServerName "localhost" does not match cert SANs.
+		tlsErr := status.Error(codes.Unavailable,
+			`connection error: desc = "transport: authentication handshake failed: `+
+				`tls: failed to verify certificate: x509: certificate is valid for example.com, not localhost"`)
+
+		s.regionRequestSender.client = &fnClient{fn: func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+			return nil, tlsErr
+		}}
+
+		bo := retry.NewBackofferWithVars(context.Background(), 5, nil)
+		resp, retryTimes, err := s.regionRequestSender.SendReq(bo, req, region.Region, time.Second)
+		s.Nil(resp)
+		s.NotNil(err)
+		// TLS auth error should fail fast without any retry.
+		s.Zero(retryTimes)
+		s.Contains(err.Error(), "x509:")
+	}
+
+	s.Run("Default", test)
+
+	failpoint.Enable("tikvclient/useSendReqAsync", `return(true)`)
+	defer failpoint.Disable("tikvclient/useSendReqAsync")
+	s.Run("AsyncAPI", test)
 }
 
 func TestBackoffErrWithRPCContext(t *testing.T) {


### PR DESCRIPTION
### What is changed and how it works?

When a TiDB cluster table (e.g. CLUSTER_TIDB_TRX) fans out to a peer TiDB node whose advertise-address is empty, the status address becomes :10080. gRPC normalizes this to localhost:10080, causing TLS ServerName = "localhost" which fails certificate verification.

Previously, this TLS error was treated as a transient RPC failure and retried by the backoffer until the 40000ms budget was exhausted, turning an instant configuration bug into a ~40s query hang.

This PR detects TLS authentication errors in onSendFail and returns them immediately without retry, since certificate mismatches are permanent configuration issues that will not recover by waiting.

ref https://github.com/pingcap/tidb/issues/68519

### Changes

- internal/locate/region_request.go: add isTLSAuthError() helper and use it in onSendFail() to bypass backoffer retry for TLS errors.
- internal/locate/region_request_test.go: add TestSendReqTLSFailFast to verify zero retries for x509 errors.

### Check List

Tests
- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects
- [ ] Breaking backward compatibility
- [ ] Performance regression

### Related changes

- [ ] Need to cherry-pick to the release branch
- [ ] Need to update the documentation (none)
- [ ] Need to update the tidb-ansible repository (none)

### Release note

- Fail fast on TLS authentication errors instead of retrying until backoffer timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * TLS authentication certificate handshake failures are now treated as permanent, non-retriable errors. This prevents unnecessary retry attempts and improves response time for authentication failures.

* **Tests**
  * Added test coverage to verify that TLS authentication failures fail fast without retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/client-go/pull/1972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->