### PR TITLE
ci: enable classic CI for release-nextgen-20251011

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,26 +2,27 @@ name: Compatibility Test
 
 on:
   push:
-    branches: [master]
+    branches: [master, release-nextgen-20251011]
 
 jobs:
   tidb-compatibility:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23.2"
 
       - name: Checkout Client-Go
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: client-go
 
       - name: Checkout TiDB
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: pingcap/tidb
+          ref: release-nextgen-20251011
           path: tidb
 
       - name: Check build
@@ -32,7 +33,7 @@ jobs:
         working-directory: tidb
 
       - name: Checkout go-ycsb
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: pingcap/go-ycsb
           path: go-ycsb

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,9 +2,9 @@ name: Integration Test
 
 on:
   push:
-    branches: [master]
+    branches: [master, release-nextgen-20251011]
   pull_request:
-    branches: [master]
+    branches: [master, release-nextgen-20251011]
 
 jobs:
   integration-local:
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
 
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
 
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
 
@@ -96,10 +96,10 @@ jobs:
         api_version: [v1ttl, v2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
 
@@ -135,14 +135,14 @@ jobs:
         working-directory: integration_tests/raw
 
   integration-next-gen-tikv:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') && !startsWith(github.ref_name, 'release-') && !startsWith(github.base_ref, 'release-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,18 @@ name: Unit Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-nextgen-20251011 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-nextgen-20251011 ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23.2
 
@@ -23,10 +23,10 @@ jobs:
   race-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.23.2
 
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
 
@@ -50,7 +50,7 @@ jobs:
           git diff --exit-code
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61.0
-          skip-pkg-cache: true
+          skip-cache: true


### PR DESCRIPTION
## Summary

- enable non-next-gen CI on `release-nextgen-20251011`
- keep classic integration jobs on existing `nightly` PD/TiKV images
- add the compatibility PR trigger and checkout the matching TiDB `release-nextgen-20251011` ref
- keep the next-gen integration job skipped on release branches
- update official GitHub Actions wrappers to currently runnable major versions

## Validation

- `git diff --check`
- Ruby YAML parsing for all workflow files
- `actionlint` for all workflow files