### PR TITLE
apicodec: complete API v2 key-bearing command coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository is the Go module `github.com/tikv/client-go/v2`, a Go client library for TiKV and CSE. Public packages live at the repository root, including `tikv`, `rawkv`, `txnkv`, `kv`, `tikvrpc`, `oracle`, `config`, `metrics`, `trace`, and `error`. Implementation-only packages live under `internal/`, such as `internal/client`, `internal/locate`, `internal/apicodec`, `internal/kvrpc`, `internal/mockstore`, and `internal/unionstore`.
+
+Tests are colocated with packages in `*_test.go` files. Broader integration coverage is under `integration_tests/`, with a separate `go.mod`; raw KV integration tests live in `integration_tests/raw/`. Runnable examples are under `examples/`, and several example directories are independent Go modules.
+
+## Build, Test, and Development Commands
+
+- `go test ./...`: run the main module unit tests locally.
+- `go test --tags=intest ./...`: run the full unit-test set used by CI.
+- `go test -race --tags=intest ./...`: run CI-equivalent race tests.
+- `go test ./internal/apicodec`: run targeted API codec tests; use this after changing API v2 request or response key handling.
+- `go generate ./...`: regenerate generated files, then check `git diff` for unexpected output.
+- `golangci-lint run`: run repository linting and formatting checks from `.golangci.yml`.
+- `cd integration_tests && gotestsum --format short-verbose -- ./...`: run local integration tests from the integration module.
+- `cd integration_tests && go test --with-tikv`: run integration tests against local `pd-server` and `tikv-server` binaries after starting them as described in `README.md`.
+
+## Coding Style & Naming Conventions
+
+Use Go 1.25.x and standard Go formatting. Run `gofmt`/`goimports` through `golangci-lint`, or format touched files before submitting. Keep package names short, lowercase, and consistent with existing directories. Exported identifiers must have clear Go doc comments when they are part of the public client API.
+
+Prefer existing error, retry, backoff, logging, metrics, and failpoint helpers instead of introducing parallel mechanisms. Keep public API changes small and deliberate because this module is consumed by multiple TiDB ecosystem components, including TiDB, TiCDC, BR, go-ycsb, and other projects. Design and review for compatibility and stability across these consumers, not only for TiDB.
+
+## API v2 Codec Guidelines
+
+All API v2 commands that carry keys must have complete and consistent encode/decode handling in `internal/apicodec`. This includes keys, key ranges, lock information, region errors, and any request or response fields that carry encoded keys. When adding or modifying a key-bearing RPC, update both request and response paths, add table-driven coverage in `internal/apicodec`, and verify that encode/decode behavior is symmetric. Missing or one-sided handling can create key-format mismatches and correctness bugs, especially across TiKV and CSE paths.
+
+## Testing Guidelines
+
+Use Go's `testing` package with `testify/require`, `testify/assert`, and `testify/suite`, matching nearby tests. Name tests `TestXxx` and keep suite types in the existing lowercase style, such as `testRawkvSuite` or `testSnapshotSuite`.
+
+Add or update package-level tests for every behavior change. Use `integration_tests/` when behavior depends on TiKV, PD, transactions, lock resolution, failpoints, or API-version behavior that mocks cannot cover. For concurrency-sensitive changes, run the race command before opening a PR.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use concise, imperative subjects scoped by package or area, for example `apicodec: cover remaining API v2 key-bearing commands` or `txnkv: enable TiKV-side async resolve region lock for read path`. Follow that pattern and reference issues or PRs when relevant. This repository has DCO checks enabled; create commits with `git commit -s` so the commit message includes the required `Signed-off-by` trailer.
+
+Pull requests should include a short problem statement, a summary of behavior changes, and the exact tests run. Link related issues and note compatibility impact for TiDB, TiCDC, BR, CSE, or other downstream users.
+
+## Security & Configuration Tips
+
+Do not commit local TiKV, PD, MinIO, or credential configuration. Keep generated logs, local data directories, and temporary integration-test artifacts out of version control. When testing against TiDB, prefer a local `go mod edit -replace=github.com/tikv/client-go/v2=/path/to/client-go` and avoid committing temporary replace directives unless the PR intentionally changes dependency wiring.
+
+## Agent-Specific Instructions
+
+Before editing, check the working tree and avoid modifying unrelated untracked or user-edited files. Keep documentation updates factual and repository-specific. When touching generated code, run `go generate ./...` and include generated diffs only when they are expected.

--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -205,6 +205,25 @@ func (c *codecV2) EncodeRequest(req *tikvrpc.Request) (*tikvrpc.Request, error) 
 		r := *req.CheckSecondaryLocks()
 		r.Keys = c.encodeKeys(r.Keys)
 		req.Req = &r
+	case tikvrpc.CmdFlush:
+		r := *req.Flush()
+		r.Mutations = c.encodeMutations(r.Mutations)
+		if len(r.PrimaryKey) > 0 {
+			r.PrimaryKey = c.EncodeKey(r.PrimaryKey)
+		}
+		req.Req = &r
+	case tikvrpc.CmdBufferBatchGet:
+		r := *req.BufferBatchGet()
+		r.Keys = c.encodeKeys(r.Keys)
+		req.Req = &r
+	case tikvrpc.CmdFlashbackToVersion:
+		r := *req.FlashbackToVersion()
+		r.StartKey, r.EndKey = c.encodeRange(r.StartKey, r.EndKey, false)
+		req.Req = &r
+	case tikvrpc.CmdPrepareFlashbackToVersion:
+		r := *req.PrepareFlashbackToVersion()
+		r.StartKey, r.EndKey = c.encodeRange(r.StartKey, r.EndKey, false)
+		req.Req = &r
 
 	// Raw Request Types.
 	case tikvrpc.CmdRawGet:
@@ -485,6 +504,42 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		if err != nil {
 			return nil, err
 		}
+	case tikvrpc.CmdFlush:
+		r := resp.Resp.(*kvrpcpb.FlushResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
+		r.Errors, err = c.decodeKeyErrors(r.Errors)
+		if err != nil {
+			return nil, err
+		}
+	case tikvrpc.CmdBufferBatchGet:
+		r := resp.Resp.(*kvrpcpb.BufferBatchGetResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
+		r.Pairs, err = c.decodePairs(r.Pairs)
+		if err != nil {
+			return nil, err
+		}
+		r.Error, err = c.decodeKeyError(r.Error)
+		if err != nil {
+			return nil, err
+		}
+	case tikvrpc.CmdFlashbackToVersion:
+		r := resp.Resp.(*kvrpcpb.FlashbackToVersionResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
+	case tikvrpc.CmdPrepareFlashbackToVersion:
+		r := resp.Resp.(*kvrpcpb.PrepareFlashbackToVersionResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
 	// RawKV Responses.
 	// Most of these responses does not require treatment aside from Region Error decoding.
 	// Exceptions are Response with keys attach to them, like RawScan and RawBatchGet,
@@ -577,6 +632,12 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		if err != nil {
 			return nil, err
 		}
+	case tikvrpc.CmdCheckLockObserver:
+		r := resp.Resp.(*kvrpcpb.CheckLockObserverResponse)
+		r.Locks, err = c.decodeLockInfos(r.Locks)
+		if err != nil {
+			return nil, err
+		}
 	case tikvrpc.CmdCop:
 		r := resp.Resp.(*coprocessor.Response)
 		r.RegionError, err = c.decodeRegionError(r.RegionError)
@@ -600,6 +661,38 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		r.RegionError, err = c.decodeRegionError(r.RegionError)
 		if err != nil {
 			return nil, err
+		}
+		r.Info, err = c.decodeMvccInfo(r.Info)
+		if err != nil {
+			return nil, err
+		}
+	case tikvrpc.CmdMvccGetByStartTs:
+		r := resp.Resp.(*kvrpcpb.MvccGetByStartTsResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
+		if len(r.Key) > 0 {
+			r.Key, err = c.DecodeKey(r.Key)
+			if err != nil {
+				return nil, err
+			}
+		}
+		r.Info, err = c.decodeMvccInfo(r.Info)
+		if err != nil {
+			return nil, err
+		}
+	case tikvrpc.CmdLockWaitInfo:
+		r := resp.Resp.(*kvrpcpb.GetLockWaitInfoResponse)
+		r.RegionError, err = c.decodeRegionError(r.RegionError)
+		if err != nil {
+			return nil, err
+		}
+		for i := range r.Entries {
+			r.Entries[i].Key, err = c.DecodeKey(r.Entries[i].Key)
+			if err != nil {
+				return nil, err
+			}
 		}
 	case tikvrpc.CmdSplitRegion:
 		r := resp.Resp.(*kvrpcpb.SplitRegionResponse)
@@ -975,6 +1068,10 @@ func (c *codecV2) decodeKeyError(keyError *kvrpcpb.KeyError) (*kvrpcpb.KeyError,
 			if mvccInfo.Key, err = c.DecodeKey(mvccInfo.Key); err != nil {
 				return nil, err
 			}
+			mvccInfo.Mvcc, err = c.decodeMvccInfo(mvccInfo.Mvcc)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return keyError, nil
@@ -989,6 +1086,33 @@ func (c *codecV2) decodeKeyErrors(keyErrors []*kvrpcpb.KeyError) ([]*kvrpcpb.Key
 		}
 	}
 	return keyErrors, nil
+}
+
+func (c *codecV2) decodeMvccInfo(info *kvrpcpb.MvccInfo) (*kvrpcpb.MvccInfo, error) {
+	if info == nil {
+		return nil, nil
+	}
+	lock := info.Lock
+	if lock == nil {
+		return info, nil
+	}
+	var err error
+	if len(lock.Primary) > 0 {
+		lock.Primary, err = c.DecodeKey(lock.Primary)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for i := range lock.Secondaries {
+		if len(lock.Secondaries[i]) == 0 {
+			continue
+		}
+		lock.Secondaries[i], err = c.DecodeKey(lock.Secondaries[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return info, nil
 }
 
 func (c *codecV2) decodeLockInfo(info *kvrpcpb.LockInfo) (*kvrpcpb.LockInfo, error) {

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -102,6 +102,88 @@ func (suite *testCodecV2Suite) TestEncodeRequest() {
 				re.Equal(append(keyspacePrefix, []byte("key1")...), encoded.Commit().PrimaryKey)
 			},
 		},
+		{
+			name: "CmdFlush",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdFlush,
+				Req: &kvrpcpb.FlushRequest{
+					Mutations: []*kvrpcpb.Mutation{
+						{
+							Op:  kvrpcpb.Op_Put,
+							Key: []byte("key1"),
+						},
+						{
+							Op:  kvrpcpb.Op_Del,
+							Key: []byte("key2"),
+						},
+					},
+					PrimaryKey: []byte("primary"),
+				},
+			},
+			validate: func(encoded *tikvrpc.Request) {
+				re.Len(encoded.Flush().Mutations, 2)
+				re.Equal(append(keyspacePrefix, []byte("key1")...), encoded.Flush().Mutations[0].Key)
+				re.Equal(append(keyspacePrefix, []byte("key2")...), encoded.Flush().Mutations[1].Key)
+				re.Equal(append(keyspacePrefix, []byte("primary")...), encoded.Flush().PrimaryKey)
+			},
+		},
+		{
+			name: "CmdBufferBatchGet",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdBufferBatchGet,
+				Req: &kvrpcpb.BufferBatchGetRequest{
+					Keys: [][]byte{[]byte("key1"), []byte("key2")},
+				},
+			},
+			validate: func(encoded *tikvrpc.Request) {
+				re.Equal([][]byte{
+					append(keyspacePrefix, []byte("key1")...),
+					append(keyspacePrefix, []byte("key2")...),
+				}, encoded.BufferBatchGet().Keys)
+			},
+		},
+		{
+			name: "CmdFlashbackToVersion",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdFlashbackToVersion,
+				Req: &kvrpcpb.FlashbackToVersionRequest{
+					StartKey: []byte("start"),
+				},
+			},
+			validate: func(encoded *tikvrpc.Request) {
+				re.Equal(append(keyspacePrefix, []byte("start")...), encoded.FlashbackToVersion().StartKey)
+				re.Equal(keyspaceEndKey, encoded.FlashbackToVersion().EndKey)
+			},
+		},
+		{
+			name: "CmdPrepareFlashbackToVersion",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdPrepareFlashbackToVersion,
+				Req: &kvrpcpb.PrepareFlashbackToVersionRequest{
+					StartKey: []byte("prepare-start"),
+				},
+			},
+			validate: func(encoded *tikvrpc.Request) {
+				re.Equal(append(keyspacePrefix, []byte("prepare-start")...), encoded.PrepareFlashbackToVersion().StartKey)
+				re.Equal(keyspaceEndKey, encoded.PrepareFlashbackToVersion().EndKey)
+			},
+		},
+		{
+			name: "CmdCompact",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCompact,
+				Req: &kvrpcpb.CompactRequest{
+					StartKey: []byte("compact-start"),
+				},
+			},
+			validate: func(encoded *tikvrpc.Request) {
+				// Compact cursors are TiFlash RowKeyValue cursors, not API v2 storage keys.
+				// TiFlash carries API v2 context separately through ApiVersion and KeyspaceId.
+				re.Equal([]byte("compact-start"), encoded.Compact().StartKey)
+				re.Equal(kvrpcpb.APIVersion_V2, encoded.Compact().ApiVersion)
+				re.Equal(testKeyspaceID, encoded.Compact().KeyspaceId)
+			},
+		},
 	}
 
 	for _, req := range requests {
@@ -423,8 +505,16 @@ func (suite *testCodecV2Suite) TestDecodeKeyError() {
 				DebugInfo: &kvrpcpb.DebugInfo{
 					MvccInfo: []*kvrpcpb.MvccDebugInfo{
 						{
-							Key:  append(keyspacePrefix, []byte("key1")...),
-							Mvcc: &kvrpcpb.MvccInfo{},
+							Key: append(keyspacePrefix, []byte("key1")...),
+							Mvcc: &kvrpcpb.MvccInfo{
+								Lock: &kvrpcpb.MvccLock{
+									Primary: append(keyspacePrefix, []byte("debug-primary")...),
+									Secondaries: [][]byte{
+										append(keyspacePrefix, []byte("debug-secondary-1")...),
+										append(keyspacePrefix, []byte("debug-secondary-2")...),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -433,6 +523,11 @@ func (suite *testCodecV2Suite) TestDecodeKeyError() {
 				re.Equal([]byte("key1"), decoded.TxnLockNotFound.Key)
 				re.Equal(1, len(decoded.DebugInfo.MvccInfo))
 				re.Equal([]byte("key1"), decoded.DebugInfo.MvccInfo[0].Key)
+				re.Equal([]byte("debug-primary"), decoded.DebugInfo.MvccInfo[0].Mvcc.Lock.Primary)
+				re.Equal([][]byte{
+					[]byte("debug-secondary-1"),
+					[]byte("debug-secondary-2"),
+				}, decoded.DebugInfo.MvccInfo[0].Mvcc.Lock.Secondaries)
 			},
 		},
 	}
@@ -447,6 +542,327 @@ func (suite *testCodecV2Suite) TestDecodeKeyError() {
 			keyErr.validate(re, decoded)
 		})
 	}
+}
+
+func (suite *testCodecV2Suite) TestDecodeResponseHotPathCommands() {
+	makeRegionError := func(key, start, end []byte) *errorpb.Error {
+		encodedStart, encodedEnd := suite.codec.EncodeRegionRange(start, end)
+		return &errorpb.Error{
+			KeyNotInRegion: &errorpb.KeyNotInRegion{
+				Key:      suite.codec.EncodeKey(key),
+				StartKey: encodedStart,
+				EndKey:   encodedEnd,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		req      *tikvrpc.Request
+		resp     *tikvrpc.Response
+		validate func(*require.Assertions, *tikvrpc.Response)
+	}{
+		{
+			name: "CmdFlush",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdFlush,
+				Req:  &kvrpcpb.FlushRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.FlushResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Errors: []*kvrpcpb.KeyError{
+						{
+							TxnLockNotFound: &kvrpcpb.TxnLockNotFound{
+								Key: suite.codec.EncodeKey([]byte("lock-key")),
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.FlushResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+				re.Len(resp.Errors, 1)
+				re.Equal([]byte("lock-key"), resp.Errors[0].TxnLockNotFound.Key)
+			},
+		},
+		{
+			name: "CmdBufferBatchGet",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdBufferBatchGet,
+				Req:  &kvrpcpb.BufferBatchGetRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.BufferBatchGetResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Error: &kvrpcpb.KeyError{
+						TxnLockNotFound: &kvrpcpb.TxnLockNotFound{
+							Key: suite.codec.EncodeKey([]byte("response-lock")),
+						},
+					},
+					Pairs: []*kvrpcpb.KvPair{
+						{
+							Key: suite.codec.EncodeKey([]byte("pair-key")),
+							Error: &kvrpcpb.KeyError{
+								TxnLockNotFound: &kvrpcpb.TxnLockNotFound{
+									Key: suite.codec.EncodeKey([]byte("pair-lock")),
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.BufferBatchGetResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+				re.Equal([]byte("response-lock"), resp.Error.TxnLockNotFound.Key)
+				re.Len(resp.Pairs, 1)
+				re.Equal([]byte("pair-key"), resp.Pairs[0].Key)
+				re.Equal([]byte("pair-lock"), resp.Pairs[0].Error.TxnLockNotFound.Key)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		suite.Run(test.name, func() {
+			re := suite.Require()
+			decoded, err := suite.codec.DecodeResponse(test.req, test.resp)
+			re.NoError(err)
+			test.validate(re, decoded)
+		})
+	}
+}
+
+func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
+	makeRegionError := func(key, start, end []byte) *errorpb.Error {
+		encodedStart, encodedEnd := suite.codec.EncodeRegionRange(start, end)
+		return &errorpb.Error{
+			KeyNotInRegion: &errorpb.KeyNotInRegion{
+				Key:      suite.codec.EncodeKey(key),
+				StartKey: encodedStart,
+				EndKey:   encodedEnd,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		req      *tikvrpc.Request
+		resp     *tikvrpc.Response
+		validate func(*require.Assertions, *tikvrpc.Response)
+	}{
+		{
+			name: "CmdCheckLockObserver",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCheckLockObserver,
+				Req:  &kvrpcpb.CheckLockObserverRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.CheckLockObserverResponse{
+					Locks: []*kvrpcpb.LockInfo{
+						{
+							Key:         suite.codec.EncodeKey([]byte("observer-key")),
+							PrimaryLock: suite.codec.EncodeKey([]byte("observer-primary")),
+							Secondaries: [][]byte{suite.codec.EncodeKey([]byte("observer-secondary"))},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.CheckLockObserverResponse)
+				re.Len(resp.Locks, 1)
+				re.Equal([]byte("observer-key"), resp.Locks[0].Key)
+				re.Equal([]byte("observer-primary"), resp.Locks[0].PrimaryLock)
+				re.Equal([][]byte{[]byte("observer-secondary")}, resp.Locks[0].Secondaries)
+			},
+		},
+		{
+			name: "CmdLockWaitInfo",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdLockWaitInfo,
+				Req:  &kvrpcpb.GetLockWaitInfoRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.GetLockWaitInfoResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Entries: []*deadlockpb.WaitForEntry{
+						{
+							Key: suite.codec.EncodeKey([]byte("wait-key")),
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.GetLockWaitInfoResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+				re.Len(resp.Entries, 1)
+				re.Equal([]byte("wait-key"), resp.Entries[0].Key)
+			},
+		},
+		{
+			name: "CmdMvccGetByStartTs",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdMvccGetByStartTs,
+				Req:  &kvrpcpb.MvccGetByStartTsRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.MvccGetByStartTsResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Key:         suite.codec.EncodeKey([]byte("mvcc-key")),
+					Info: &kvrpcpb.MvccInfo{
+						Lock: &kvrpcpb.MvccLock{
+							Primary: suite.codec.EncodeKey([]byte("mvcc-primary")),
+							Secondaries: [][]byte{
+								suite.codec.EncodeKey([]byte("mvcc-secondary-1")),
+								suite.codec.EncodeKey([]byte("mvcc-secondary-2")),
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.MvccGetByStartTsResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+				re.Equal([]byte("mvcc-key"), resp.Key)
+				re.Equal([]byte("mvcc-primary"), resp.Info.Lock.Primary)
+				re.Equal([][]byte{
+					[]byte("mvcc-secondary-1"),
+					[]byte("mvcc-secondary-2"),
+				}, resp.Info.Lock.Secondaries)
+			},
+		},
+		{
+			name: "CmdMvccGetByKey",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdMvccGetByKey,
+				Req:  &kvrpcpb.MvccGetByKeyRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.MvccGetByKeyResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Info: &kvrpcpb.MvccInfo{
+						Lock: &kvrpcpb.MvccLock{
+							Primary: suite.codec.EncodeKey([]byte("mvcc-by-key-primary")),
+							Secondaries: [][]byte{
+								suite.codec.EncodeKey([]byte("mvcc-by-key-secondary-1")),
+								suite.codec.EncodeKey([]byte("mvcc-by-key-secondary-2")),
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.MvccGetByKeyResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+				re.Equal([]byte("mvcc-by-key-primary"), resp.Info.Lock.Primary)
+				re.Equal([][]byte{
+					[]byte("mvcc-by-key-secondary-1"),
+					[]byte("mvcc-by-key-secondary-2"),
+				}, resp.Info.Lock.Secondaries)
+			},
+		},
+		{
+			name: "CmdFlashbackToVersion",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdFlashbackToVersion,
+				Req:  &kvrpcpb.FlashbackToVersionRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.FlashbackToVersionResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.FlashbackToVersionResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+			},
+		},
+		{
+			name: "CmdPrepareFlashbackToVersion",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdPrepareFlashbackToVersion,
+				Req:  &kvrpcpb.PrepareFlashbackToVersionRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.PrepareFlashbackToVersionResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.PrepareFlashbackToVersionResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Equal([]byte("range-start"), resp.RegionError.KeyNotInRegion.StartKey)
+				re.Equal([]byte("range-end"), resp.RegionError.KeyNotInRegion.EndKey)
+			},
+		},
+		{
+			name: "CmdCompact",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCompact,
+				Req:  &kvrpcpb.CompactRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.CompactResponse{
+					// Compact cursors are TiFlash RowKeyValue cursors, not API v2 storage keys.
+					// TiFlash carries API v2 context separately through ApiVersion and KeyspaceId.
+					CompactedStartKey: []byte("compacted-start"),
+					CompactedEndKey:   []byte("compacted-end"),
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.CompactResponse)
+				re.Equal([]byte("compacted-start"), resp.CompactedStartKey)
+				re.Equal([]byte("compacted-end"), resp.CompactedEndKey)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		suite.Run(test.name, func() {
+			re := suite.Require()
+			decoded, err := suite.codec.DecodeResponse(test.req, test.resp)
+			re.NoError(err)
+			test.validate(re, decoded)
+		})
+	}
+}
+
+func (suite *testCodecV2Suite) TestDecodeMvccInfoPreservesEmptyLockKeys() {
+	re := suite.Require()
+	info := &kvrpcpb.MvccInfo{
+		Lock: &kvrpcpb.MvccLock{
+			Primary: []byte{},
+			Secondaries: [][]byte{
+				{},
+				suite.codec.EncodeKey([]byte("mvcc-secondary")),
+			},
+		},
+	}
+
+	decoded, err := suite.codec.decodeMvccInfo(info)
+	re.NoError(err)
+	re.Same(info, decoded)
+	re.NotNil(decoded.Lock.Primary)
+	re.Empty(decoded.Lock.Primary)
+	re.Len(decoded.Lock.Secondaries, 2)
+	re.NotNil(decoded.Lock.Secondaries[0])
+	re.Empty(decoded.Lock.Secondaries[0])
+	re.Equal([]byte("mvcc-secondary"), decoded.Lock.Secondaries[1])
 }
 
 func (suite *testCodecV2Suite) TestGetKeyspaceID() {


### PR DESCRIPTION
## Summary

Port [#1993](https://github.com/tikv/client-go/pull/1994)

This PR completes the missing API v2 encode/decode coverage for key-bearing commands in `internal/apicodec`.

`apicodec` already handled many common API v2 paths correctly, but coverage was still partial. Some commands could bypass request-side key encoding or response-side key decoding, which leaves room for key-format mismatches once keyspace prefixes are involved. That kind of mismatch is a correctness issue rather than a cleanup issue.

This work follows up on https://github.com/tikv/client-go/pull/1986, which fixed a real bug we hit in a PoC. That fix addressed one concrete API v2 codec gap in lock error handling. This PR extends the same principle to the remaining key-bearing command paths so that API v2 handling is complete and consistent at the codec layer.

## Changes

This PR is split into three logical parts.

### 1. Cover the hot paths used by flush and buffered reads

The first part adds API v2 handling for:

- `CmdFlush`
  - encode request `Mutations`
  - encode request `PrimaryKey`
  - decode response `RegionError`
  - decode response `Errors`
- `CmdBufferBatchGet`
  - encode request `Keys`
  - decode response `RegionError`
  - decode response `Error`
  - decode response `Pairs`

These paths are already used by pipelined DML and buffered snapshot reads, so leaving them outside API v2 coverage means the client can still send or consume keys in inconsistent formats.

### 2. Cover the remaining key-bearing command paths in `apicodec`

The second part adds API v2 handling for the remaining commands in this area that still carry keys or key ranges:

- `CmdCheckLockObserver`
- `CmdLockWaitInfo`
- `CmdMvccGetByStartTs`
- `CmdFlashbackToVersion`
- `CmdPrepareFlashbackToVersion`

These commands are not all on the same hot path as flush and buffered reads, but they still cross the API v2 boundary with keys, key ranges, lock information, or region errors. Leaving them partially covered means the client can still send raw keys without the expected API v2 encoding or return storage-encoded keys without decoding them first.

### 3. Add repository guidance for future API v2 codec work

This PR also adds `AGENTS.md` to document repository-specific guidance for future development and review.

In particular, the new guidance makes two expectations explicit:

- `client-go` is shared infrastructure for both TiKV and CSE, and it is consumed by multiple TiDB ecosystem components such as TiDB, TiCDC, BR, and others. Changes in this repository therefore need to be coded and reviewed with downstream compatibility and stability in mind, rather than only validating a single TiDB-facing path.
- API v2 key-bearing commands should be handled symmetrically in `apicodec`. If a request or response carries keys, key ranges, lock information, or region errors with encoded keys, the codec needs complete and consistent handling in both directions. Partial coverage makes it too easy to introduce encode/decode mismatches and correctness bugs.

## Tests

```bash
go test ./internal/apicodec
```