### PR TITLE
tikvrpc: add default request origin

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -3,7 +3,7 @@ module txnkv
 go 1.25.8
 
 require (
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
 	github.com/tikv/client-go/v2 v2.0.0
 )
 

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 h1:n6QWAac97mv2NJhn17iFPFnsE5fMgtPLNmsGZeqq78o=
-github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 h1:VV03wSSG2XhOwhF79lvT88Z83lwzMT+aZHXrcCIN9B0=
+github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473
+	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
 	github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1440,8 +1440,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473 h1:n6QWAac97mv2NJhn17iFPFnsE5fMgtPLNmsGZeqq78o=
-github.com/pingcap/kvproto v0.0.0-20260514102340-daa7c864b473/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 h1:VV03wSSG2XhOwhF79lvT88Z83lwzMT+aZHXrcCIN9B0=
+github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -271,13 +271,34 @@ type Request struct {
 	rev uint32
 }
 
+var defaultRequestOrigin atomic.Uint32
+
+// SetDefaultRequestOrigin sets the process-wide request origin used when an RPC
+// context does not carry an explicit origin.
+func SetDefaultRequestOrigin(origin kvrpcpb.RequestOrigin) {
+	defaultRequestOrigin.Store(uint32(origin))
+}
+
+// GetDefaultRequestOrigin returns the process-wide default request origin.
+func GetDefaultRequestOrigin() kvrpcpb.RequestOrigin {
+	return kvrpcpb.RequestOrigin(defaultRequestOrigin.Load())
+}
+
+func fillDefaultRequestOrigin(ctx *kvrpcpb.Context) {
+	if ctx.GetRequestOrigin() == kvrpcpb.RequestOrigin_RequestOriginUnknown {
+		ctx.RequestOrigin = GetDefaultRequestOrigin()
+	}
+}
+
 // NewRequest returns new kv rpc request.
 func NewRequest(typ CmdType, pointer interface{}, ctxs ...kvrpcpb.Context) *Request {
 	if len(ctxs) > 0 {
+		ctx := ctxs[0]
+		fillDefaultRequestOrigin(&ctx)
 		return &Request{
 			Type:    typ,
 			Req:     pointer,
-			Context: ctxs[0],
+			Context: ctx,
 		}
 	}
 	return &Request{
@@ -850,6 +871,7 @@ type MPPStreamResponse struct {
 // return false if encounter unknown request type.
 // Parameter `rpcCtx` use `kvrpcpb.Context` instead of `*kvrpcpb.Context` to avoid concurrent modification by shallow copy.
 func AttachContext(req *Request, rpcCtx kvrpcpb.Context) bool {
+	fillDefaultRequestOrigin(&rpcCtx)
 	ctx := &rpcCtx
 	cmd := req.Type
 	// CmdCopStream and CmdCop share the same request type.

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -271,12 +271,12 @@ type Request struct {
 	rev uint32
 }
 
-var defaultRequestOrigin atomic.Uint32
+var defaultRequestOrigin atomic.Int32
 
 // SetDefaultRequestOrigin sets the process-wide request origin used when an RPC
 // context does not carry an explicit origin.
 func SetDefaultRequestOrigin(origin kvrpcpb.RequestOrigin) {
-	defaultRequestOrigin.Store(uint32(origin))
+	defaultRequestOrigin.Store(int32(origin))
 }
 
 // GetDefaultRequestOrigin returns the process-wide default request origin.
@@ -872,6 +872,7 @@ type MPPStreamResponse struct {
 // Parameter `rpcCtx` use `kvrpcpb.Context` instead of `*kvrpcpb.Context` to avoid concurrent modification by shallow copy.
 func AttachContext(req *Request, rpcCtx kvrpcpb.Context) bool {
 	fillDefaultRequestOrigin(&rpcCtx)
+	req.Context = rpcCtx
 	ctx := &rpcCtx
 	cmd := req.Type
 	// CmdCopStream and CmdCop share the same request type.

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -59,6 +59,65 @@ func TestBatchResponse(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestDefaultRequestOrigin(t *testing.T) {
+	SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginTiDB)
+	t.Cleanup(func() {
+		SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginUnknown)
+	})
+
+	req := NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{})
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
+
+	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{})
+	require.True(t, AttachContext(req, kvrpcpb.Context{}))
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Get().GetContext().GetRequestOrigin())
+
+	for _, tc := range []struct {
+		name   string
+		req    *Request
+		origin func(*Request) kvrpcpb.RequestOrigin
+	}{
+		{
+			name: "scan_lock",
+			req:  NewRequest(CmdScanLock, &kvrpcpb.ScanLockRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.ScanLock().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "cleanup",
+			req:  NewRequest(CmdCleanup, &kvrpcpb.CleanupRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.Cleanup().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "check_txn_status",
+			req:  NewRequest(CmdCheckTxnStatus, &kvrpcpb.CheckTxnStatusRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.CheckTxnStatus().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "check_secondary_locks",
+			req:  NewRequest(CmdCheckSecondaryLocks, &kvrpcpb.CheckSecondaryLocksRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.CheckSecondaryLocks().GetContext().GetRequestOrigin()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, AttachContext(tc.req, kvrpcpb.Context{}))
+			require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, tc.origin(tc.req))
+		})
+	}
+
+	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{
+		RequestOrigin: kvrpcpb.RequestOrigin_RequestOriginTiDB,
+	})
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
+}
+
 // https://github.com/pingcap/tidb/issues/51921
 func TestTiDB51921(t *testing.T) {
 	for _, r := range []*Request{

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -71,7 +71,7 @@ func TestDefaultRequestOrigin(t *testing.T) {
 
 	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{})
 	require.True(t, AttachContext(req, kvrpcpb.Context{}))
-	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
 	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Get().GetContext().GetRequestOrigin())
 
 	for _, tc := range []struct {

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -60,9 +60,10 @@ func TestBatchResponse(t *testing.T) {
 }
 
 func TestDefaultRequestOrigin(t *testing.T) {
+	previousOrigin := GetDefaultRequestOrigin()
 	SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginTiDB)
 	t.Cleanup(func() {
-		SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginUnknown)
+		SetDefaultRequestOrigin(previousOrigin)
 	})
 
 	req := NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{})
@@ -70,6 +71,7 @@ func TestDefaultRequestOrigin(t *testing.T) {
 
 	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{})
 	require.True(t, AttachContext(req, kvrpcpb.Context{}))
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
 	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Get().GetContext().GetRequestOrigin())
 
 	for _, tc := range []struct {
@@ -112,6 +114,7 @@ func TestDefaultRequestOrigin(t *testing.T) {
 		})
 	}
 
+	SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginUnknown)
 	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{
 		RequestOrigin: kvrpcpb.RequestOrigin_RequestOriginTiDB,
 	})

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -66,7 +66,7 @@ func TestDefaultRequestOrigin(t *testing.T) {
 	})
 
 	req := NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{})
-	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
 
 	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{})
 	require.True(t, AttachContext(req, kvrpcpb.Context{}))
@@ -115,7 +115,7 @@ func TestDefaultRequestOrigin(t *testing.T) {
 	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{
 		RequestOrigin: kvrpcpb.RequestOrigin_RequestOriginTiDB,
 	})
-	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Context.GetRequestOrigin())
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
 }
 
 // https://github.com/pingcap/tidb/issues/51921


### PR DESCRIPTION
### What changed

- Add a process-wide default request origin in `tikvrpc`.
- Fill `kvrpcpb.Context.request_origin` from that default when creating or attaching request context.
- Keep the default as unspecified so non-TiDB client-go users do not get TiDB trust by accident.

### Dependency stack

- Uses merged pingcap/kvproto#1479 for `RequestOrigin` and `Context.request_origin`.
- Ref pingcap/tidb#68799.
- No temporary kvproto `replace` remains; the root module, integration test module, and example modules are bumped directly to the merged kvproto pseudo-version.

### Tests

- `gotestsum --format short-verbose -- ./tikvrpc`
- `go test ./tikvrpc -run '^TestDefaultRequestOrigin$' -race`
- `cd integration_tests && go list -mod=readonly ./...`
- `for mod in $(find examples -name go.mod -print | sort); do (cd "${mod%/go.mod}" && go list -mod=readonly ./...); done`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable default request origin for RPCs, ensuring consistent request identification and tracking across operations.

* **Chores**
  * Bumped an indirect dependency used by examples and integration tests to a newer commit across multiple modules.

* **Tests**
  * Added unit tests to verify default request origin behavior and that explicit origins are preserved across RPC creation and attachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->