### PR TITLE
txnkv: enable TiKV-side async resolve region lock for read path

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -3,7 +3,7 @@ module txnkv
 go 1.25.8
 
 require (
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
 	github.com/tikv/client-go/v2 v2.0.0
 )
 

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 h1:wjhJRzyeRKpJqMg6XmqQ7cJdhEhE5mSoCh94rWdTVOk=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 h1:n6QWAac97mv2NJhn17iFPFnsE5fMgtPLNmsGZeqq78o=
+github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53
+	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
 	github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1440,8 +1440,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53 h1:wjhJRzyeRKpJqMg6XmqQ7cJdhEhE5mSoCh94rWdTVOk=
-github.com/pingcap/kvproto v0.0.0-20260408021215-335c5c64af53/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 h1:n6QWAac97mv2NJhn17iFPFnsE5fMgtPLNmsGZeqq78o=
+github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=
@@ -1584,8 +1584,6 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tikv/pd/client v0.0.0-20260228084044-4f5039d43753 h1:WSiznlCpoBCnJMZt5nHDC0Ig8PvQ9O+rgVSO7gwU44o=
-github.com/tikv/pd/client v0.0.0-20260228084044-4f5039d43753/go.mod h1:tloQKNFqF/T5JfLx4bloR8MKPZyp7y6cF3guAlls88M=
 github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 h1:5hCQ6J2fwUpYqIgQGR625bW98wvYS9FUpTiVszIbVSg=
 github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71/go.mod h1:4kxXuAQAREpH+lVbydVwGNNDmcwdj0RG4Ofwky08W/k=
 github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1765,6 +1765,10 @@ func (s *testLockWithTiKVSuite) TestPessimisticLockMaxExecutionTime() {
 }
 
 func TestResolveLockWithTiKVSideAsync(t *testing.T) {
+	if !*withTiKV {
+		t.Skip()
+	}
+
 	for _, commitPrimary := range []bool{true, false} {
 		name := "primary_rollback"
 		if commitPrimary {
@@ -1814,20 +1818,27 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 				committer.SetCommitTS(fetchTSO(store))
 				require.NoError(t, committer.CommitMutations(ctx))
 			} else {
-				time.Sleep(10 * time.Millisecond)
-				readTS := fetchTSO(store)
-				status, err := store.NewLockResolver().GetTxnStatus(
-					retry.NewBackofferWithVars(ctx, 60000, nil),
-					txn.StartTS(),
-					keys[0],
-					readTS,
-					readTS,
-					true,
-					false,
-					nil,
-				)
-				require.NoError(t, err)
-				require.True(t, status.IsRolledBack())
+				var lastErr error
+				require.Eventually(t, func() bool {
+					readTS := fetchTSO(store)
+					status, err := store.NewLockResolver().GetTxnStatus(
+						retry.NewBackofferWithVars(ctx, 60000, nil),
+						txn.StartTS(),
+						keys[0],
+						readTS,
+						readTS,
+						true,
+						false,
+						nil,
+					)
+					if err != nil {
+						lastErr = err
+						return false
+					}
+					lastErr = nil
+					return status.IsRolledBack()
+				}, 10*time.Second, 100*time.Millisecond)
+				require.NoError(t, lastErr)
 			}
 
 			// check all the locks except the primary lock are kept.

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1820,9 +1820,12 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 			} else {
 				var lastErr error
 				require.Eventually(t, func() bool {
+					pollCtx, cancel := context.WithTimeout(ctx, time.Second)
+					defer cancel()
+
 					readTS := fetchTSO(store)
 					status, err := store.NewLockResolver().GetTxnStatus(
-						retry.NewBackofferWithVars(ctx, 60000, nil),
+						retry.NewBackofferWithVars(pollCtx, 1000, nil),
 						txn.StartTS(),
 						keys[0],
 						readTS,

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -49,11 +49,14 @@ import (
 	deadlockpb "github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -1759,4 +1762,148 @@ func (s *testLockWithTiKVSuite) TestPessimisticLockMaxExecutionTime() {
 	s.NoError(txn5.Rollback())
 	s.NoError(txn6.Rollback())
 	s.NoError(txn7.Rollback())
+}
+
+func TestResolveLockWithTiKVSideAsync(t *testing.T) {
+	for _, commitPrimary := range []bool{true, false} {
+		name := "primary_rollback"
+		if commitPrimary {
+			name = "primary_commit"
+		}
+
+		fetchTSO := func(store tikv.StoreProbe) uint64 {
+			ts, err := store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+			require.NoError(t, err)
+			return ts
+		}
+
+		t.Run(name, func(t *testing.T) {
+			store := tikv.StoreProbe{KVStore: NewTestStore(t)}
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			ctx := context.Background()
+			lockTTL := uint64(3000)
+			if !commitPrimary {
+				lockTTL = 1
+			}
+
+			keys, values := make([][]byte, 0, 20), make([][]byte, 0, 20)
+			for i := 0; i < cap(keys); i++ {
+				keys = append(keys, []byte(fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
+				values = append(values, []byte(fmt.Sprintf("value_%s_%03d", name, i)))
+			}
+			require.Greater(t, uint64(len(keys)), config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold)
+
+			// prewrite
+			txn, err := store.Begin()
+			require.NoError(t, err)
+			for i, key := range keys {
+				require.NoError(t, txn.Set(key, values[i]))
+			}
+			committer, err := txn.NewCommitter(1)
+			require.NoError(t, err)
+			committer.SetPrimaryKey(keys[0])
+			committer.SetTxnSize(len(keys))
+			committer.SetLockTTL(lockTTL)
+			require.NoError(t, committer.PrewriteAllMutations(ctx))
+
+			// commit or rollback the primary
+			if commitPrimary {
+				committer.SetCommitTS(fetchTSO(store))
+				require.NoError(t, committer.CommitMutations(ctx))
+			} else {
+				time.Sleep(10 * time.Millisecond)
+				readTS := fetchTSO(store)
+				status, err := store.NewLockResolver().GetTxnStatus(
+					retry.NewBackofferWithVars(ctx, 60000, nil),
+					txn.StartTS(),
+					keys[0],
+					readTS,
+					readTS,
+					true,
+					false,
+					nil,
+				)
+				require.NoError(t, err)
+				require.True(t, status.IsRolledBack())
+			}
+
+			// check all the locks except the primary lock are kept.
+			keysEnd := []byte(fmt.Sprintf("resolve_lock_%s_\xff", name))
+			locks, err := store.ScanLocks(ctx, keys[0], keysEnd, fetchTSO(store))
+			require.NoError(t, err)
+			require.Len(t, locks, len(keys)-1, "only the primary lock should be resolved")
+
+			// trigger resolve lock for read
+			resolveLocksBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLocks)
+			resolveLockLiteBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite)
+			resolveLockReqs := make([]*kvrpcpb.ResolveLockRequest, 0)
+			require.NoError(t, failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+			defer func() {
+				require.NoError(t, failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+			}()
+			ctx = context.WithValue(ctx, "sendReqToRegionHook", func(req *tikvrpc.Request) {
+				if req.Type == tikvrpc.CmdResolveLock {
+					resolveLockReqs = append(resolveLockReqs, req.ResolveLock())
+				}
+			})
+			store.GetLockResolver().Close()
+
+			snapshot := store.GetSnapshot(fetchTSO(store))
+			value, err := snapshot.BatchGet(ctx, keys)
+			require.NoError(t, err)
+			if commitPrimary {
+				require.Len(t, value, len(keys))
+			} else {
+				require.Empty(t, value)
+			}
+
+			// wait all locks are resolved
+			require.Eventually(t, func() bool {
+				locks, err := store.ScanLocks(ctx, keys[0], keysEnd, fetchTSO(store))
+				require.NoError(t, err)
+				return len(locks) == 0
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// check resolve lock requests
+			require.NotEmpty(t, resolveLockReqs, "ResolveLock request should be sent")
+			for _, req := range resolveLockReqs {
+				require.Empty(t, req.Keys)
+				if commitPrimary {
+					require.Equal(t, committer.GetCommitTS(), req.CommitVersion)
+				} else {
+					require.Zero(t, req.CommitVersion)
+				}
+				// check in next-gen the IsAsync should be true in ResolveLockRequest
+				require.Equal(t, config.NextGen, req.GetIsAsync(), "ResolveLock should use TiKV-side async resolve")
+			}
+
+			// check resolve lock metrics, no resolve lock lite should be used
+			require.Greater(t,
+				testutil.ToFloat64(metrics.LockResolverCountWithResolveLocks),
+				resolveLocksBefore,
+				"ResolveLocks should be called",
+			)
+			require.Equal(
+				t,
+				resolveLockLiteBefore,
+				testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite),
+				"ResolveLock should be non-lite",
+			)
+
+			// check the keys are committed or rolled back correctly
+			snapshot = store.GetSnapshot(fetchTSO(store))
+			for i, key := range keys {
+				value, err := snapshot.Get(ctx, key)
+				if commitPrimary {
+					require.NoError(t, err)
+					require.Equal(t, values[i], value.Value)
+				} else {
+					require.True(t, tikverr.IsErrNotFound(err), "unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }

--- a/internal/client/client_collapse.go
+++ b/internal/client/client_collapse.go
@@ -82,7 +82,7 @@ func (r reqCollapse) SendRequestAsync(ctx context.Context, addr string, req *tik
 	}
 	if req.Type == tikvrpc.CmdResolveLock && len(req.ResolveLock().Keys) == 0 && len(req.ResolveLock().TxnInfos) == 0 {
 		// try collapse resolve lock request.
-		key := strconv.FormatUint(req.RegionId, 10) + "-" + strconv.FormatUint(req.ResolveLock().StartVersion, 10)
+		key := resolveLockCollapseKey(req)
 		copyReq := *req
 		rsC := resolveRegionSf.DoChan(key, func() (interface{}, error) {
 			// resolveRegionSf will call this function in a goroutine, thus use SendRequest directly.
@@ -119,13 +119,20 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 			return
 		}
 		canCollapse = true
-		key := strconv.FormatUint(req.RegionId, 10) + "-" + strconv.FormatUint(resolveLock.StartVersion, 10)
+		key := resolveLockCollapseKey(req)
 		resp, err = r.collapse(ctx, key, &resolveRegionSf, addr, req, timeout)
 		return
 	default:
 		// now we only support collapse resolve lock.
 		return
 	}
+}
+
+func resolveLockCollapseKey(req *tikvrpc.Request) string {
+	resolveLock := req.ResolveLock()
+	return strconv.FormatUint(req.RegionId, 10) + "-" +
+		strconv.FormatUint(resolveLock.StartVersion, 10) + "-" +
+		strconv.FormatBool(resolveLock.GetIsAsync())
 }
 
 func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -227,12 +227,13 @@ func (c *chanClient) SendRequestAsync(ctx context.Context, addr string, req *tik
 }
 
 func TestCollapseResolveLock(t *testing.T) {
-	buildResolveLockReq := func(regionID uint64, startTS uint64, commitTS uint64, keys [][]byte) *tikvrpc.Request {
+	buildResolveLockReq := func(regionID uint64, startTS uint64, commitTS uint64, keys [][]byte, isAsync bool) *tikvrpc.Request {
 		region := &metapb.Region{Id: regionID}
 		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, &kvrpcpb.ResolveLockRequest{
 			StartVersion:  startTS,
 			CommitVersion: commitTS,
 			Keys:          keys,
+			IsAsync:       isAsync,
 		})
 		tikvrpc.SetContextNoAttach(req, region, nil)
 		return req
@@ -252,7 +253,7 @@ func TestCollapseResolveLock(t *testing.T) {
 	ctx := context.Background()
 
 	// Collapse ResolveLock.
-	resolveLockReq := buildResolveLockReq(1, 10, 20, nil)
+	resolveLockReq := buildResolveLockReq(1, 10, 20, nil, false)
 	wg.Add(1)
 	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
 	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
@@ -266,8 +267,33 @@ func TestCollapseResolveLock(t *testing.T) {
 	default:
 	}
 
+	// Collapse async ResolveLock separately.
+	asyncResolveLockReq := buildResolveLockReq(1, 10, 20, nil, true)
+	wg.Add(1)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	time.Sleep(300 * time.Millisecond)
+	wg.Done()
+	req = <-reqCh
+	assert.Equal(t, *req, *asyncResolveLockReq)
+	select {
+	case <-reqCh:
+		assert.Fail(t, "fail to collapse async ResolveLock")
+	default:
+	}
+
+	// Don't collapse sync ResolveLock with async ResolveLock signal.
+	wg.Add(1)
+	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	time.Sleep(300 * time.Millisecond)
+	wg.Done()
+	for i := 0; i < 2; i++ {
+		<-reqCh
+	}
+
 	// Don't collapse ResolveLockLite.
-	resolveLockLiteReq := buildResolveLockReq(1, 10, 20, [][]byte{[]byte("foo")})
+	resolveLockLiteReq := buildResolveLockReq(1, 10, 20, [][]byte{[]byte("foo")}, false)
 	wg.Add(1)
 	go client.SendRequest(ctx, "", resolveLockLiteReq, time.Second)
 	go client.SendRequest(ctx, "", resolveLockLiteReq, time.Second)

--- a/internal/locate/region_request_test.go
+++ b/internal/locate/region_request_test.go
@@ -767,6 +767,10 @@ func (s *mockTikvGrpcServer) GetTiFlashSystemTable(context.Context, *kvrpcpb.TiF
 	return nil, errors.New("unreachable")
 }
 
+func (s *mockTikvGrpcServer) GetEstimateTiCICount(context.Context, *coprocessor.TiCIEstimateCountRequest) (*coprocessor.TiCIEstimateCountResponse, error) {
+	return nil, errors.New("unreachable")
+}
+
 func (s *mockTikvGrpcServer) GetDisaggConfig(context.Context, *disaggregated.GetDisaggConfigRequest) (*disaggregated.GetDisaggConfigResponse, error) {
 	return nil, errors.New("unreachable")
 }

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1562,8 +1562,3 @@ func (lr *LockResolver) resolvePessimisticLock(bo *retry.Backoffer, l *Lock, pes
 		return nil
 	}
 }
-
-// SetEnableTiKVSideAsyncResolve sets whether to enable TiKV-side async resolve.
-func (lr *LockResolver) SetEnableTiKVSideAsyncResolve(enabled bool) {
-	lr.enableTiKVSideAsyncResolve.Store(enabled)
-}

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1428,6 +1428,9 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 			metrics.LockResolverCountWithResolveLockLite.Inc()
 			lreq.Keys = [][]byte{l.Key}
 		} else if !resultRequired && lr.enableTiKVSideAsyncResolve.Load() {
+			if intest.InTest && !config.NextGen {
+				panic("TiKV side async resolve should only be enabled in next-gen cluster")
+			}
 			lreq.IsAsync = true
 		}
 		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, lreq, kvrpcpb.Context{

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -87,6 +87,9 @@ type LockResolver struct {
 	// The Cancel function is to cancel these goroutines for passing goleak test.
 	asyncResolveCtx    context.Context
 	asyncResolveCancel func()
+
+	// enableTiKVSideAsyncResolve indicates whether to enable TiKV side async resolve.
+	enableTiKVSideAsyncResolve atomic.Bool
 }
 
 // ResolvingLock stands for current resolving locks' information
@@ -109,6 +112,8 @@ func NewLockResolver(store storage) *LockResolver {
 	r.mu.resolvingConcurrency = make(map[uint64]int)
 	r.mu.recentResolved = list.New()
 	r.asyncResolveCtx, r.asyncResolveCancel = context.WithCancel(context.Background())
+	// only next-gen supports TiKV side async resolve currently.
+	r.enableTiKVSideAsyncResolve.Store(config.NextGen)
 	return r
 }
 
@@ -620,13 +625,15 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			}
 		} else {
 			asyncResolve := false
+			resultRequired := true
 			if forRead {
+				resultRequired = false
 				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
 				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
 				asyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
-					err := lr.resolveLock(asyncBo, l, status, lite, map[locate.RegionVerID]struct{}{})
+					err := lr.resolveLock(asyncBo, l, status, lite, resultRequired, map[locate.RegionVerID]struct{}{})
 					if err != nil {
 						logutil.BgLogger().Info("failed to resolve lock asynchronously",
 							zap.String("lock", l.String()), zap.Uint64("commitTS", status.CommitTS()), zap.Error(err))
@@ -637,7 +644,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				}
 			}
 			if !asyncResolve {
-				err = lr.resolveLock(bo, l, status, lite, cleanRegions)
+				err = lr.resolveLock(bo, l, status, lite, resultRequired, cleanRegions)
 			}
 		}
 		return status, err
@@ -1383,7 +1390,7 @@ func resolveActionLabel(status TxnStatus) string {
 	return "rollback"
 }
 
-func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStatus, lite bool, cleanRegions map[locate.RegionVerID]struct{}) error {
+func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStatus, lite bool, resultRequired bool, cleanRegions map[locate.RegionVerID]struct{}) error {
 	util.EvalFailpoint("resolveLock")
 
 	metrics.LockResolverCountWithResolveLocks.Inc()
@@ -1420,6 +1427,8 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 			// prevent from scanning the whole region in this case.
 			metrics.LockResolverCountWithResolveLockLite.Inc()
 			lreq.Keys = [][]byte{l.Key}
+		} else if !resultRequired && lr.enableTiKVSideAsyncResolve.Load() {
+			lreq.IsAsync = true
 		}
 		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, lreq, kvrpcpb.Context{
 			ResourceControlContext: &kvrpcpb.ResourceControlContext{
@@ -1552,4 +1561,9 @@ func (lr *LockResolver) resolvePessimisticLock(bo *retry.Backoffer, l *Lock, pes
 		)
 		return nil
 	}
+}
+
+// SetEnableTiKVSideAsyncResolve sets whether to enable TiKV-side async resolve.
+func (lr *LockResolver) SetEnableTiKVSideAsyncResolve(enabled bool) {
+	lr.enableTiKVSideAsyncResolve.Store(enabled)
 }

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -54,7 +54,7 @@ func (l LockResolverProbe) ResolveAsyncCommitLock(bo *retry.Backoffer, lock *Loc
 
 // ResolveLock resolves single lock.
 func (l LockResolverProbe) ResolveLock(bo *retry.Backoffer, lock *Lock) error {
-	return l.resolveLock(bo, lock, TxnStatus{}, false, make(map[locate.RegionVerID]struct{}))
+	return l.resolveLock(bo, lock, TxnStatus{}, false, true, make(map[locate.RegionVerID]struct{}))
 }
 
 // ResolvePessimisticLock resolves single pessimistic lock.


### PR DESCRIPTION
close #1963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional TiKV-side asynchronous lock resolution behind a feature gate; read paths default to async when results aren't required and behavior can be toggled per resolver.

* **Tests**
  * New integration and unit tests validating TiKV-side async resolve behavior, request patterns, and resolver metrics.

* **Chores**
  * Bumped kvproto dependency version across examples and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/client-go/pull/1973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->