### PR TITLE
Reset dependency to TiDB back to master

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 // indirect
-	github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e // indirect
+	github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374 // indirect
 	github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
-	github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e
+	github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2
@@ -179,7 +179,3 @@ replace (
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
 	github.com/tikv/client-go/v2 => ../
 )
-
-replace github.com/pingcap/tidb => github.com/MyonKeminta/tidb v1.1.0-alpha.1.0.20260601112735-92902581ea8e
-
-replace github.com/pingcap/tidb/pkg/parser => github.com/MyonKeminta/tidb/pkg/parser v0.0.0-20260601112735-92902581ea8e

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
-	github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374
+	github.com/pingcap/tidb v1.1.0-beta.0.20260603040045-b254c43931d9
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.14.4
-	github.com/tikv/client-go/v2 v2.0.8-0.20260511022933-fb7ee09992a7
+	github.com/tikv/client-go/v2 v2.0.8-0.20260602013621-8804d7c60a7e
 	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.75.1
@@ -116,7 +116,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 // indirect
-	github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374 // indirect
+	github.com/pingcap/tidb/pkg/parser v0.0.0-20260603040045-b254c43931d9 // indirect
 	github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -851,10 +851,6 @@ github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvK
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/MyonKeminta/tidb v1.1.0-alpha.1.0.20260601112735-92902581ea8e h1:ck/U0BpN6yShgOjBrK4JnA/FN9tlcswB4Jb+tF5kEwg=
-github.com/MyonKeminta/tidb v1.1.0-alpha.1.0.20260601112735-92902581ea8e/go.mod h1:IGHc9T4L6nJsUbMrO9sLdgl3EBULTWVIePogbcTZgzU=
-github.com/MyonKeminta/tidb/pkg/parser v0.0.0-20260601112735-92902581ea8e h1:xd0LLS2+OGXg51oKb7fNfo3ZFzBLh/48qwmtEi9cyCQ=
-github.com/MyonKeminta/tidb/pkg/parser v0.0.0-20260601112735-92902581ea8e/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -1459,6 +1455,10 @@ github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d h1:5JCgncG9X7
 github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d/go.mod h1:HMNxmg0/lrn3SPGJ6LTZqP0WwEpcXMu9s/4TWJbzT8w=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0RWHdQu0pD9b9OC47sbISRiMvf9vJ2RY=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
+github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374 h1:npZIYfrghMoR/PjPEPce5+4pICRB1TVofCET76gsBro=
+github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374/go.mod h1:XFwitEgE10D4RRzDH/XS7pUMbREZ+km52XgpMoqcQlc=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e h1:eHtFDQynLMsHBpHrt0DstEjWMUldgW6C2vFkLhHctqM=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e/go.mod h1:K5X1FVP5k4EvzAlnUUAwAxV58thzPpl7bU5g6mg48Cg=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4 h1:7kN995aOhNamG8IOnN7Rj6nNqq+F3Z2AyfPGjCNdqoI=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1457,8 +1457,8 @@ github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0R
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
 github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374 h1:npZIYfrghMoR/PjPEPce5+4pICRB1TVofCET76gsBro=
 github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374/go.mod h1:XFwitEgE10D4RRzDH/XS7pUMbREZ+km52XgpMoqcQlc=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e h1:eHtFDQynLMsHBpHrt0DstEjWMUldgW6C2vFkLhHctqM=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260317213042-b1525070ca3e/go.mod h1:K5X1FVP5k4EvzAlnUUAwAxV58thzPpl7bU5g6mg48Cg=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374 h1:8LSV94Jt+d5irLbIn5YRZG9k9Ms0CP0sxhR5wbKjQEY=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4 h1:7kN995aOhNamG8IOnN7Rj6nNqq+F3Z2AyfPGjCNdqoI=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1455,10 +1455,10 @@ github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d h1:5JCgncG9X7
 github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d/go.mod h1:HMNxmg0/lrn3SPGJ6LTZqP0WwEpcXMu9s/4TWJbzT8w=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0RWHdQu0pD9b9OC47sbISRiMvf9vJ2RY=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
-github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374 h1:npZIYfrghMoR/PjPEPce5+4pICRB1TVofCET76gsBro=
-github.com/pingcap/tidb v1.1.0-beta.0.20260602090337-41f830fc6374/go.mod h1:XFwitEgE10D4RRzDH/XS7pUMbREZ+km52XgpMoqcQlc=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374 h1:8LSV94Jt+d5irLbIn5YRZG9k9Ms0CP0sxhR5wbKjQEY=
-github.com/pingcap/tidb/pkg/parser v0.0.0-20260602090337-41f830fc6374/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
+github.com/pingcap/tidb v1.1.0-beta.0.20260603040045-b254c43931d9 h1:4tHT8WZZJolwqAfbQ8PEH8XXoYsFhMNuAErYQt4xq8Y=
+github.com/pingcap/tidb v1.1.0-beta.0.20260603040045-b254c43931d9/go.mod h1:ycs2pxZNlCN5CQwDK3yw+uKR25jtYU/qOVZ4SvPmXZU=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260603040045-b254c43931d9 h1:+NH72hXXLYjpfL0fMGhxSRoEIbxHH/agt1c3ddUPpJk=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260603040045-b254c43931d9/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4 h1:7kN995aOhNamG8IOnN7Rj6nNqq+F3Z2AyfPGjCNdqoI=
 github.com/pingcap/tipb v0.0.0-20260515142222-a4d204a193b4/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
Ref: 
* https://github.com/tikv/pd/issues/10659
* https://github.com/pingcap/tidb/issues/68844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal project dependencies to newer revisions and aligned related indirect modules to the same timestamps.
  * Removed temporary fork redirects and cleaned up legacy override entries in module metadata.
  * Simplified the module replacement block to keep only necessary overrides.
  * No changes to public APIs or exported entities; purely metadata maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->