### PR TITLE
ci: use tidbx images for next-gen integration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,9 +2,9 @@ name: Integration Test
 
 on:
   push:
-    branches: [master, "feature/*"]
+    branches: [master, "feature/*", "release-nextgen-*"]
   pull_request:
-    branches: [master, "feature/*"]
+    branches: [master, "feature/*", "release-nextgen-*"]
 
 jobs:
   integration-local:
@@ -137,6 +137,9 @@ jobs:
   integration-next-gen-tikv:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-integration-tests') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -149,18 +152,54 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
-      - name: Fetch PD
+      - name: Resolve Next-Gen Image Tags
+        id: resolve-nextgen-tags
+        shell: bash
+        run: |
+          target_branch="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
+
+          case "${target_branch}" in
+            release-nextgen-*)
+              pd_tag="${target_branch}"
+              tikv_tag="${target_branch}"
+              ;;
+            *)
+              pd_tag="master-nextgen"
+              tikv_tag="cloud-engine-nextgen"
+              ;;
+          esac
+
+          echo "pd_tag=${pd_tag}" >> "${GITHUB_OUTPUT}"
+          echo "tikv_tag=${tikv_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: pingcap-testing-account
+          workload_identity_provider: projects/890604261603/locations/global/workloadIdentityPools/github-tikv/providers/github-oidc
+          service_account: tidbx-gar-reader@pingcap-testing-account.iam.gserviceaccount.com
+          token_format: access_token
+
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Fetch Next-Gen PD
         uses: shrink/actions-docker-extract@v1
         id: extract-pd
         with:
-          image: pingcap/pd:nightly
+          image: us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:${{ steps.resolve-nextgen-tags.outputs.pd_tag }}
           path: /pd-server
 
       - name: Fetch Next-Gen TiKV
         uses: shrink/actions-docker-extract@v1
         id: extract-tikv
         with:
-          image: gcr.io/pingcap-public/dbaas/tikv:dedicated-next-gen
+          image: us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:${{ steps.resolve-nextgen-tags.outputs.tikv_tag }}
           path: /tikv-server
 
       - name: Run MinIO, PD & Next-Gen TiKV
@@ -178,7 +217,7 @@ jobs:
           ./pd-server --config pd_next_gen.toml > pd.log 2>&1 &
           sleep 5
           ./tikv-server -C tikv_next_gen.toml --pd-endpoints="127.0.0.1:2379" --addr="127.0.0.1:20160" --data-dir=${{ github.workspace }}/integration_tests/tikv-data > tikv.log 2>&1 &
-          
+
           echo "Waiting for servers to start..."
           sleep 15
 


### PR DESCRIPTION
## Summary
- authenticate the next-gen integration workflow to GAR through Workload Identity Federation
- fetch next-gen PD and TiKV binaries from `pingcap-testing-account/tidbx`
- resolve image tags from the target branch so `release-nextgen-*` uses the branch name while `main`/`master` use the fixed next-gen tags
- restrict the job to supported branches and same-repository PRs before requesting cloud credentials

## Image mapping
- PD: `us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/pd/image:<tag>`
- TiKV: `us-docker.pkg.dev/pingcap-testing-account/tidbx/tikv/tikv/image:<tag>`

## Tag rules
- `release-nextgen-*` -> `<tag>` is the target branch name
- `main` / `master` -> PD `master-nextgen`, TiKV `cloud-engine-nextgen`

## Notes
- this change assumes the GCP Workload Identity provider `projects/890604261603/locations/global/workloadIdentityPools/github-tikv/providers/github-oidc` and the `tidbx-gar-reader@pingcap-testing-account.iam.gserviceaccount.com` binding are in place


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline now runs for additional feature and release branches to broaden automated testing.
  * Improved build/runtime asset retrieval with authenticated access and dynamic image/tag resolution for Next‑Gen components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->