### PR TITLE
txnkv: batch lite lock resolves by region

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -228,7 +228,7 @@ func DefaultTiKVClient() TiKVClient {
 		},
 		CoprReqTimeout: 60 * time.Second,
 
-		ResolveLockLiteThreshold:   256,
+		ResolveLockLiteThreshold:   512,
 		MaxConcurrencyRequestLimit: DefMaxConcurrencyRequestLimit,
 		EnableReplicaSelectorV2:    true,
 		RUV2:                       DefaultRUV2TiKVConfig(),

--- a/config/client.go
+++ b/config/client.go
@@ -228,7 +228,7 @@ func DefaultTiKVClient() TiKVClient {
 		},
 		CoprReqTimeout: 60 * time.Second,
 
-		ResolveLockLiteThreshold:   16,
+		ResolveLockLiteThreshold:   256,
 		MaxConcurrencyRequestLimit: DefMaxConcurrencyRequestLimit,
 		EnableReplicaSelectorV2:    true,
 		RUV2:                       DefaultRUV2TiKVConfig(),

--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260401072359-048f0d8f6f71 // indirect
+	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1113,7 +1113,9 @@ func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
 			resolver := s.store.NewLockResolver()
 			defer resolver.Close()
 			const expectedResolveReqCount = 4
+			const expectedLiteResolveReqCount = 3
 			asyncResolveTaskCountBefore := resolver.AsyncResolveTaskCount()
+			resolveLockLiteBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite)
 
 			// Capture ResolveLock RPCs after RegionRequestSender attaches region
 			// context. The hook blocks ResolveLock requests so the test can
@@ -1236,6 +1238,7 @@ func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
 			}
 
 			s.Len(reqsByTxn, 3)
+			s.Equal(resolveLockLiteBefore+expectedLiteResolveReqCount, testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite))
 
 			// The multi-key lite txn is grouped by region. One region has two
 			// keys, and the other has one key.

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1284,6 +1284,66 @@ func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
 	runCase("for_read", true)
 }
 
+func (s *testLockSuite) TestBatchLiteResolveLocksForReadIgnoresInlineCleanupError() {
+	if *withTiKV {
+		s.T().Skip("this test relies on client-side failpoints for deterministic cleanup errors")
+	}
+
+	// This test covers the for-read fallback path where client-side async
+	// cleanup is rejected and the cleanup runs inline. Once CheckTxnStatus has
+	// confirmed the transaction status, the read can already proceed, so a later
+	// physical cleanup error should be swallowed instead of being returned to
+	// ResolveLocksForRead.
+	key := []byte("batch_lite_for_read_fallback_key")
+	primaryKey := []byte("batch_lite_for_read_fallback_primary")
+	startTS, _ := s.lockKey(key, []byte("value"), primaryKey, []byte("primary_value"), 3000, true, false)
+	lock := s.mustGetLock(key)
+	lock.TxnSize = 1
+
+	callerStartTS, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+	s.Nil(err)
+
+	resolver := s.store.NewLockResolver()
+	defer resolver.Close()
+	// A zero-sized pool rejects client-side async cleanup and forces the
+	// fallback path to execute cleanup inline.
+	resolver.SetAsyncResolvePoolSize(0)
+
+	injectResolveFailure := true
+	resolveFailureInjected := false
+	s.Nil(failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+	defer func() {
+		s.Nil(failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+		if resolveFailureInjected {
+			s.Nil(failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+		}
+	}()
+
+	ctx := context.WithValue(context.Background(), "sendReqToRegionHook", func(req *tikvrpc.Request) {
+		if req.Type == tikvrpc.CmdCheckTxnStatus && injectResolveFailure && !resolveFailureInjected {
+			// Inject the timeout only after the status check request is sent, so
+			// the injected error belongs to the following cleanup ResolveLock RPC.
+			resolveFailureInjected = true
+			s.Nil(failpoint.Enable("tikvclient/tikvStoreSendReqResult", `return("timeout")`))
+		}
+	})
+	bo := tikv.NewBackofferWithVars(ctx, getMaxBackoff, nil)
+	ttl, canIgnore, canAccess, err := resolver.ResolveLocksForRead(bo, callerStartTS, []*txnkv.Lock{lock}, true)
+	s.Nil(err)
+	s.Equal(int64(0), ttl)
+	s.Empty(canIgnore)
+	s.Equal([]uint64{startTS}, canAccess)
+	s.True(resolveFailureInjected)
+
+	injectResolveFailure = false
+	s.Nil(failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+	resolveFailureInjected = false
+	remainingLock := s.mustGetLock(key)
+	cleanupResolver := s.store.NewLockResolver()
+	defer cleanupResolver.Close()
+	s.Nil(cleanupResolver.ForceResolveLock(context.Background(), remainingLock))
+}
+
 func (s *testLockSuite) TestLockWaitTimeLimit() {
 	k1 := []byte("k1")
 	k2 := []byte("k2")

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -2046,6 +2046,13 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 		t.Skip()
 	}
 
+	originalConf := *config.GetGlobalConfig()
+	testConf := originalConf
+	const resolveLiteThreshold = uint64(16)
+	testConf.TiKVClient.ResolveLockLiteThreshold = resolveLiteThreshold
+	config.StoreGlobalConfig(&testConf)
+	defer config.StoreGlobalConfig(&originalConf)
+
 	for _, commitPrimary := range []bool{true, false} {
 		name := "primary_rollback"
 		if commitPrimary {
@@ -2075,7 +2082,7 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 				keys = append(keys, []byte(fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
 				values = append(values, []byte(fmt.Sprintf("value_%s_%03d", name, i)))
 			}
-			require.Greater(t, uint64(len(keys)), config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold)
+			require.Greater(t, uint64(len(keys)), resolveLiteThreshold)
 
 			// prewrite
 			txn, err := store.Begin()

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1004,6 +1004,283 @@ func (s *testLockSuite) TestResolveLocksForRead() {
 	s.Equal(committedLocks, committed)
 }
 
+func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
+	if *withTiKV {
+		s.T().Skip("this test validates client-side ResolveLock request planning and avoids real TiKV split timing")
+	}
+
+	originalConf := *config.GetGlobalConfig()
+	testConf := originalConf
+	const resolveLiteThreshold = uint64(8)
+	testConf.TiKVClient.ResolveLockLiteThreshold = resolveLiteThreshold
+	config.StoreGlobalConfig(&testConf)
+	defer config.StoreGlobalConfig(&originalConf)
+
+	// Prewrite all keys but commit only the primary key. The secondary locks stay
+	// unresolved and become the inputs to ResolveLocksWithOpts below.
+	prepareTxn := func(primary []byte, secondaryKeys [][]byte, txnSize int) (uint64, uint64, []*txnkv.Lock) {
+		txn, err := s.store.Begin()
+		s.Nil(err)
+		s.Nil(txn.Set(primary, []byte("primary_value")))
+		for i, key := range secondaryKeys {
+			s.Nil(txn.Set(key, []byte(fmt.Sprintf("secondary_value_%d", i))))
+		}
+
+		committer, err := txn.NewCommitter(1)
+		s.Nil(err)
+		committer.SetPrimaryKey(primary)
+		committer.SetTxnSize(txnSize)
+		committer.SetLockTTL(3000)
+		s.Nil(committer.PrewriteAllMutations(context.Background()))
+
+		commitTS, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+		s.Nil(err)
+		committer.SetCommitTS(commitTS)
+		s.Nil(committer.CommitMutations(context.Background()))
+
+		locks := make([]*txnkv.Lock, 0, len(secondaryKeys))
+		for _, key := range secondaryKeys {
+			locks = append(locks, s.mustGetLock(key))
+		}
+		return txn.StartTS(), commitTS, locks
+	}
+
+	pinLockTxnSize := func(locks []*txnkv.Lock, txnSize uint64) {
+		for _, lock := range locks {
+			lock.TxnSize = txnSize
+		}
+	}
+
+	runCase := func(name string, forRead bool) {
+		s.Run(name, func() {
+			key := func(suffix string) []byte {
+				return []byte(fmt.Sprintf("batch_lite_%s_%s", name, suffix))
+			}
+			scanStartKey := key("")
+			scanEndKey := []byte(fmt.Sprintf("batch_lite_%s_\xff", name))
+
+			// Split the keyspace so the multi-key lite transaction is resolved
+			// by one ResolveLock request per region.
+			splitKey := key("multi_m")
+			_, err := s.store.SplitRegions(context.Background(), [][]byte{splitKey}, false, nil)
+			s.Nil(err)
+
+			// A small transaction with multiple locks spanning two regions. It
+			// should be batched by txn and then split into region-level
+			// ResolveLock requests.
+			multiKeyTxnKeys := [][]byte{
+				key("multi_a1"),
+				key("multi_a2"),
+				key("multi_z1"),
+			}
+			multiKeyTxnID, multiKeyCommitTS, multiKeyLocks := prepareTxn(
+				key("multi_primary"),
+				multiKeyTxnKeys,
+				len(multiKeyTxnKeys)+1,
+			)
+
+			// A small transaction with one lock. It should keep the old
+			// single-key lite resolve shape.
+			singleKeyTxnKeys := [][]byte{key("single_secondary")}
+			singleKeyTxnID, singleKeyCommitTS, singleKeyLocks := prepareTxn(
+				key("single_primary"),
+				singleKeyTxnKeys,
+				len(singleKeyTxnKeys)+1,
+			)
+
+			// A large transaction. It should bypass the batched-lite path and
+			// use the original region-level resolve with empty Keys.
+			regionLevelTxnKeys := [][]byte{key("region_secondary")}
+			regionLevelTxnID, regionLevelCommitTS, regionLevelLocks := prepareTxn(
+				key("region_primary"),
+				regionLevelTxnKeys,
+				int(resolveLiteThreshold)+1,
+			)
+
+			// Pin the resolver branch condition directly on the Lock inputs.
+			// This keeps the test stable even if the default lite threshold changes.
+			pinLockTxnSize(multiKeyLocks, resolveLiteThreshold-1)
+			pinLockTxnSize(singleKeyLocks, resolveLiteThreshold-1)
+			pinLockTxnSize(regionLevelLocks, resolveLiteThreshold+1)
+
+			boForLocate := tikv.NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
+			loc1, err := s.store.GetRegionCache().LocateKey(boForLocate, multiKeyTxnKeys[0])
+			s.Nil(err)
+			loc2, err := s.store.GetRegionCache().LocateKey(boForLocate, multiKeyTxnKeys[2])
+			s.Nil(err)
+			s.NotEqual(loc1.Region.GetID(), loc2.Region.GetID())
+
+			resolver := s.store.NewLockResolver()
+			defer resolver.Close()
+			const expectedResolveReqCount = 4
+			asyncResolveTaskCountBefore := resolver.AsyncResolveTaskCount()
+
+			// Capture ResolveLock RPCs after RegionRequestSender attaches region
+			// context. The hook blocks ResolveLock requests so the test can
+			// distinguish client-side async resolve from synchronous resolve.
+			var resolveReqMu sync.Mutex
+			var resolveReqs []*tikvrpc.Request
+			unblockResolveReqs := make(chan struct{})
+			var unblockResolveReqsOnce sync.Once
+			unblockResolveReqsFn := func() {
+				unblockResolveReqsOnce.Do(func() {
+					close(unblockResolveReqs)
+				})
+			}
+			defer unblockResolveReqsFn()
+			s.Nil(failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+			defer func() {
+				s.Nil(failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+			}()
+
+			ctx := util.WithInternalSourceType(context.Background(), fmt.Sprintf("batch_lite_resolve_%s", name))
+			ctx = context.WithValue(ctx, "sendReqToRegionHook", func(req *tikvrpc.Request) {
+				if req.Type == tikvrpc.CmdResolveLock {
+					resolveReqMu.Lock()
+					resolveReqs = append(resolveReqs, req)
+					resolveReqMu.Unlock()
+					if !forRead {
+						s.Equal(asyncResolveTaskCountBefore, resolver.AsyncResolveTaskCount())
+					}
+					<-unblockResolveReqs
+				}
+			})
+			getResolveReqs := func() []*tikvrpc.Request {
+				resolveReqMu.Lock()
+				defer resolveReqMu.Unlock()
+				return append([]*tikvrpc.Request(nil), resolveReqs...)
+			}
+			scanRemainingLocks := func() ([]*txnkv.Lock, error) {
+				scanTS, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+				if err != nil {
+					return nil, err
+				}
+				return s.store.ScanLocks(context.Background(), scanStartKey, scanEndKey, scanTS)
+			}
+
+			callerStartTS := uint64(0)
+			if forRead {
+				callerStartTS, err = s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+				s.Nil(err)
+			}
+
+			bo := tikv.NewBackofferWithVars(ctx, getMaxBackoff, nil)
+			locks := make([]*txnkv.Lock, 0, len(multiKeyLocks)+len(singleKeyLocks)+len(regionLevelLocks))
+			locks = append(locks, multiKeyLocks...)
+			locks = append(locks, singleKeyLocks...)
+			locks = append(locks, regionLevelLocks...)
+			if forRead {
+				resolver.SetAsyncResolveContext(ctx)
+			}
+			type resolveCallResult struct {
+				res txnlock.ResolveLockResult
+				err error
+			}
+			resolveDone := make(chan resolveCallResult, 1)
+			go func() {
+				res, err := resolver.ResolveLocksWithOpts(bo, txnlock.ResolveLocksOptions{
+					CallerStartTS: callerStartTS,
+					Locks:         locks,
+					ForRead:       forRead,
+				})
+				resolveDone <- resolveCallResult{res: res, err: err}
+			}()
+
+			waitResolveDone := func() resolveCallResult {
+				select {
+				case result := <-resolveDone:
+					return result
+				case <-time.After(5 * time.Second):
+					s.FailNow("ResolveLocksWithOpts did not return in time")
+					return resolveCallResult{}
+				}
+			}
+
+			if forRead {
+				// forRead uses client-side async resolve: ResolveLocksWithOpts
+				// should return while the ResolveLock RPCs are still blocked.
+				callResult := waitResolveDone()
+				s.Nil(callResult.err)
+				s.Equal(int64(0), callResult.res.TTL)
+				s.Eventually(func() bool {
+					return len(getResolveReqs()) >= expectedResolveReqCount
+				}, 5*time.Second, 10*time.Millisecond)
+				s.Equal(asyncResolveTaskCountBefore+expectedResolveReqCount, resolver.AsyncResolveTaskCount())
+				unblockResolveReqsFn()
+				s.Eventually(func() bool {
+					return resolver.AsyncResolveTaskCount() == asyncResolveTaskCountBefore
+				}, 5*time.Second, 10*time.Millisecond)
+			} else {
+				// Non-read resolve is synchronous: the call should be blocked by
+				// the first ResolveLock request until the hook is released.
+				s.Eventually(func() bool {
+					return len(getResolveReqs()) > 0
+				}, 5*time.Second, 10*time.Millisecond)
+				s.Equal(asyncResolveTaskCountBefore, resolver.AsyncResolveTaskCount())
+				select {
+				case callResult := <-resolveDone:
+					s.FailNow("synchronous ResolveLocksWithOpts returned before the blocked ResolveLock request was released", callResult)
+				case <-time.After(100 * time.Millisecond):
+				}
+				unblockResolveReqsFn()
+				callResult := waitResolveDone()
+				s.Nil(callResult.err)
+				s.Equal(int64(0), callResult.res.TTL)
+			}
+
+			reqsByTxn := make(map[uint64][]*tikvrpc.Request)
+			for _, req := range getResolveReqs() {
+				s.Equal(util.RequestSourceFromCtx(ctx), req.RequestSource)
+				resolveLock := req.ResolveLock()
+				reqsByTxn[resolveLock.StartVersion] = append(reqsByTxn[resolveLock.StartVersion], req)
+			}
+
+			s.Len(reqsByTxn, 3)
+
+			// The multi-key lite txn is grouped by region. One region has two
+			// keys, and the other has one key.
+			multiKeyReqs := reqsByTxn[multiKeyTxnID]
+			s.Len(multiKeyReqs, 2)
+			var multiKeyResolvedKeys [][]byte
+			var multiKeyResolvedRegions []uint64
+			for _, req := range multiKeyReqs {
+				resolveLock := req.ResolveLock()
+				s.Equal(multiKeyCommitTS, resolveLock.CommitVersion)
+				s.False(resolveLock.GetIsAsync())
+				s.NotEmpty(resolveLock.Keys)
+				multiKeyResolvedKeys = append(multiKeyResolvedKeys, resolveLock.Keys...)
+				multiKeyResolvedRegions = append(multiKeyResolvedRegions, req.RegionId)
+			}
+			s.ElementsMatch(multiKeyTxnKeys, multiKeyResolvedKeys)
+			s.ElementsMatch([]uint64{loc1.Region.GetID(), loc2.Region.GetID()}, multiKeyResolvedRegions)
+
+			// The single-key lite txn still sends a single-key ResolveLock request.
+			singleKeyReqs := reqsByTxn[singleKeyTxnID]
+			s.Len(singleKeyReqs, 1)
+			s.Equal(singleKeyCommitTS, singleKeyReqs[0].ResolveLock().CommitVersion)
+			s.False(singleKeyReqs[0].ResolveLock().GetIsAsync())
+			s.ElementsMatch(singleKeyTxnKeys, singleKeyReqs[0].ResolveLock().Keys)
+
+			// The large txn keeps the original region-level resolve shape.
+			regionLevelReqs := reqsByTxn[regionLevelTxnID]
+			s.Len(regionLevelReqs, 1)
+			s.Equal(regionLevelCommitTS, regionLevelReqs[0].ResolveLock().CommitVersion)
+			s.Equal(forRead && config.NextGen, regionLevelReqs[0].ResolveLock().GetIsAsync())
+			s.Empty(regionLevelReqs[0].ResolveLock().Keys)
+
+			// Finally verify the ResolveLock requests actually clear every lock
+			// created by this test, including the keys that were grouped by
+			// region above.
+			remainingLocks, err := scanRemainingLocks()
+			s.Nil(err)
+			s.Empty(remainingLocks)
+		})
+	}
+
+	runCase("write", false)
+	runCase("for_read", true)
+}
+
 func (s *testLockSuite) TestLockWaitTimeLimit() {
 	k1 := []byte("k1")
 	k2 := []byte("k2")

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1357,7 +1357,11 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 
 func (lr *LockResolver) newAsyncResolveBackoffer(originalBo *retry.Backoffer) *retry.Backoffer {
 	// Async cleanup must not inherit the caller's cancellation, but it should
-	// keep request metadata such as RequestSource for observability.
+	// keep RequestSource for observability.
+	// This intentionally preserves the existing for-read async resolve behavior:
+	// resource group attribution is not copied to the detached cleanup context here.
+	// Whether background lock cleanup should be charged to the triggering request's resource group is a separate
+	// policy decision.
 	asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, originalBo.GetCtx().Value(util.RequestSourceKey))
 	return retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
 }
@@ -1365,50 +1369,47 @@ func (lr *LockResolver) newAsyncResolveBackoffer(originalBo *retry.Backoffer) *r
 // batchLiteResolveLocks resolves small-transaction locks that have already had
 // their primary status checked. keys must all belong to l.TxnID.
 func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys [][]byte, status TxnStatus, forRead bool) error {
-	logAsyncErr := func(err error, fallbackSync bool) {
+	logErr := func(err error, failedKeys [][]byte) {
 		if err == nil {
 			return
 		}
-		keysForLog := make([]string, len(keys))
-		for i, key := range keys {
-			keysForLog[i] = redact.Key(key)
+		failedKeysForLog := make([]string, len(failedKeys))
+		for i, key := range failedKeys {
+			failedKeysForLog[i] = redact.Key(key)
 		}
-		logutil.BgLogger().Info("failed to batch resolve lock lite asynchronously",
+		logutil.BgLogger().Info("failed to batch resolve lock lite",
 			zap.String("lock", l.String()),
-			zap.Strings("keys", keysForLog),
+			zap.Strings("keys", failedKeysForLog),
 			zap.Uint64("commitTS", status.CommitTS()),
-			zap.Bool("fallbackSync", fallbackSync),
+			zap.Bool("forRead", forRead),
 			zap.Error(err),
 		)
 	}
 
-	asyncResolveOrNot := func(f func(*retry.Backoffer) error) error {
-		// Read callers can continue once the lock is known to be readable or
-		// ignorable, so the physical cleanup can run in the background.
+	inplaceOrScheduleAsync := func(bo *retry.Backoffer, f func(*retry.Backoffer) error) (err error) {
 		isAsync := false
 		if forRead {
-			isAsync = lr.asyncResolvePool.tryAsyncResolve(
-				func() {
-					logAsyncErr(f(lr.newAsyncResolveBackoffer(bo)), false)
-				},
-				metrics.LockResolverAsyncRunningTasksForReadResolve,
-			)
+			asyncBo := lr.newAsyncResolveBackoffer(bo)
+			isAsync = lr.asyncResolvePool.tryAsyncResolve(func() {
+				// do not return error when forRead
+				_ = f(asyncBo)
+			}, metrics.LockResolverAsyncRunningTasksForReadResolve)
 
 			if !isAsync {
 				metrics.LockResolverCountWithReadAsyncResolveFallback.Inc()
 			}
 		}
 
+		// isAsync is false means either it is not for read or the async resolve
+		// task is rejected. For reads, the lock status is already known, so the
+		// physical cleanup is best-effort even when it runs inline.
 		if !isAsync {
-			// asyncResolvePool is full or !forRead, and we need to resolve lock synchronously.
-			err := f(bo)
-			if err != nil && forRead {
-				logAsyncErr(err, true)
+			if err = f(bo); err != nil && forRead {
+				err = nil
 			}
-			return err
 		}
 
-		return nil
+		return
 	}
 
 	if len(keys) == 1 {
@@ -1417,28 +1418,39 @@ func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys
 				panic(fmt.Sprintf("the only key in keys should be the same as l.Key, but got %v and %v", l.Key, keys[0]))
 			}
 		}
-		return asyncResolveOrNot(func(asyncBo *retry.Backoffer) error {
-			return lr.resolveLock(asyncBo, l, status, true, true, nil)
+		return inplaceOrScheduleAsync(bo, func(asyncBo *retry.Backoffer) error {
+			if err := lr.resolveLock(asyncBo, l, status, true, true, nil); err != nil {
+				logErr(err, keys)
+				return err
+			}
+			return nil
 		})
 	}
 
-	regions, _, err := lr.store.GetRegionCache().GroupKeysByRegion(bo, keys, nil)
-	if err != nil {
-		return err
-	}
-
-	// Multiple lite keys are resolved with exact key lists per region. This
-	// avoids one RPC per key while still avoiding a whole-region resolve scan.
-	for region, regionKeys := range regions {
-		err = asyncResolveOrNot(func(asyncBo *retry.Backoffer) error {
-			return lr.resolveRegionLocks(asyncBo, l, region, regionKeys, status)
-		})
+	return inplaceOrScheduleAsync(bo, func(asyncBo *retry.Backoffer) error {
+		regions, _, err := lr.store.GetRegionCache().GroupKeysByRegion(asyncBo, keys, nil)
 		if err != nil {
+			logErr(err, keys)
 			return err
 		}
-	}
 
-	return nil
+		// Multiple lite keys are resolved with exact key lists per region. This
+		// avoids one RPC per key while still avoiding a whole-region resolve scan.
+		for region, regionKeys := range regions {
+			err = inplaceOrScheduleAsync(asyncBo, func(asyncBo *retry.Backoffer) error {
+				if err := lr.resolveRegionLocks(asyncBo, l, region, regionKeys, status); err != nil {
+					logErr(err, regionKeys)
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 // resolveRegionLocks is essentially the same as resolveLock, but we resolve all keys in the same region at the same time.

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1401,10 +1401,12 @@ func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys
 		}
 
 		// isAsync is false means either it is not for read or the async resolve
-		// task is rejected. For reads, the lock status is already known, so the
-		// physical cleanup is best-effort even when it runs inline.
+		// task is rejected.
 		if !isAsync {
 			if err = f(bo); err != nil && forRead {
+				// Do not return error for read to make a some behavior with the async cleanup,
+				// so that the only difference between async and async-fallback path is whether the cleanup is
+				// performed in-place or not.
 				err = nil
 			}
 		}

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1413,7 +1413,7 @@ func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys
 
 	if len(keys) == 1 {
 		if intest.InTest {
-			if bytes.Compare(l.Key, keys[0]) != 0 {
+			if !bytes.Equal(l.Key, keys[0]) {
 				panic(fmt.Sprintf("the only key in keys should be the same as l.Key, but got %v and %v", l.Key, keys[0]))
 			}
 		}

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -563,24 +563,24 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 	// TODO: Maybe put it in LockResolver and share by all txns.
 	cleanTxns := make(map[uint64]map[locate.RegionVerID]struct{})
 	pessimisticCleanTxns := make(map[uint64]map[locate.RegionVerID]struct{})
-	var resolve func(*Lock, bool) (TxnStatus, error)
-	resolve = func(l *Lock, forceSyncCommit bool) (TxnStatus, error) {
+	var resolve func(*Lock, bool) (TxnStatus, bool, error)
+	resolve = func(l *Lock, forceSyncCommit bool) (_ TxnStatus, needBatchLiteResolve bool, _ error) {
 		status, err := lr.getTxnStatusFromLock(bo, l, callerStartTS, forceSyncCommit, detail)
 
 		if _, ok := errors.Cause(err).(primaryMismatch); ok {
 			if !l.IsPessimistic() {
 				logutil.BgLogger().Info("unexpected primaryMismatch error occurred on a non-pessimistic lock", zap.Stringer("lock", l), zap.Error(err))
-				return TxnStatus{}, err
+				return TxnStatus{}, false, err
 			}
 			// Pessimistic rollback the pessimistic lock as it points to an invalid primary.
 			status, err = TxnStatus{}, nil
 		} else if err != nil {
-			return TxnStatus{}, err
+			return TxnStatus{}, false, err
 		}
 		ttlExpired := (lr.store == nil) || (lr.store.GetOracle().IsExpired(l.TxnID, status.ttl, &oracle.Option{TxnScope: oracle.GlobalTxnScope}))
 		expiredAsyncCommitLocks := status.primaryLock != nil && status.primaryLock.UseAsyncCommit && !forceSyncCommit && ttlExpired
 		if status.ttl != 0 && !expiredAsyncCommitLocks {
-			return status, nil
+			return status, false, nil
 		}
 
 		// If the lock is non-async-commit type:
@@ -602,14 +602,14 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			// resolveAsyncCommitLock will resolve all locks of the transaction, so we needn't resolve
 			// it again if it has been resolved once.
 			if exists {
-				return status, nil
+				return status, false, nil
 			}
 			// status of async-commit transaction is determined by resolveAsyncCommitLock.
 			status, err = lr.resolveAsyncCommitLock(bo, l, status, forRead)
 			if _, ok := errors.Cause(err).(*nonAsyncCommitLock); ok {
-				status, err = resolve(l, true)
+				status, needBatchLiteResolve, err = resolve(l, true)
 			}
-			return status, err
+			return status, needBatchLiteResolve, err
 		}
 		if l.IsPessimistic() {
 			// pessimistic locks don't block read so it needn't be async.
@@ -624,12 +624,16 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				err = lr.resolvePessimisticLock(bo, l, false, nil)
 			}
 		} else {
+			if lite || l.TxnSize < lr.resolveLockLiteThreshold {
+				// Avoid sending one lite ResolveLock request per lock.
+				// Defer it so locks from the same transaction can be batched later.
+				return status, true, err
+			}
 			asyncResolve := false
 			resultRequired := true
 			if forRead {
 				resultRequired = false
-				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
-				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
+				asyncBo := lr.newAsyncResolveBackoffer(bo)
 				asyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
@@ -647,21 +651,45 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				err = lr.resolveLock(bo, l, status, lite, resultRequired, cleanRegions)
 			}
 		}
-		return status, err
+		return status, false, err
 	}
 
 	var canIgnore, canAccess []uint64
+	type batchLiteResolveTxn struct {
+		txnStatus TxnStatus
+		firstLock *Lock
+		keys      [][]byte
+	}
+	// TxnID -> locks that should use the lite ResolveLock path. They are
+	// collected first so a transaction with multiple encountered locks sends at
+	// most one ResolveLock request per region instead of one request per key.
+	var batchLiteResolveTxnList map[uint64]*batchLiteResolveTxn
 	for _, l := range locks {
 		if l.IsShared() {
 			logutil.Logger(bo.GetCtx()).Warn("cannot resolve a shared lock directly, should extract the inner locks and resolve them one by one", zap.Stack("stack"))
 			return ResolveLockResult{}, errors.New("misuse of resolveLocks: trying to resolve a shared lock directly")
 		}
-		status, err := resolve(l, false)
+		status, batchLiteResolve, err := resolve(l, false)
 		if err != nil {
 			msBeforeTxnExpired.update(0)
 			return ResolveLockResult{
 				TTL: msBeforeTxnExpired.value(),
 			}, err
+		}
+		if batchLiteResolve {
+			if batchLiteResolveTxnList == nil {
+				batchLiteResolveTxnList = make(map[uint64]*batchLiteResolveTxn)
+			}
+			txn, ok := batchLiteResolveTxnList[l.TxnID]
+			if ok {
+				txn.keys = append(txn.keys, l.Key)
+			} else {
+				batchLiteResolveTxnList[l.TxnID] = &batchLiteResolveTxn{
+					txnStatus: status,
+					firstLock: l,
+					keys:      [][]byte{l.Key},
+				}
+			}
 		}
 		if !forRead {
 			if status.ttl != 0 {
@@ -688,6 +716,19 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			msBeforeTxnExpired.update(msBeforeLockExpired)
 		}
 	}
+
+	// Resolve all collected lite locks after the status pass. For read requests,
+	// this cleanup may be scheduled in the async resolve pool; for write or
+	// result-required requests it is resolved synchronously.
+	for _, txn := range batchLiteResolveTxnList {
+		if err = lr.batchLiteResolveLocks(bo, txn.firstLock, txn.keys, txn.txnStatus, forRead); err != nil {
+			msBeforeTxnExpired.update(0)
+			return ResolveLockResult{
+				TTL: msBeforeTxnExpired.value(),
+			}, err
+		}
+	}
+
 	if msBeforeTxnExpired.value() > 0 {
 		metrics.LockResolverCountWithWaitExpired.Inc()
 	}
@@ -1314,6 +1355,92 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 	return &shared, nil
 }
 
+func (lr *LockResolver) newAsyncResolveBackoffer(originalBo *retry.Backoffer) *retry.Backoffer {
+	// Async cleanup must not inherit the caller's cancellation, but it should
+	// keep request metadata such as RequestSource for observability.
+	asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, originalBo.GetCtx().Value(util.RequestSourceKey))
+	return retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
+}
+
+// batchLiteResolveLocks resolves small-transaction locks that have already had
+// their primary status checked. keys must all belong to l.TxnID.
+func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys [][]byte, status TxnStatus, forRead bool) error {
+	logAsyncErr := func(err error, fallbackSync bool) {
+		if err == nil {
+			return
+		}
+		keysForLog := make([]string, len(keys))
+		for i, key := range keys {
+			keysForLog[i] = redact.Key(key)
+		}
+		logutil.BgLogger().Info("failed to batch resolve lock lite asynchronously",
+			zap.String("lock", l.String()),
+			zap.Strings("keys", keysForLog),
+			zap.Uint64("commitTS", status.CommitTS()),
+			zap.Bool("fallbackSync", fallbackSync),
+			zap.Error(err),
+		)
+	}
+
+	asyncResolveOrNot := func(f func(*retry.Backoffer) error) error {
+		// Read callers can continue once the lock is known to be readable or
+		// ignorable, so the physical cleanup can run in the background.
+		isAsync := false
+		if forRead {
+			isAsync = lr.asyncResolvePool.tryAsyncResolve(
+				func() {
+					logAsyncErr(f(lr.newAsyncResolveBackoffer(bo)), false)
+				},
+				metrics.LockResolverAsyncRunningTasksForReadResolve,
+			)
+
+			if !isAsync {
+				metrics.LockResolverCountWithReadAsyncResolveFallback.Inc()
+			}
+		}
+
+		if !isAsync {
+			// asyncResolvePool is full or !forRead, and we need to resolve lock synchronously.
+			err := f(bo)
+			if err != nil && forRead {
+				logAsyncErr(err, true)
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	if len(keys) == 1 {
+		if intest.InTest {
+			if bytes.Compare(l.Key, keys[0]) != 0 {
+				panic(fmt.Sprintf("the only key in keys should be the same as l.Key, but got %v and %v", l.Key, keys[0]))
+			}
+		}
+		return asyncResolveOrNot(func(asyncBo *retry.Backoffer) error {
+			return lr.resolveLock(asyncBo, l, status, true, true, nil)
+		})
+	}
+
+	regions, _, err := lr.store.GetRegionCache().GroupKeysByRegion(bo, keys, nil)
+	if err != nil {
+		return err
+	}
+
+	// Multiple lite keys are resolved with exact key lists per region. This
+	// avoids one RPC per key while still avoiding a whole-region resolve scan.
+	for region, regionKeys := range regions {
+		err = asyncResolveOrNot(func(asyncBo *retry.Backoffer) error {
+			return lr.resolveRegionLocks(asyncBo, l, region, regionKeys, status)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // resolveRegionLocks is essentially the same as resolveLock, but we resolve all keys in the same region at the same time.
 func (lr *LockResolver) resolveRegionLocks(bo *retry.Backoffer, l *Lock, region locate.RegionVerID, keys [][]byte, status TxnStatus) error {
 	lreq := &kvrpcpb.ResolveLockRequest{
@@ -1324,6 +1451,7 @@ func (lr *LockResolver) resolveRegionLocks(bo *retry.Backoffer, l *Lock, region 
 	}
 	lreq.Keys = keys
 	req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, lreq, kvrpcpb.Context{
+		RequestSource: util.RequestSourceFromCtx(bo.GetCtx()),
 		ResourceControlContext: &kvrpcpb.ResourceControlContext{
 			ResourceGroupName: util.ResourceGroupNameFromCtx(bo.GetCtx()),
 		},

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -1438,6 +1438,7 @@ func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys
 		// avoids one RPC per key while still avoiding a whole-region resolve scan.
 		for region, regionKeys := range regions {
 			err = inplaceOrScheduleAsync(asyncBo, func(asyncBo *retry.Backoffer) error {
+				metrics.LockResolverCountWithResolveLockLite.Inc()
 				if err := lr.resolveRegionLocks(asyncBo, l, region, regionKeys, status); err != nil {
 					logErr(err, regionKeys)
 					return err

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -91,6 +91,12 @@ func (l LockResolverProbe) SetAsyncResolveContext(ctx context.Context) {
 	l.asyncResolveCtx, l.asyncResolveCancel = context.WithCancel(ctx)
 }
 
+// SetAsyncResolvePoolSize replaces the async resolve pool with a bounded one.
+func (l LockResolverProbe) SetAsyncResolvePoolSize(size int) {
+	l.asyncResolvePool.Close()
+	l.asyncResolvePool = newAsyncResolveTaskPool(make(chan struct{}, size))
+}
+
 // AsyncResolveTaskCount returns the number of running or queued async resolve tasks.
 func (l LockResolverProbe) AsyncResolveTaskCount() int {
 	return len(l.asyncResolvePool.semaphore)

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -15,6 +15,8 @@
 package txnlock
 
 import (
+	"context"
+
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/config/retry"
@@ -81,6 +83,17 @@ func (l LockResolverProbe) GetSecondariesFromTxnStatus(status TxnStatus) [][]byt
 // SetMeetLockCallback is called whenever it meets locks.
 func (l LockResolverProbe) SetMeetLockCallback(f func([]*Lock)) {
 	l.testingKnobs.meetLock = f
+}
+
+// SetAsyncResolveContext replaces the context used by async resolve tasks.
+func (l LockResolverProbe) SetAsyncResolveContext(ctx context.Context) {
+	l.asyncResolveCancel()
+	l.asyncResolveCtx, l.asyncResolveCancel = context.WithCancel(ctx)
+}
+
+// AsyncResolveTaskCount returns the number of running or queued async resolve tasks.
+func (l LockResolverProbe) AsyncResolveTaskCount() int {
+	return len(l.asyncResolvePool.semaphore)
 }
 
 // CheckAllSecondaries checks the secondary locks of an async commit transaction to find out the final


### PR DESCRIPTION
ref https://github.com/pingcap/tidb/issues/68352

## What changed

- Batch lite lock resolves by transaction before grouping keys by region.
- Keep the single-key lite resolve path unchanged while resolving multi-key lite locks with per-region key lists.
- Allow read-path lite cleanup to run through the async resolve pool.
- Increase the default `resolve-lock-lite-threshold` from 16 to 512.
- Add integration coverage for both synchronous and read async batch-lite resolve paths.

## Why

The old lite resolve path could send one `ResolveLock` request per lock. With the new batched lite resolve path, increasing the threshold lets more small and medium transactions avoid whole-region resolve without regressing to a long serial sequence of per-lock resolve requests.

## Validation

- `go test ./config`
- `go test . -run 'TestLock/TestBatchLiteResolveLocksByRegion' -count=1`
- `go test . -run 'TestLock/TestResolveLocksForRead|TestBatchLiteResolveLocksByRegion' -count=1`
- `go test ./txnkv/txnlock`
- `git diff --check -- integration_tests/lock_test.go txnkv/txnlock/test_probe.go txnkv/txnlock/lock_resolver.go config/client.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * TiKV client default lock-resolution threshold increased (16 → 256), altering lite-vs-region resolve decision

* **Lock Resolution Improvements**
  * Per-transaction lite-resolution batching, better region grouping, and refined async vs sync dispatch with request metadata preserved

* **Tests**
  * New integration test for lite resolve batching; test helpers added to control and report async resolve tasks

* **Chores**
  * Bumped indirect dependencies in example modules to newer revisions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->