### PR TITLE
txn: pick shared lock support into TiCDC release branch

### DIFF
--- a/integration_tests/2pc_test.go
+++ b/integration_tests/2pc_test.go
@@ -88,7 +88,8 @@ func (s *testCommitterSuite) SetupSuite() {
 
 func (s *testCommitterSuite) TearDownSuite() {
 	s.Nil(failpoint.Disable("tikvclient/injectLiveness"))
-	atomic.StoreUint64(&transaction.CommitMaxBackoff, 20000)
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 20000)
+	atomic.StoreUint64(&transaction.CommitMaxBackoff, 40000)
 }
 
 func (s *testCommitterSuite) SetupTest() {

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20251109100001-1907922fbd18
+	github.com/pingcap/kvproto v0.0.0-20251218093338-9f0ac2fc9a1a
 	github.com/pingcap/tidb v1.1.0-beta.0.20250609033843-a165d9fd7c01
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1351,8 +1351,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20251109100001-1907922fbd18 h1:ZgebBNwgma8INCfexAX8dfqZo7TWQrvMXHGABEmAY2Y=
-github.com/pingcap/kvproto v0.0.0-20251109100001-1907922fbd18/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20251218093338-9f0ac2fc9a1a h1:uGZ0XGBMtcJTmh+6mlpF/SCRZhJXOPES7lx0oY3NBas=
+github.com/pingcap/kvproto v0.0.0-20251218093338-9f0ac2fc9a1a/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250514022801-14f3b4ca066e h1:8AZZRv1Ox9FVGATVZBBgr6y1MrNBQFABEdovNJt1QIc=

--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -473,6 +473,7 @@ func (s *testPipelinedMemDBSuite) TestPipelinedDMLFailedByPKRollback() {
 func (s *testPipelinedMemDBSuite) TestPipelinedDMLFailedByPKMaxTTLExceeded() {
 	originManagedTTLVal := atomic.LoadUint64(&transaction.ManagedLockTTL)
 	originMaxPipelinedTxnTTL := atomic.LoadUint64(&transaction.MaxPipelinedTxnTTL)
+	restoreConf := restoreGlobalConfFunc()                   // Get the restore function BEFORE changing config
 	atomic.StoreUint64(&transaction.ManagedLockTTL, 100)     // set to 100ms
 	atomic.StoreUint64(&transaction.MaxPipelinedTxnTTL, 200) // set to 200ms
 	updateGlobalConfig(func(conf *config.Config) {
@@ -481,7 +482,7 @@ func (s *testPipelinedMemDBSuite) TestPipelinedDMLFailedByPKMaxTTLExceeded() {
 	defer func() {
 		atomic.StoreUint64(&transaction.ManagedLockTTL, originManagedTTLVal)
 		atomic.StoreUint64(&transaction.MaxPipelinedTxnTTL, originMaxPipelinedTxnTTL)
-		restoreGlobalConfFunc()
+		restoreConf()
 	}()
 
 	txn, err := s.store.Begin(tikv.WithDefaultPipelinedTxn())

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -1,0 +1,465 @@
+// Copyright 2025 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/suite"
+	"github.com/tikv/client-go/v2/config"
+	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/tikv"
+	"github.com/tikv/client-go/v2/txnkv/transaction"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
+)
+
+func TestSharedLock(t *testing.T) {
+	if !*withTiKV {
+		t.Skip("skipping TestSharedLock because with-tikv is not enabled")
+		return
+	}
+	if config.NextGen {
+		t.Skip("skipping TestSharedLock because next-gen doesn't support shared lock yet")
+		return
+	}
+	suite.Run(t, new(testSharedLockSuite))
+}
+
+type testSharedLockSuite struct {
+	suite.Suite
+	store tikv.StoreProbe
+}
+
+func (s *testSharedLockSuite) SetupSuite() {
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 3000) // 3s
+	atomic.StoreUint64(&transaction.CommitMaxBackoff, 1000)
+	s.Nil(failpoint.Enable("tikvclient/injectLiveness", `return("reachable")`))
+}
+
+func (s *testSharedLockSuite) TearDownSuite() {
+	s.Nil(failpoint.Disable("tikvclient/injectLiveness"))
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 20000)
+	atomic.StoreUint64(&transaction.CommitMaxBackoff, 40000)
+}
+
+func (s *testSharedLockSuite) SetupTest() {
+	s.store = tikv.StoreProbe{KVStore: NewTestStore(s.T())}
+}
+
+func (s *testSharedLockSuite) TearDownTest() {
+	s.store.Close()
+}
+
+func (s *testSharedLockSuite) begin() transaction.TxnProbe {
+	txn, err := s.store.Begin()
+	s.Require().Nil(err)
+	txn.SetPessimistic(true)
+	return txn
+}
+
+func (s *testSharedLockSuite) getTS() uint64 {
+	ts, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{})
+	s.Nil(err)
+	return ts
+}
+
+func (s *testSharedLockSuite) scanLocks(key []byte, maxTS uint64) []*txnlock.Lock {
+	locks, err := s.store.ScanLocks(context.Background(), key, append(key, 0), maxTS)
+	s.Nil(err)
+	if len(locks) == 0 {
+		return nil
+	}
+	return locks
+}
+
+func (s *testSharedLockSuite) TestSharedLockBlockExclusiveLock() {
+	for _, commit := range []bool{true, false} {
+		txn1 := s.begin()
+		txn2 := s.begin()
+		txn3 := s.begin()
+
+		pk1 := []byte("TestSharedLockBlockExclusiveLock_pk1")
+		pk2 := []byte("TestSharedLockBlockExclusiveLock_pk2")
+		pk3 := []byte("TestSharedLockBlockExclusiveLock_pk3")
+		key := []byte("TestSharedLockBlockExclusiveLock_shared_key")
+
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)
+		lockctx1 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockctx1.InShareMode = true
+		s.Nil(txn1.LockKeys(context.Background(), lockctx1, key))
+
+		s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
+		lockctx2 := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockctx2.InShareMode = true
+		s.Nil(txn2.LockKeys(context.Background(), lockctx2, key))
+
+		flags, err := txn2.GetMemBuffer().GetFlags(key)
+		s.Nil(err)
+		s.True(flags.HasLockedInShareMode())
+
+		s.Nil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk3))
+		s.Equal(txn3.GetCommitter().GetPrimaryKey(), pk3)
+		lockDone := make(chan time.Time)
+		go func() {
+			s.NotNil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key)) // should block and return conflict
+			lockDone <- time.Now()
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+		beforeRelease := time.Now()
+
+		if commit {
+			s.Nil(txn1.Commit(context.Background()))
+			s.Nil(txn2.Commit(context.Background()))
+		} else {
+			s.Nil(txn1.Rollback())
+			s.Nil(txn2.Rollback())
+		}
+
+		afterRelease := <-lockDone
+		s.True(afterRelease.After(beforeRelease), "txn3(exclusive lock) should block until txn1(shared lock) and txn2(shared lock) commit")
+		s.Nil(txn3.Rollback())
+	}
+}
+
+func (s *testSharedLockSuite) TestExclusiveLockBlockSharedLock() {
+	for _, commit := range []bool{true, false} {
+		txn1 := s.begin()
+		txn2 := s.begin()
+		txn3 := s.begin()
+
+		pk1 := []byte("TestExclusiveLockBlockSharedLock_pk1")
+		pk2 := []byte("TestExclusiveLockBlockSharedLock_pk2")
+		pk3 := []byte("TestExclusiveLockBlockSharedLock_pk3")
+		key := []byte("TestExclusiveLockBlockSharedLock_shared_key")
+
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key))
+
+		s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
+		s.Nil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk3))
+		s.Equal(txn3.GetCommitter().GetPrimaryKey(), pk3)
+
+		txn2LockDone := make(chan time.Time)
+		go func() {
+			lockctx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+			lockctx.InShareMode = true
+			s.NotNil(txn2.LockKeys(context.Background(), lockctx, key)) // should block and return conflict
+			txn2LockDone <- time.Now()
+		}()
+		txn3LockDone := make(chan time.Time)
+		go func() {
+			lockctx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+			lockctx.InShareMode = true
+			s.NotNil(txn3.LockKeys(context.Background(), lockctx, key)) // should block and return conflict
+			txn3LockDone <- time.Now()
+		}()
+
+		time.Sleep(500 * time.Millisecond)
+		beforeRelease := time.Now()
+
+		if commit {
+			s.Nil(txn1.Commit(context.Background()))
+		} else {
+			s.Nil(txn1.Rollback())
+		}
+
+		txn2Locked := <-txn2LockDone
+		txn3Locked := <-txn3LockDone
+		s.True(txn2Locked.After(beforeRelease), "txn2(shared lock) should block until txn1(exclusive lock) commit/rollback")
+		s.True(txn3Locked.After(beforeRelease), "txn3(shared lock) should block until txn1(exclusive lock) commit/rollback")
+		s.Nil(txn2.Rollback())
+		s.Nil(txn3.Rollback())
+	}
+}
+
+func (s *testSharedLockSuite) TestResolveSharedLock() {
+	txn1 := s.begin()
+
+	pk := []byte("TestResolveSharedLock_pk")
+	key := []byte("TestResolveSharedLock_shared_key")
+	_, err := s.store.SplitRegions(context.Background(), [][]byte{pk, key}, false, nil)
+	s.Nil(err)
+
+	s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk))
+	s.Equal(pk, txn1.GetCommitter().GetPrimaryKey())
+	lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+	lockCtx.InShareMode = true
+	s.Nil(txn1.LockKeys(context.Background(), lockCtx, key))
+
+	s.Nil(failpoint.Enable("tikvclient/beforeCommitSecondaries", `return("skip")`))
+	txn1.SetSessionID(1)
+	s.Nil(txn1.Commit(context.Background()))
+
+	locks := s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	lock := locks[0]
+	s.Equal(key, lock.Key)
+	s.Equal(pk, lock.Primary)
+
+	s.Equal(txn1.StartTS(), lock.TxnID)
+	s.Equal(lock.LockType, kvrpcpb.Op_Lock)
+
+	txn2 := s.begin()
+	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk))
+	s.Equal(pk, txn2.GetCommitter().GetPrimaryKey())
+	s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), key))
+
+	locks = s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	lock = locks[0]
+	s.NotNil(lock)
+	s.Equal(key, lock.Key)
+	s.Equal(pk, lock.Primary)
+	s.Equal(txn2.StartTS(), lock.TxnID)
+	s.Equal(lock.LockType, kvrpcpb.Op_PessimisticLock)
+
+	s.Nil(txn2.Rollback())
+	s.Len(s.scanLocks(key, s.getTS()), 0)
+	s.Nil(failpoint.Disable("tikvclient/beforeCommitSecondaries"))
+}
+
+func (s *testSharedLockSuite) TestScanSharedLock() {
+	pk1 := []byte("TestScanSharedLock_pk_1")
+	pk2 := []byte("TestScanSharedLock_pk_2")
+	pk3 := []byte("TestScanSharedLock_pk_3")
+	sharedKey := []byte("TestScanSharedLock_shared_key")
+	txn1 := s.begin()
+	txn2 := s.begin()
+	txn3 := s.begin()
+
+	pks := [][]byte{pk1, pk2, pk3}
+	txns := []transaction.TxnProbe{txn1, txn2, txn3}
+
+	for i, txn := range txns {
+		s.Nil(txn.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pks[i]))
+		s.Equal(pks[i], txn.GetCommitter().GetPrimaryKey())
+		lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockCtx.InShareMode = true
+		s.Nil(txn.LockKeys(context.Background(), lockCtx, sharedKey))
+	}
+
+	maxTS2LockNum := map[uint64]int{
+		txn1.StartTS() - 1: 0,
+		txn1.StartTS():     1,
+		txn2.StartTS():     2,
+		txn3.StartTS():     3,
+	}
+	for maxTS, lockNum := range maxTS2LockNum {
+		locks := s.scanLocks(sharedKey, maxTS)
+		s.Equal(len(locks), lockNum, fmt.Sprintf("when maxTS=%d, expect %d locks", maxTS, lockNum))
+		for _, lock := range locks {
+			s.Equal(sharedKey, lock.Key)
+			s.LessOrEqual(lock.TxnID, maxTS)
+		}
+	}
+
+	for _, txn := range txns {
+		s.Nil(txn.Rollback())
+	}
+	locks, err := s.store.ScanLocks(context.Background(), sharedKey, append(sharedKey, 0), txn3.StartTS())
+	s.Nil(err)
+	s.Equal(len(locks), 0, "no locks after rollback")
+}
+
+func (s *testSharedLockSuite) TestGCSharedLock() {
+	originManagedLockTTL := atomic.LoadUint64(&transaction.ManagedLockTTL)
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 1000) // 1000ms, increased for test stability in busy environments
+	defer atomic.StoreUint64(&transaction.ManagedLockTTL, originManagedLockTTL)
+
+	txn1 := s.begin()
+	txn2 := s.begin()
+	txn3 := s.begin()
+	pk1 := []byte("TestGCSharedLock_pk1")
+	pk2 := []byte("TestGCSharedLock_pk2")
+	pk3 := []byte("TestGCSharedLock_pk3")
+	sharedKey := []byte("TestGCSharedLock_shared_key")
+
+	pks := [][]byte{pk1, pk2, pk3}
+	txns := []transaction.TxnProbe{txn1, txn2, txn3}
+
+	for i, txn := range txns {
+		s.Nil(txn.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pks[i]))
+		s.Equal(pks[i], txn.GetCommitter().GetPrimaryKey())
+		lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+		lockCtx.InShareMode = true
+		s.Nil(txn.LockKeys(context.Background(), lockCtx, sharedKey))
+	}
+	// keep heartbeat for txn3 only
+	txn1.GetCommitter().CloseTTLManager()
+	txn2.GetCommitter().CloseTTLManager()
+
+	// Verify txn3's TTL manager is still running
+	s.True(txn3.GetCommitter().IsTTLRunning(), "txn3's TTL manager should be running")
+
+	var locks []*txnlock.Lock
+	s.Eventually(func() bool {
+		locks = s.scanLocks(sharedKey, s.getTS())
+		return len(locks) == 3
+	}, 5*time.Second, 100*time.Millisecond, "expect 3 locks after pipelined locks being applied")
+
+	s.Len(locks, 3)
+	for _, lock := range locks {
+		s.Equal(sharedKey, lock.Key)
+		s.Equal(lock.LockType, kvrpcpb.Op_PessimisticLock)
+	}
+
+	// wait managed lock ttl to expire for txn1 and txn2
+	time.Sleep(time.Duration(atomic.LoadUint64(&transaction.ManagedLockTTL))*time.Millisecond + 200*time.Millisecond)
+
+	// Verify txn3's TTL manager is still running after the sleep
+	s.True(txn3.GetCommitter().IsTTLRunning(), "txn3's TTL manager should still be running after sleep")
+
+	lr := s.store.NewLockResolver()
+	bo := tikv.NewGcResolveLockMaxBackoffer(context.Background())
+	ttl, err := lr.ResolveLocks(bo, 0, locks)
+	s.Nil(err)
+	s.Zero(ttl)
+
+	locks = s.scanLocks(sharedKey, s.getTS())
+	s.Len(locks, 1, "expected 1 lock (txn3's) to remain, but got %d; txn3 TTL running: %v", len(locks), txn3.GetCommitter().IsTTLRunning())
+	s.Equal(txn3.StartTS(), locks[0].TxnID)
+	s.Equal(sharedKey, locks[0].Key)
+	s.Nil(txn3.Rollback())
+}
+
+func (s *testSharedLockSuite) TestSharedLockCommitAndRollback() {
+	for _, commit := range []bool{true, false} {
+		txn1 := s.begin()
+		txn2 := s.begin()
+		txn3 := s.begin()
+
+		pk1 := []byte("TestSharedLockCommitAndRollback_pk1")
+		pk2 := []byte("TestSharedLockCommitAndRollback_pk2")
+		pk3 := []byte("TestSharedLockCommitAndRollback_pk3")
+		key := []byte("TestSharedLockCommitAndRollback_shared_key")
+
+		s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk1))
+		s.Equal(txn1.GetCommitter().GetPrimaryKey(), pk1)
+		s.Nil(txn2.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk2))
+		s.Equal(txn2.GetCommitter().GetPrimaryKey(), pk2)
+		s.Nil(txn3.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk3))
+		s.Equal(txn3.GetCommitter().GetPrimaryKey(), pk3)
+
+		for _, txn := range []transaction.TxnProbe{txn1, txn2, txn3} {
+			lockctx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+			lockctx.InShareMode = true
+			s.Nil(txn.LockKeys(context.Background(), lockctx, key))
+		}
+
+		var locks []*txnlock.Lock
+		s.Eventually(func() bool {
+			locks = s.scanLocks(key, s.getTS())
+			return len(locks) == 3
+		}, 5*time.Second, 100*time.Millisecond, "expect 3 locks after pipelined locks being applied")
+		s.Len(locks, 3)
+
+		for i, txn := range []transaction.TxnProbe{txn1, txn2, txn3} {
+			if commit {
+				s.Nil(txn.Commit(context.Background()))
+			} else {
+				s.Nil(txn.Rollback())
+			}
+
+			currLocks := 3 - i
+			s.Eventually(func() bool {
+				locks = s.scanLocks(key, s.getTS())
+				s.LessOrEqual(len(locks), currLocks)
+				if len(locks) == currLocks {
+					return false
+				}
+				return len(locks) == currLocks-1
+			}, 5*time.Second, 100*time.Millisecond, "after txn %d commit/rollback, expect %d locks remain", i+1, currLocks-1)
+
+			for _, lock := range locks {
+				s.Equal(key, lock.Key)
+				s.NotEqual(lock.TxnID, txn.StartTS())
+			}
+		}
+		locks = s.scanLocks(key, s.getTS())
+		s.Len(locks, 0)
+	}
+}
+
+func (s *testSharedLockSuite) TestPrewriteResolveExpiredSharedLock() {
+	// Set short ManagedLockTTL so locks expire quickly
+	originManagedLockTTL := atomic.LoadUint64(&transaction.ManagedLockTTL)
+	atomic.StoreUint64(&transaction.ManagedLockTTL, 500) // 500ms, increased for test stability
+	defer atomic.StoreUint64(&transaction.ManagedLockTTL, originManagedLockTTL)
+
+	pk := []byte("TestPrewriteResolveExpiredSharedLock_pk")
+	key := []byte("TestPrewriteResolveExpiredSharedLock_key")
+
+	// Step 1: Create a pessimistic transaction with shared lock
+	txn1 := s.begin()
+	s.Nil(txn1.LockKeys(context.Background(), kv.NewLockCtx(s.getTS(), 1000, time.Now()), pk))
+	s.Equal(pk, txn1.GetCommitter().GetPrimaryKey())
+
+	lockCtx := kv.NewLockCtx(s.getTS(), 1000, time.Now())
+	lockCtx.InShareMode = true
+	s.Nil(txn1.LockKeys(context.Background(), lockCtx, key))
+
+	// Wait for the shared lock to be visible
+	s.Eventually(func() bool {
+		locks := s.scanLocks(key, s.getTS())
+		return len(locks) == 1
+	}, 5*time.Second, 100*time.Millisecond, "expect 1 shared lock")
+
+	// Step 2: Close TTL manager and wait for lock to expire
+	txn1.GetCommitter().CloseTTLManager()
+	time.Sleep(time.Duration(atomic.LoadUint64(&transaction.ManagedLockTTL))*time.Millisecond + 200*time.Millisecond)
+
+	// Verify the shared lock still exists (but is expired)
+	locks := s.scanLocks(key, s.getTS())
+	s.Len(locks, 1)
+	s.Equal(key, locks[0].Key)
+
+	// Step 3: Create an optimistic transaction to write to the same key
+	txn2, err := s.store.Begin()
+	s.Nil(err)
+	txn2.SetPessimistic(false) // Make it optimistic
+
+	value := []byte("value_from_txn2")
+	s.Nil(txn2.Set(key, value))
+
+	// Step 4: Commit should succeed after resolving the expired shared lock
+	// This exercises the extractKeyErrs -> GetSharedLockInfos() code path
+	err = txn2.Commit(context.Background())
+	s.Nil(err, "optimistic transaction should successfully resolve expired shared lock and commit")
+
+	// Step 5: Verify the write succeeded
+	snapshot := s.store.GetSnapshot(txn2.CommitTS())
+	v, err := snapshot.Get(context.Background(), key)
+	s.Nil(err)
+	s.Equal(value, v.Value)
+
+	// Step 6: Verify the shared lock is gone
+	locks = s.scanLocks(key, s.getTS())
+	s.Len(locks, 0, "shared lock should have been resolved")
+
+	// Cleanup
+	s.Nil(txn1.Rollback())
+}

--- a/integration_tests/shared_lock_test.go
+++ b/integration_tests/shared_lock_test.go
@@ -454,7 +454,7 @@ func (s *testSharedLockSuite) TestPrewriteResolveExpiredSharedLock() {
 	snapshot := s.store.GetSnapshot(txn2.CommitTS())
 	v, err := snapshot.Get(context.Background(), key)
 	s.Nil(err)
-	s.Equal(value, v.Value)
+	s.Equal(value, v)
 
 	// Step 6: Verify the shared lock is gone
 	locks = s.scanLocks(key, s.getTS())

--- a/internal/locate/region_cache.go
+++ b/internal/locate/region_cache.go
@@ -762,8 +762,9 @@ func NewRegionCache(pdClient pd.Client, opt ...RegionCacheOpt) *RegionCache {
 }
 
 // only used fot test.
-func newTestRegionCache() *RegionCache {
+func NewTestRegionCache() *RegionCache {
 	c := &RegionCache{}
+	c.codec = apicodec.NewCodecV1(apicodec.ModeTxn)
 	c.bg = newBackgroundRunner(context.Background())
 	c.mu = *newRegionIndexMu(nil)
 	return c

--- a/internal/locate/region_cache_test.go
+++ b/internal/locate/region_cache_test.go
@@ -2556,7 +2556,7 @@ func generateKeyForSimulator(id int, keyLen int) []byte {
 
 func BenchmarkInsertRegionToCache(b *testing.B) {
 	b.StopTimer()
-	cache := newTestRegionCache()
+	cache := NewTestRegionCache()
 	r := &Region{
 		meta: &metapb.Region{
 			Id:          1,
@@ -2593,7 +2593,7 @@ func BenchmarkInsertRegionToCache(b *testing.B) {
 
 func BenchmarkInsertRegionToCache2(b *testing.B) {
 	b.StopTimer()
-	cache := newTestRegionCache()
+	cache := NewTestRegionCache()
 	r := &Region{
 		meta: &metapb.Region{
 			Id:          1,

--- a/kv/keyflags.go
+++ b/kv/keyflags.go
@@ -78,7 +78,13 @@ const (
 	// ends when the lock is acquired.
 	flagPreviousPresumeKNE
 
-	persistentFlags = flagKeyLocked | flagKeyLockedValExist | flagNeedConstraintCheckInPrewrite
+	// flagKeyLockedInShareMode indicates the key is locked in share mode. The semantic of flagKeyLockedInShareMode is
+	// to indicate the lock mode. If this flag is set, then flagKeyLocked must also be set, indicating that the key has
+	// been locked in share mode. If only flagKeyLocked is set (and flagKeyLockedInShareMode is not), then it indicates
+	// that the key has been locked in exclusive mode.
+	flagKeyLockedInShareMode
+
+	persistentFlags = flagKeyLocked | flagKeyLockedValExist | flagNeedConstraintCheckInPrewrite | flagKeyLockedInShareMode
 )
 
 // HasAssertExist returns whether the key need ensure exists in 2pc.
@@ -109,6 +115,11 @@ func (f KeyFlags) HasPresumeKeyNotExists() bool {
 // HasLocked returns whether the associated key has acquired pessimistic lock.
 func (f KeyFlags) HasLocked() bool {
 	return f&flagKeyLocked != 0
+}
+
+// HasLockedInShareMode returns whether the associated key has been locked in share mode.
+func (f KeyFlags) HasLockedInShareMode() bool {
+	return f&flagKeyLockedInShareMode != 0
 }
 
 // HasNeedLocked return whether the key needed to be locked
@@ -206,6 +217,10 @@ func ApplyFlagsOps(origin KeyFlags, ops ...FlagsOp) KeyFlags {
 			origin &= ^flagNeedConstraintCheckInPrewrite
 		case SetPreviousPresumeKNE:
 			origin |= flagPreviousPresumeKNE
+		case SetKeyLockedInShareMode:
+			origin |= flagKeyLockedInShareMode
+		case SetKeyLockedInExclusiveMode:
+			origin &= ^flagKeyLockedInShareMode
 		}
 	}
 	return origin
@@ -257,4 +272,8 @@ const (
 	DelNeedConstraintCheckInPrewrite
 	// SetPreviousPresumeKNE sets flagPreviousPresumeKNE.
 	SetPreviousPresumeKNE
+	// SetKeyLockedInShareMode marks the associated key is locked in share mode.
+	SetKeyLockedInShareMode
+	// SetKeyLockedInExclusiveMode reverts SetKeyLockedInShareMode.
+	SetKeyLockedInExclusiveMode
 )

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -64,6 +64,7 @@ type LockCtx struct {
 	ReturnValues            bool
 	CheckExistence          bool
 	LockOnlyIfExists        bool
+	InShareMode             bool
 	Values                  map[string]ReturnedValue
 	MaxLockedWithConflictTS uint64
 	ValuesLock              sync.Mutex

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -140,6 +140,7 @@ const (
 	LblBatchGet        = "batch_get"
 	LblGet             = "get"
 	LblLockKeys        = "lock_keys"
+	LblSharedLockKeys  = "shared_lock_keys"
 	LabelBatchRecvLoop = "batch-recv-loop"
 	LabelBatchSendLoop = "batch-send-loop"
 	LblAddress         = "address"

--- a/metrics/shortcuts.go
+++ b/metrics/shortcuts.go
@@ -38,16 +38,18 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Shortcuts for performance improvement.
 var (
-	TxnCmdHistogramWithCommitInternal   prometheus.Observer
-	TxnCmdHistogramWithCommitGeneral    prometheus.Observer
-	TxnCmdHistogramWithRollbackInternal prometheus.Observer
-	TxnCmdHistogramWithRollbackGeneral  prometheus.Observer
-	TxnCmdHistogramWithBatchGetInternal prometheus.Observer
-	TxnCmdHistogramWithBatchGetGeneral  prometheus.Observer
-	TxnCmdHistogramWithGetInternal      prometheus.Observer
-	TxnCmdHistogramWithGetGeneral       prometheus.Observer
-	TxnCmdHistogramWithLockKeysInternal prometheus.Observer
-	TxnCmdHistogramWithLockKeysGeneral  prometheus.Observer
+	TxnCmdHistogramWithCommitInternal         prometheus.Observer
+	TxnCmdHistogramWithCommitGeneral          prometheus.Observer
+	TxnCmdHistogramWithRollbackInternal       prometheus.Observer
+	TxnCmdHistogramWithRollbackGeneral        prometheus.Observer
+	TxnCmdHistogramWithBatchGetInternal       prometheus.Observer
+	TxnCmdHistogramWithBatchGetGeneral        prometheus.Observer
+	TxnCmdHistogramWithGetInternal            prometheus.Observer
+	TxnCmdHistogramWithGetGeneral             prometheus.Observer
+	TxnCmdHistogramWithLockKeysInternal       prometheus.Observer
+	TxnCmdHistogramWithLockKeysGeneral        prometheus.Observer
+	TxnCmdHistogramWithSharedLockKeysInternal prometheus.Observer
+	TxnCmdHistogramWithSharedLockKeysGeneral  prometheus.Observer
 
 	RawkvCmdHistogramWithGet           prometheus.Observer
 	RawkvCmdHistogramWithBatchGet      prometheus.Observer
@@ -205,6 +207,8 @@ func initShortcuts() {
 	TxnCmdHistogramWithGetGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblGet, LblGeneral)
 	TxnCmdHistogramWithLockKeysInternal = TiKVTxnCmdHistogram.WithLabelValues(LblLockKeys, LblInternal)
 	TxnCmdHistogramWithLockKeysGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblLockKeys, LblGeneral)
+	TxnCmdHistogramWithSharedLockKeysInternal = TiKVTxnCmdHistogram.WithLabelValues(LblSharedLockKeys, LblInternal)
+	TxnCmdHistogramWithSharedLockKeysGeneral = TiKVTxnCmdHistogram.WithLabelValues(LblSharedLockKeys, LblGeneral)
 
 	RawkvCmdHistogramWithGet = TiKVRawkvCmdHistogram.WithLabelValues("get")
 	RawkvCmdHistogramWithBatchGet = TiKVRawkvCmdHistogram.WithLabelValues("batch_get")

--- a/tikv/gc.go
+++ b/tikv/gc.go
@@ -287,9 +287,16 @@ func scanLocksInOneRegionWithRange(bo *retry.Backoffer, store Storage, startKey 
 			return nil, loc, errors.Errorf("unexpected scanlock error: %s", locksResp)
 		}
 		locksInfo := locksResp.GetLocks()
-		locks = make([]*txnlock.Lock, len(locksInfo))
-		for i := range locksInfo {
-			locks[i] = txnlock.NewLock(locksInfo[i])
+		locks = make([]*txnlock.Lock, 0, len(locksInfo))
+		for _, lockInfo := range locksInfo {
+			if sharedLockInfos := lockInfo.GetSharedLockInfos(); len(sharedLockInfos) > 0 {
+				// expand shared lock into multiple locks, and drop the dummy wrapper lock.
+				for _, sharedLockInfo := range sharedLockInfos {
+					locks = append(locks, txnlock.NewLock(sharedLockInfo))
+				}
+				continue
+			}
+			locks = append(locks, txnlock.NewLock(lockInfo))
 		}
 		return locks, loc, nil
 	}

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -137,6 +137,7 @@ type twoPhaseCommitter struct {
 	detail              unsafe.Pointer
 	txnSize             int
 	hasNoNeedCommitKeys bool
+	hasSharedLocks      bool
 	resourceGroupName   string
 
 	primaryKey  []byte
@@ -548,8 +549,17 @@ func (c *twoPhaseCommitter) checkSchemaOnAssertionFail(ctx context.Context, asse
 	return assertionFailed
 }
 
+// getLockTypeFromFlags gets the lock type from the key flags. It's valid only when flags.HasLocked() is true.
+func getLockTypeFromFlags(flags kv.KeyFlags) kvrpcpb.Op {
+	if flags.HasLockedInShareMode() {
+		return kvrpcpb.Op_SharedLock
+	} else {
+		return kvrpcpb.Op_Lock
+	}
+}
+
 func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
-	var size, putCnt, delCnt, lockCnt, checkCnt int
+	var size, putCnt, delCnt, lockCnt, sharedLockCnt, checkCnt int
 
 	txn := c.txn
 	memBuf := txn.GetMemBuffer().GetMemDB()
@@ -571,7 +581,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 			if !flags.HasLocked() {
 				continue
 			}
-			op = kvrpcpb.Op_Lock
+			op = getLockTypeFromFlags(flags)
 			lockCnt++
 		} else {
 			value = it.Value()
@@ -590,7 +600,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 					// If the key was locked before, we should prewrite the lock even if
 					// the KV needn't be committed according to the filter. Otherwise, we
 					// were forgetting removing pessimistic locks added before.
-					op = kvrpcpb.Op_Lock
+					op = getLockTypeFromFlags(flags)
 					lockCnt++
 				} else {
 					op = kvrpcpb.Op_Put
@@ -611,16 +621,15 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 					toUpdatePrewriteOnly = append(toUpdatePrewriteOnly, key)
 				} else {
 					if flags.HasNewlyInserted() {
+						if !flags.HasLocked() {
+							continue
+						}
 						// The delete-your-write keys in pessimistic transactions, only lock needed keys and skip
 						// other deletes for example the secondary index delete.
 						// Here if `tidb_constraint_check_in_place` is enabled and the transaction is in optimistic mode,
 						// the logic is same as the pessimistic mode.
-						if flags.HasLocked() {
-							op = kvrpcpb.Op_Lock
-							lockCnt++
-						} else {
-							continue
-						}
+						op = getLockTypeFromFlags(flags)
+						lockCnt++
 					} else {
 						op = kvrpcpb.Op_Del
 						delCnt++
@@ -636,6 +645,9 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 		mustExist, mustNotExist, hasAssertUnknown := flags.HasAssertExist(), flags.HasAssertNotExist(), flags.HasAssertUnknown()
 		if c.txn.assertionLevel == kvrpcpb.AssertionLevel_Off {
 			mustExist, mustNotExist, hasAssertUnknown = false, false, false
+		}
+		if op == kvrpcpb.Op_SharedLock {
+			sharedLockCnt++
 		}
 		c.mutations.Push(op, isPessimistic, mustExist, mustNotExist, flags.HasNeedConstraintCheckInPrewrite(), it.Handle())
 		size += len(key) + len(value)
@@ -678,7 +690,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 			}
 		}
 
-		if len(c.primaryKey) == 0 && op != kvrpcpb.Op_CheckNotExists {
+		if len(c.primaryKey) == 0 && op != kvrpcpb.Op_CheckNotExists && op != kvrpcpb.Op_SharedLock {
 			c.primaryKey = key
 		}
 	}
@@ -689,6 +701,22 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 
 	if c.mutations.Len() == 0 {
 		return nil
+	} else if len(c.primaryKey) == 0 && sharedLockCnt > 0 {
+		// A shared-locked key is not allowed to be the primary key for now. `LockKeys` already guarantees
+		// that (it's the only place that sets `flagKeyLockedInShareMode`). Here we just double check it.
+		// Only report error when there are shared locks - if all keys are CheckNotExists (delete-your-writes),
+		// we allow the transaction to continue and use the first key as primary via the primary() fallback.
+		msg := "no suitable primary key found for the transaction"
+		logutil.BgLogger().Warn(msg,
+			zap.Uint64("session", c.sessionID),
+			zap.Int("keys", c.mutations.Len()),
+			zap.Int("puts", putCnt),
+			zap.Int("dels", delCnt),
+			zap.Int("locks", lockCnt),
+			zap.Int("sharedLocks", sharedLockCnt),
+			zap.Int("checks", checkCnt),
+			zap.Uint64("txnStartTS", txn.startTS))
+		return errors.New(msg)
 	}
 	c.txnSize = size
 
@@ -703,6 +731,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 			zap.Int("puts", putCnt),
 			zap.Int("dels", delCnt),
 			zap.Int("locks", lockCnt),
+			zap.Int("sharedLocks", sharedLockCnt),
 			zap.Int("checks", checkCnt),
 			zap.Uint64("txnStartTS", txn.startTS))
 	}
@@ -730,6 +759,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 		metrics.TxnWriteKVCountHistogramGeneral.Observe(float64(commitDetail.WriteKeys))
 		metrics.TxnWriteSizeHistogramGeneral.Observe(float64(commitDetail.WriteSize))
 	}
+	c.hasSharedLocks = sharedLockCnt > 0
 	c.hasNoNeedCommitKeys = checkCnt > 0
 	c.lockTTL = txnLockTTL(txn.startTime, size)
 	c.priority = txn.priority.ToPB()
@@ -1719,7 +1749,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 
 	commitDetail := c.getDetail()
 	commitTSMayBeCalculated := false
-	if !c.txn.isPipelined {
+	if !c.txn.isPipelined && !c.hasSharedLocks {
 		// Check async commit is available or not.
 		if c.checkAsyncCommit() {
 			commitTSMayBeCalculated = true

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -567,6 +567,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 	c.mutations = newMemBufferMutations(sizeHint, memBuf)
 	c.isPessimistic = txn.IsPessimistic()
 	filter := txn.kvFilter
+	primaryKeyIsSharedLock := false
 
 	var err error
 	var assertionError error
@@ -648,6 +649,9 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 		}
 		if op == kvrpcpb.Op_SharedLock {
 			sharedLockCnt++
+			if bytes.Equal(c.primaryKey, key) {
+				primaryKeyIsSharedLock = true
+			}
 		}
 		c.mutations.Push(op, isPessimistic, mustExist, mustNotExist, flags.HasNeedConstraintCheckInPrewrite(), it.Handle())
 		size += len(key) + len(value)
@@ -701,12 +705,12 @@ func (c *twoPhaseCommitter) initKeysAndMutations(ctx context.Context) error {
 
 	if c.mutations.Len() == 0 {
 		return nil
-	} else if len(c.primaryKey) == 0 && sharedLockCnt > 0 {
+	} else if primaryKeyIsSharedLock || len(c.primaryKey) == 0 && sharedLockCnt > 0 {
 		// A shared-locked key is not allowed to be the primary key for now. `LockKeys` already guarantees
 		// that (it's the only place that sets `flagKeyLockedInShareMode`). Here we just double check it.
 		// Only report error when there are shared locks - if all keys are CheckNotExists (delete-your-writes),
 		// we allow the transaction to continue and use the first key as primary via the primary() fallback.
-		msg := "no suitable primary key found for the transaction"
+		msg := "shared lock key cannot be used as transaction primary key"
 		logutil.BgLogger().Warn(msg,
 			zap.Uint64("session", c.sessionID),
 			zap.Int("keys", c.mutations.Len()),
@@ -1545,6 +1549,9 @@ func sendTxnHeartBeat(
 
 // checkAsyncCommit checks if async commit protocol is available for current transaction commit, true is returned if possible.
 func (c *twoPhaseCommitter) checkAsyncCommit() bool {
+	if c.hasSharedLocks {
+		return false
+	}
 	// Disable async commit in local transactions
 	if c.txn.GetScope() != oracle.GlobalTxnScope {
 		return false
@@ -1576,6 +1583,9 @@ func (c *twoPhaseCommitter) checkAsyncCommit() bool {
 
 // checkOnePC checks if 1PC protocol is available for current transaction.
 func (c *twoPhaseCommitter) checkOnePC() bool {
+	if c.hasSharedLocks {
+		return false
+	}
 	// Disable 1PC in local transactions
 	if c.txn.GetScope() != oracle.GlobalTxnScope {
 		return false
@@ -1749,6 +1759,10 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 
 	commitDetail := c.getDetail()
 	commitTSMayBeCalculated := false
+	if c.hasSharedLocks {
+		c.setAsyncCommit(false)
+		c.setOnePC(false)
+	}
 	if !c.txn.isPipelined && !c.hasSharedLocks {
 		// Check async commit is available or not.
 		if c.checkAsyncCommit() {

--- a/txnkv/transaction/pessimistic.go
+++ b/txnkv/transaction/pessimistic.go
@@ -150,10 +150,14 @@ func (action actionPessimisticLock) handleSingleBatch(
 ) error {
 	convertMutationsToPb := func(committerMutations CommitterMutations) []*kvrpcpb.Mutation {
 		mutations := make([]*kvrpcpb.Mutation, committerMutations.Len())
+		op := kvrpcpb.Op_PessimisticLock
+		if action.InShareMode {
+			op = kvrpcpb.Op_SharedPessimisticLock
+		}
 		c.txn.GetMemBuffer().RLock()
 		for i := 0; i < committerMutations.Len(); i++ {
 			mut := &kvrpcpb.Mutation{
-				Op:  kvrpcpb.Op_PessimisticLock,
+				Op:  op,
 				Key: committerMutations.GetKey(i),
 			}
 			if c.txn.us.HasPresumeKeyNotExists(committerMutations.GetKey(i)) {
@@ -296,10 +300,24 @@ func (action actionPessimisticLock) handleKeyErrorForResolve(
 		// Do not resolve the lock if the lock was recently updated which indicates the txn holding the lock is
 		// much likely alive.
 		// This should only happen for wait timeout.
-		if lockInfo := keyErr.GetLocked(); lockInfo != nil &&
-			lockInfo.DurationToLastUpdateMs > 0 &&
-			lockInfo.DurationToLastUpdateMs < skipResolveThresholdMs {
-			continue
+		lockInfo := keyErr.GetLocked()
+		if lockInfo != nil {
+			if sharedLockInfos := lockInfo.GetSharedLockInfos(); len(sharedLockInfos) > 0 {
+				for _, sharedLockInfo := range sharedLockInfos {
+					if sharedLockInfo.DurationToLastUpdateMs > 0 &&
+						sharedLockInfo.DurationToLastUpdateMs < skipResolveThresholdMs {
+						continue
+					}
+					lock := txnlock.NewLock(sharedLockInfo)
+					locks = append(locks, lock)
+				}
+				// If there are shared locks, the wrapper lock is meaningless.
+				continue
+			}
+			if lockInfo.DurationToLastUpdateMs > 0 &&
+				lockInfo.DurationToLastUpdateMs < skipResolveThresholdMs {
+				continue
+			}
 		}
 
 		// Extract lock from key error

--- a/txnkv/transaction/prewrite.go
+++ b/txnkv/transaction/prewrite.go
@@ -469,8 +469,8 @@ func (handler *prewrite1BatchReqHandler) handleRegionErr(regionErr *errorpb.Erro
 	return false, err
 }
 
-// extractKeyErrs extracts locks from key errors.
 func (handler *prewrite1BatchReqHandler) extractKeyErrs(keyErrs []*kvrpcpb.KeyError) ([]*txnlock.Lock, error) {
+	// extractKeyErrs extracts locks from key errors.
 	var locks []*txnlock.Lock
 	logged := make(map[uint64]struct{})
 	for _, keyErr := range keyErrs {
@@ -480,7 +480,42 @@ func (handler *prewrite1BatchReqHandler) extractKeyErrs(keyErrs []*kvrpcpb.KeyEr
 			return nil, handler.committer.extractKeyExistsErr(e)
 		}
 
-		// Extract lock from key error
+		// Check if this is a shared lock, which needs special handling
+		lockInfo := keyErr.GetLocked()
+		if lockInfo != nil {
+			if sharedLockInfos := lockInfo.GetSharedLockInfos(); len(sharedLockInfos) > 0 {
+				for _, sharedLockInfo := range sharedLockInfos {
+					lock := txnlock.NewLock(sharedLockInfo)
+					if _, ok := logged[lock.TxnID]; !ok {
+						logutil.BgLogger().Info(
+							"prewrite encounters shared lock. "+
+								"More locks belonging to the same transaction may be omitted",
+							zap.Uint64("session", handler.committer.sessionID),
+							zap.Uint64("txnID", handler.committer.startTS),
+							zap.Stringer("lock", lock),
+							zap.Stringer("policy", handler.committer.txn.prewriteEncounterLockPolicy),
+						)
+						logged[lock.TxnID] = struct{}{}
+					}
+					// For shared locks encountered during prewrite, same logic as exclusive locks applies
+					if (lock.TxnID > handler.committer.startTS && !handler.committer.isPessimistic) ||
+						handler.committer.txn.prewriteEncounterLockPolicy == NoResolvePolicy {
+						return nil, tikverr.NewErrWriteConflictWithArgs(
+							handler.committer.startTS,
+							lock.TxnID,
+							0,
+							lock.Key,
+							kvrpcpb.WriteConflict_Optimistic,
+						)
+					}
+					locks = append(locks, lock)
+				}
+				// If there are shared locks, the wrapper lock is meaningless.
+				continue
+			}
+		}
+
+		// Extract lock from key error (for non-shared locks)
 		lock, err1 := txnlock.ExtractLockFromKeyErr(keyErr)
 		if err1 != nil {
 			return nil, err1

--- a/txnkv/transaction/test_probe.go
+++ b/txnkv/transaction/test_probe.go
@@ -328,6 +328,11 @@ func (c CommitterProbe) CheckAsyncCommit() bool {
 	return c.checkAsyncCommit()
 }
 
+// CheckOnePC returns if 1PC is available.
+func (c CommitterProbe) CheckOnePC() bool {
+	return c.checkOnePC()
+}
+
 // GetOnePCCommitTS returns the commit ts of one pc.
 func (c CommitterProbe) GetOnePCCommitTS() uint64 {
 	return c.onePCCommitTS

--- a/txnkv/transaction/test_util.go
+++ b/txnkv/transaction/test_util.go
@@ -1,0 +1,508 @@
+// Copyright 2025 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transaction
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/kvproto/pkg/meta_storagepb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/pingcap/kvproto/pkg/resource_manager"
+	"github.com/tikv/client-go/v2/config/retry"
+	"github.com/tikv/client-go/v2/internal/client"
+	"github.com/tikv/client-go/v2/internal/latch"
+	"github.com/tikv/client-go/v2/internal/locate"
+	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/txnkv/txnlock"
+	"github.com/tikv/client-go/v2/util/async"
+	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/clients/gc"
+	"github.com/tikv/pd/client/clients/router"
+	"github.com/tikv/pd/client/clients/tso"
+	"github.com/tikv/pd/client/opt"
+	"github.com/tikv/pd/client/pkg/caller"
+	sd "github.com/tikv/pd/client/servicediscovery"
+)
+
+var _ oracle.Oracle = (*unimplementedOracle)(nil)
+
+type unimplementedOracle struct{}
+
+// Close implements oracle.Oracle.
+func (u *unimplementedOracle) Close() {
+	panic("unimplemented")
+}
+
+// GetAllTSOKeyspaceGroupMinTS implements oracle.Oracle.
+func (u *unimplementedOracle) GetAllTSOKeyspaceGroupMinTS(ctx context.Context) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetExternalTimestamp implements oracle.Oracle.
+func (u *unimplementedOracle) GetExternalTimestamp(ctx context.Context) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetLowResolutionTimestamp implements oracle.Oracle.
+func (u *unimplementedOracle) GetLowResolutionTimestamp(ctx context.Context, opt *oracle.Option) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetLowResolutionTimestampAsync implements oracle.Oracle.
+func (u *unimplementedOracle) GetLowResolutionTimestampAsync(ctx context.Context, opt *oracle.Option) oracle.Future {
+	panic("unimplemented")
+}
+
+// GetStaleTimestamp implements oracle.Oracle.
+func (u *unimplementedOracle) GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetTimestamp implements oracle.Oracle.
+func (u *unimplementedOracle) GetTimestamp(ctx context.Context, opt *oracle.Option) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetTimestampAsync implements oracle.Oracle.
+func (u *unimplementedOracle) GetTimestampAsync(ctx context.Context, opt *oracle.Option) oracle.Future {
+	panic("unimplemented")
+}
+
+// IsExpired implements oracle.Oracle.
+func (u *unimplementedOracle) IsExpired(lockTimestamp uint64, TTL uint64, opt *oracle.Option) bool {
+	panic("unimplemented")
+}
+
+// SetExternalTimestamp implements oracle.Oracle.
+func (u *unimplementedOracle) SetExternalTimestamp(ctx context.Context, ts uint64) error {
+	panic("unimplemented")
+}
+
+// SetLowResolutionTimestampUpdateInterval implements oracle.Oracle.
+func (u *unimplementedOracle) SetLowResolutionTimestampUpdateInterval(time.Duration) error {
+	panic("unimplemented")
+}
+
+// UntilExpired implements oracle.Oracle.
+func (u *unimplementedOracle) UntilExpired(lockTimeStamp uint64, TTL uint64, opt *oracle.Option) int64 {
+	panic("unimplemented")
+}
+
+// ValidateReadTS implements oracle.Oracle.
+func (u *unimplementedOracle) ValidateReadTS(ctx context.Context, readTS uint64, isStaleRead bool, opt *oracle.Option) error {
+	panic("unimplemented")
+}
+
+var _ pd.Client = (*unimplementedPDClient)(nil)
+
+type unimplementedPDClient struct{}
+
+// AcquireTokenBuckets implements pd.Client.
+func (u *unimplementedPDClient) AcquireTokenBuckets(ctx context.Context, request *resource_manager.TokenBucketsRequest) ([]*resource_manager.TokenBucketResponse, error) {
+	panic("unimplemented")
+}
+
+// AddResourceGroup implements pd.Client.
+func (u *unimplementedPDClient) AddResourceGroup(ctx context.Context, metaGroup *resource_manager.ResourceGroup) (string, error) {
+	panic("unimplemented")
+}
+
+// BatchScanRegions implements pd.Client.
+func (u *unimplementedPDClient) BatchScanRegions(ctx context.Context, keyRanges []router.KeyRange, limit int, opts ...opt.GetRegionOption) ([]*router.Region, error) {
+	panic("unimplemented")
+}
+
+// Close implements pd.Client.
+func (u *unimplementedPDClient) Close() {
+	panic("unimplemented")
+}
+
+// DeleteResourceGroup implements pd.Client.
+func (u *unimplementedPDClient) DeleteResourceGroup(ctx context.Context, resourceGroupName string) (string, error) {
+	panic("unimplemented")
+}
+
+// Get implements pd.Client.
+func (u *unimplementedPDClient) Get(ctx context.Context, key []byte, opts ...opt.MetaStorageOption) (*meta_storagepb.GetResponse, error) {
+	panic("unimplemented")
+}
+
+// GetAllKeyspaces implements pd.Client.
+func (u *unimplementedPDClient) GetAllKeyspaces(ctx context.Context, startID uint32, limit uint32) ([]*keyspacepb.KeyspaceMeta, error) {
+	panic("unimplemented")
+}
+
+// GetAllMembers implements pd.Client.
+func (u *unimplementedPDClient) GetAllMembers(ctx context.Context) (*pdpb.GetMembersResponse, error) {
+	panic("unimplemented")
+}
+
+// GetAllStores implements pd.Client.
+func (u *unimplementedPDClient) GetAllStores(ctx context.Context, opts ...opt.GetStoreOption) ([]*metapb.Store, error) {
+	panic("unimplemented")
+}
+
+// GetClusterID implements pd.Client.
+func (u *unimplementedPDClient) GetClusterID(ctx context.Context) uint64 {
+	panic("unimplemented")
+}
+
+// GetExternalTimestamp implements pd.Client.
+func (u *unimplementedPDClient) GetExternalTimestamp(ctx context.Context) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetLeaderURL implements pd.Client.
+func (u *unimplementedPDClient) GetLeaderURL() string {
+	panic("unimplemented")
+}
+
+// GetLocalTS implements pd.Client.
+func (u *unimplementedPDClient) GetLocalTS(ctx context.Context, dcLocation string) (int64, int64, error) {
+	panic("unimplemented")
+}
+
+// GetLocalTSAsync implements pd.Client.
+func (u *unimplementedPDClient) GetLocalTSAsync(ctx context.Context, dcLocation string) tso.TSFuture {
+	panic("unimplemented")
+}
+
+// GetMinTS implements pd.Client.
+func (u *unimplementedPDClient) GetMinTS(ctx context.Context) (int64, int64, error) {
+	panic("unimplemented")
+}
+
+// GetOperator implements pd.Client.
+func (u *unimplementedPDClient) GetOperator(ctx context.Context, regionID uint64) (*pdpb.GetOperatorResponse, error) {
+	panic("unimplemented")
+}
+
+// GetPrevRegion implements pd.Client.
+func (u *unimplementedPDClient) GetPrevRegion(ctx context.Context, key []byte, opts ...opt.GetRegionOption) (*router.Region, error) {
+	panic("unimplemented")
+}
+
+// GetRegion implements pd.Client.
+func (u *unimplementedPDClient) GetRegion(ctx context.Context, key []byte, opts ...opt.GetRegionOption) (*router.Region, error) {
+	panic("unimplemented")
+}
+
+// GetRegionByID implements pd.Client.
+func (u *unimplementedPDClient) GetRegionByID(ctx context.Context, regionID uint64, opts ...opt.GetRegionOption) (*router.Region, error) {
+	panic("unimplemented")
+}
+
+// GetRegionFromMember implements pd.Client.
+func (u *unimplementedPDClient) GetRegionFromMember(ctx context.Context, key []byte, memberURLs []string, opts ...opt.GetRegionOption) (*router.Region, error) {
+	panic("unimplemented")
+}
+
+// GetResourceGroup implements pd.Client.
+func (u *unimplementedPDClient) GetResourceGroup(ctx context.Context, resourceGroupName string, opts ...pd.GetResourceGroupOption) (*resource_manager.ResourceGroup, error) {
+	panic("unimplemented")
+}
+
+// GetServiceDiscovery implements pd.Client.
+func (u *unimplementedPDClient) GetServiceDiscovery() sd.ServiceDiscovery {
+	panic("unimplemented")
+}
+
+// GetStore implements pd.Client.
+func (u *unimplementedPDClient) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error) {
+	panic("unimplemented")
+}
+
+// GetTS implements pd.Client.
+func (u *unimplementedPDClient) GetTS(ctx context.Context) (int64, int64, error) {
+	panic("unimplemented")
+}
+
+// GetTSAsync implements pd.Client.
+func (u *unimplementedPDClient) GetTSAsync(ctx context.Context) tso.TSFuture {
+	panic("unimplemented")
+}
+
+// ListResourceGroups implements pd.Client.
+func (u *unimplementedPDClient) ListResourceGroups(ctx context.Context, opts ...pd.GetResourceGroupOption) ([]*resource_manager.ResourceGroup, error) {
+	panic("unimplemented")
+}
+
+// LoadGlobalConfig implements pd.Client.
+func (u *unimplementedPDClient) LoadGlobalConfig(ctx context.Context, names []string, configPath string) ([]pd.GlobalConfigItem, int64, error) {
+	panic("unimplemented")
+}
+
+// LoadKeyspace implements pd.Client.
+func (u *unimplementedPDClient) LoadKeyspace(ctx context.Context, name string) (*keyspacepb.KeyspaceMeta, error) {
+	panic("unimplemented")
+}
+
+// LoadResourceGroups implements pd.Client.
+func (u *unimplementedPDClient) LoadResourceGroups(ctx context.Context) ([]*resource_manager.ResourceGroup, int64, error) {
+	panic("unimplemented")
+}
+
+// ModifyResourceGroup implements pd.Client.
+func (u *unimplementedPDClient) ModifyResourceGroup(ctx context.Context, metaGroup *resource_manager.ResourceGroup) (string, error) {
+	panic("unimplemented")
+}
+
+// Put implements pd.Client.
+func (u *unimplementedPDClient) Put(ctx context.Context, key []byte, value []byte, opts ...opt.MetaStorageOption) (*meta_storagepb.PutResponse, error) {
+	panic("unimplemented")
+}
+
+// ScanRegions implements pd.Client.
+func (u *unimplementedPDClient) ScanRegions(ctx context.Context, key []byte, endKey []byte, limit int, opts ...opt.GetRegionOption) ([]*router.Region, error) {
+	panic("unimplemented")
+}
+
+// ScatterRegion implements pd.Client.
+func (u *unimplementedPDClient) ScatterRegion(ctx context.Context, regionID uint64) error {
+	panic("unimplemented")
+}
+
+// ScatterRegions implements pd.Client.
+func (u *unimplementedPDClient) ScatterRegions(ctx context.Context, regionsID []uint64, opts ...opt.RegionsOption) (*pdpb.ScatterRegionResponse, error) {
+	panic("unimplemented")
+}
+
+// SetExternalTimestamp implements pd.Client.
+func (u *unimplementedPDClient) SetExternalTimestamp(ctx context.Context, timestamp uint64) error {
+	panic("unimplemented")
+}
+
+// SplitAndScatterRegions implements pd.Client.
+func (u *unimplementedPDClient) SplitAndScatterRegions(ctx context.Context, splitKeys [][]byte, opts ...opt.RegionsOption) (*pdpb.SplitAndScatterRegionsResponse, error) {
+	panic("unimplemented")
+}
+
+// SplitRegions implements pd.Client.
+func (u *unimplementedPDClient) SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...opt.RegionsOption) (*pdpb.SplitRegionsResponse, error) {
+	panic("unimplemented")
+}
+
+// StoreGlobalConfig implements pd.Client.
+func (u *unimplementedPDClient) StoreGlobalConfig(ctx context.Context, configPath string, items []pd.GlobalConfigItem) error {
+	panic("unimplemented")
+}
+
+// UpdateGCSafePoint implements pd.Client.
+func (u *unimplementedPDClient) UpdateGCSafePoint(ctx context.Context, safePoint uint64) (uint64, error) {
+	panic("unimplemented")
+}
+
+// UpdateGCSafePointV2 implements pd.Client.
+func (u *unimplementedPDClient) UpdateGCSafePointV2(ctx context.Context, keyspaceID uint32, safePoint uint64) (uint64, error) {
+	panic("unimplemented")
+}
+
+// UpdateKeyspaceState implements pd.Client.
+func (u *unimplementedPDClient) UpdateKeyspaceState(ctx context.Context, id uint32, state keyspacepb.KeyspaceState) (*keyspacepb.KeyspaceMeta, error) {
+	panic("unimplemented")
+}
+
+// UpdateOption implements pd.Client.
+func (u *unimplementedPDClient) UpdateOption(option opt.DynamicOption, value any) error {
+	panic("unimplemented")
+}
+
+// UpdateServiceGCSafePoint implements pd.Client.
+func (u *unimplementedPDClient) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+	panic("unimplemented")
+}
+
+// UpdateServiceSafePointV2 implements pd.Client.
+func (u *unimplementedPDClient) UpdateServiceSafePointV2(ctx context.Context, keyspaceID uint32, serviceID string, ttl int64, safePoint uint64) (uint64, error) {
+	panic("unimplemented")
+}
+
+// Watch implements pd.Client.
+func (u *unimplementedPDClient) Watch(ctx context.Context, key []byte, opts ...opt.MetaStorageOption) (chan []*meta_storagepb.Event, error) {
+	panic("unimplemented")
+}
+
+// WatchGCSafePointV2 implements pd.Client.
+func (u *unimplementedPDClient) WatchGCSafePointV2(ctx context.Context, revision int64) (chan []*pdpb.SafePointEvent, error) {
+	panic("unimplemented")
+}
+
+// WatchGlobalConfig implements pd.Client.
+func (u *unimplementedPDClient) WatchGlobalConfig(ctx context.Context, configPath string, revision int64) (chan []pd.GlobalConfigItem, error) {
+	panic("unimplemented")
+}
+
+// WatchKeyspaces implements pd.Client.
+func (u *unimplementedPDClient) WatchKeyspaces(ctx context.Context) (chan []*keyspacepb.KeyspaceMeta, error) {
+	panic("unimplemented")
+}
+
+// WatchResourceGroup implements pd.Client.
+func (u *unimplementedPDClient) WatchResourceGroup(ctx context.Context, revision int64) (chan []*resource_manager.ResourceGroup, error) {
+	panic("unimplemented")
+}
+
+// GetTSWithinKeyspace implements pd.Client.
+func (u *unimplementedPDClient) GetTSWithinKeyspace(ctx context.Context, keyspaceID uint32) (int64, int64, error) {
+	panic("unimplemented")
+}
+
+// GetTSWithinKeyspaceAsync implements pd.Client.
+func (u *unimplementedPDClient) GetTSWithinKeyspaceAsync(ctx context.Context, keyspaceID uint32) tso.TSFuture {
+	panic("unimplemented")
+}
+
+// GetLocalTSWithinKeyspace implements pd.Client.
+func (u *unimplementedPDClient) GetLocalTSWithinKeyspace(ctx context.Context, dcLocation string, keyspaceID uint32) (int64, int64, error) {
+	panic("unimplemented")
+}
+
+// GetLocalTSWithinKeyspaceAsync implements pd.Client.
+func (u *unimplementedPDClient) GetLocalTSWithinKeyspaceAsync(ctx context.Context, dcLocation string, keyspaceID uint32) tso.TSFuture {
+	panic("unimplemented")
+}
+
+// GetGCInternalController implements pd.Client.
+func (u *unimplementedPDClient) GetGCInternalController(keyspaceID uint32) gc.InternalController {
+	panic("unimplemented")
+}
+
+// GetGCStatesClient implements pd.Client.
+func (u *unimplementedPDClient) GetGCStatesClient(keyspaceID uint32) gc.GCStatesClient {
+	panic("unimplemented")
+}
+
+// WithCallerComponent implements pd.Client.
+func (u *unimplementedPDClient) WithCallerComponent(caller.Component) pd.Client {
+	return u
+}
+
+var _ kvstore = (*unimplementedKVStore)(nil)
+
+type unimplementedKVStore struct{}
+
+// Ctx implements kvstore.
+func (u *unimplementedKVStore) Ctx() context.Context {
+	panic("unimplemented")
+}
+
+// CurrentTimestamp implements kvstore.
+func (u *unimplementedKVStore) CurrentTimestamp(txnScope string) (uint64, error) {
+	panic("unimplemented")
+}
+
+// GetClusterID implements kvstore.
+func (u *unimplementedKVStore) GetClusterID() uint64 {
+	panic("unimplemented")
+}
+
+// GetLockResolver implements kvstore.
+func (u *unimplementedKVStore) GetLockResolver() *txnlock.LockResolver {
+	panic("unimplemented")
+}
+
+// GetOracle implements kvstore.
+func (u *unimplementedKVStore) GetOracle() oracle.Oracle {
+	panic("unimplemented")
+}
+
+// GetRegionCache implements kvstore.
+func (u *unimplementedKVStore) GetRegionCache() *locate.RegionCache {
+	panic("unimplemented")
+}
+
+// GetTiKVClient implements kvstore.
+func (u *unimplementedKVStore) GetTiKVClient() (client client.Client) {
+	panic("unimplemented")
+}
+
+// GetTimestampWithRetry implements kvstore.
+func (u *unimplementedKVStore) GetTimestampWithRetry(bo *retry.Backoffer, scope string) (uint64, error) {
+	panic("unimplemented")
+}
+
+// Go implements kvstore.
+func (u *unimplementedKVStore) Go(f func()) error {
+	panic("unimplemented")
+}
+
+// IsClose implements kvstore.
+func (u *unimplementedKVStore) IsClose() bool {
+	panic("unimplemented")
+}
+
+// SendReq implements kvstore.
+func (u *unimplementedKVStore) SendReq(bo *retry.Backoffer, req *tikvrpc.Request, regionID locate.RegionVerID, timeout time.Duration) (*tikvrpc.Response, error) {
+	panic("unimplemented")
+}
+
+// SplitRegions implements kvstore.
+func (u *unimplementedKVStore) SplitRegions(ctx context.Context, splitKeys [][]byte, scatter bool, tableID *int64) (regionIDs []uint64, err error) {
+	panic("unimplemented")
+}
+
+// TxnLatches implements kvstore.
+func (u *unimplementedKVStore) TxnLatches() *latch.LatchesScheduler {
+	panic("unimplemented")
+}
+
+// WaitGroup implements kvstore.
+func (u *unimplementedKVStore) WaitGroup() *sync.WaitGroup {
+	panic("unimplemented")
+}
+
+// WaitScatterRegionFinish implements kvstore.
+func (u *unimplementedKVStore) WaitScatterRegionFinish(ctx context.Context, regionID uint64, backOff int) error {
+	panic("unimplemented")
+}
+
+// CheckVisibility implements txnsnapshot.kvstore.
+func (m *unimplementedKVStore) CheckVisibility(startTime uint64) error {
+	panic("unimplemented")
+}
+
+var _ client.Client = (*unimplementedKVClient)(nil)
+
+type unimplementedKVClient struct{}
+
+// Close implements client.Client.
+func (u *unimplementedKVClient) Close() error {
+	panic("unimplemented")
+}
+
+// CloseAddr implements client.Client.
+func (u *unimplementedKVClient) CloseAddr(addr string) error {
+	panic("unimplemented")
+}
+
+// SendRequest implements client.Client.
+func (u *unimplementedKVClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	panic("unimplemented")
+}
+
+// SetEventListener implements client.Client.
+func (u *unimplementedKVClient) SetEventListener(listener client.ClientEventListener) {
+	panic("unimplemented")
+}
+
+// SendRequestAsync implements client.Client.
+func (u *unimplementedKVClient) SendRequestAsync(ctx context.Context, addr string, req *tikvrpc.Request, cb async.Callback[*tikvrpc.Response]) {
+	panic("unimplemented")
+}

--- a/txnkv/transaction/test_util.go
+++ b/txnkv/transaction/test_util.go
@@ -225,7 +225,7 @@ func (u *unimplementedPDClient) GetServiceDiscovery() sd.ServiceDiscovery {
 }
 
 // GetStore implements pd.Client.
-func (u *unimplementedPDClient) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error) {
+func (u *unimplementedPDClient) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, error) {
 	panic("unimplemented")
 }
 

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -635,6 +635,7 @@ func (txn *KVTxn) InitPipelinedMemDB() error {
 			var value []byte
 			var op kvrpcpb.Op
 
+			// TODO(slock): pipelined DML do not prewrite shared lock even when flags.HasLockedInShareMode() is true.
 			if !it.HasValue() {
 				if !flags.HasLocked() {
 					continue
@@ -1307,8 +1308,8 @@ func (txn *KVTxn) collectAggressiveLockingStats(lockCtx *tikv.LockCtx, keys int,
 	lockCtx.Stats.AggressiveLockDerivedCount += filteredAggressiveLockedKeysCount
 }
 
-func (txn *KVTxn) exitAggressiveLockingIfInapplicable(ctx context.Context, keys [][]byte) error {
-	if len(keys) > 1 && txn.IsInAggressiveLockingMode() {
+func (txn *KVTxn) exitAggressiveLockingIfInapplicable(ctx context.Context, lockCtx *tikv.LockCtx, keys [][]byte) error {
+	if (len(keys) > 1 || lockCtx.InShareMode) && txn.IsInAggressiveLockingMode() {
 		// Only allow fair locking if it only needs to lock one key. Considering that it's possible that a
 		// statement causes multiple calls to `LockKeys` (which means some keys may have been locked in fair
 		// locking mode), here we exit fair locking mode by calling DoneFairLocking instead of cancelling.
@@ -1349,16 +1350,24 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 
-	err = txn.exitAggressiveLockingIfInapplicable(ctx, keysInput)
+	err = txn.exitAggressiveLockingIfInapplicable(ctx, lockCtx, keysInput)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		if txn.isInternal() {
-			metrics.TxnCmdHistogramWithLockKeysInternal.Observe(time.Since(startTime).Seconds())
+		if lockCtx.InShareMode {
+			if txn.isInternal() {
+				metrics.TxnCmdHistogramWithSharedLockKeysInternal.Observe(time.Since(startTime).Seconds())
+			} else {
+				metrics.TxnCmdHistogramWithSharedLockKeysGeneral.Observe(time.Since(startTime).Seconds())
+			}
 		} else {
-			metrics.TxnCmdHistogramWithLockKeysGeneral.Observe(time.Since(startTime).Seconds())
+			if txn.isInternal() {
+				metrics.TxnCmdHistogramWithLockKeysInternal.Observe(time.Since(startTime).Seconds())
+			} else {
+				metrics.TxnCmdHistogramWithLockKeysGeneral.Observe(time.Since(startTime).Seconds())
+			}
 		}
 		if lockCtx.Stats != nil {
 			lockCtx.Stats.TotalTime = time.Since(startTime)
@@ -1369,14 +1378,26 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 			}
 		}
 	}()
-	defer func() {
-		if fn != nil {
-			fn()
-		}
-	}()
+	if fn != nil {
+		defer fn()
+	}
 
 	if !txn.IsPessimistic() && txn.IsInAggressiveLockingMode() {
 		return errors.New("trying to perform aggressive locking in optimistic transaction")
+	}
+
+	if lockCtx.InShareMode {
+		// create shared lock span in tracing.
+		if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
+			span1 := span.Tracer().StartSpan("Shared Lock", opentracing.ChildOf(span.Context()))
+			defer span1.Finish()
+			ctx = opentracing.ContextWithSpan(ctx, span1)
+		}
+
+		// Shared lock in aggressive locking mode is not supported.
+		if txn.IsInAggressiveLockingMode() {
+			txn.DoneAggressiveLocking(ctx)
+		}
 	}
 
 	memBuf := txn.us.GetMemBuffer()
@@ -1384,12 +1405,19 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	memBuf.RLock()
 	for _, key := range keysInput {
 		// The value of lockedMap is only used by pessimistic transactions.
-		var valueExist, locked, checkKeyExists bool
+		var valueExist, locked, lockedInShareMode, checkKeyExists bool
 		if flags, err := memBuf.GetFlags(key); err == nil {
 			locked = flags.HasLocked()
+			lockedInShareMode = flags.HasLockedInShareMode()
 			valueExist = flags.HasLockedValueExists()
 			checkKeyExists = flags.HasNeedCheckExists()
 		}
+
+		if lockedInShareMode && !lockCtx.InShareMode {
+			memBuf.RUnlock()
+			return errors.New("upgrading a shared lock to an exclusive lock is not supported")
+		}
+
 		// If the key is locked in the current aggressive locking stage, override the information in memBuf.
 		isInLastAggressiveLockingStage := false
 		if txn.IsInAggressiveLockingMode() {
@@ -1467,6 +1495,11 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 			}
 		}
 		if txn.committer.primaryKey == nil {
+			if lockCtx.InShareMode {
+				// TODO(slock): currently a shared locked key can not be selected as primary key, that is, some keys
+				// should be locked in exclusive mode before acquiring shared locks.
+				return errors.New("pessimistic lock in share mode requires primary key to be selected")
+			}
 			assignedPrimaryKey = true
 			txn.selectPrimaryForPessimisticLock(keys)
 		}
@@ -1637,7 +1670,11 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 			if !valExists {
 				setValExists = tikv.SetKeyLockedValueNotExists
 			}
-			memBuf.UpdateFlags(key, tikv.SetKeyLocked, tikv.DelNeedCheckExists, setValExists)
+			setLockMode := tikv.SetKeyLockedInExclusiveMode
+			if lockCtx.InShareMode && txn.IsPessimistic() {
+				setLockMode = tikv.SetKeyLockedInShareMode
+			}
+			memBuf.UpdateFlags(key, tikv.SetKeyLocked, tikv.DelNeedCheckExists, setValExists, setLockMode)
 		}
 	}
 	if err != nil {

--- a/txnkv/transaction/txn.go
+++ b/txnkv/transaction/txn.go
@@ -635,7 +635,9 @@ func (txn *KVTxn) InitPipelinedMemDB() error {
 			var value []byte
 			var op kvrpcpb.Op
 
-			// TODO(slock): pipelined DML do not prewrite shared lock even when flags.HasLockedInShareMode() is true.
+			if flags.HasLockedInShareMode() {
+				return errors.New("shared lock is not supported in pipelined transaction")
+			}
 			if !it.HasValue() {
 				if !flags.HasLocked() {
 					continue
@@ -1309,7 +1311,13 @@ func (txn *KVTxn) collectAggressiveLockingStats(lockCtx *tikv.LockCtx, keys int,
 }
 
 func (txn *KVTxn) exitAggressiveLockingIfInapplicable(ctx context.Context, lockCtx *tikv.LockCtx, keys [][]byte) error {
-	if (len(keys) > 1 || lockCtx.InShareMode) && txn.IsInAggressiveLockingMode() {
+	if !txn.IsInAggressiveLockingMode() {
+		return nil
+	}
+	if lockCtx.InShareMode {
+		return errors.New("shared lock is not supported in aggressive/fair locking mode")
+	}
+	if len(keys) > 1 {
 		// Only allow fair locking if it only needs to lock one key. Considering that it's possible that a
 		// statement causes multiple calls to `LockKeys` (which means some keys may have been locked in fair
 		// locking mode), here we exit fair locking mode by calling DoneFairLocking instead of cancelling.
@@ -1385,6 +1393,9 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 	if !txn.IsPessimistic() && txn.IsInAggressiveLockingMode() {
 		return errors.New("trying to perform aggressive locking in optimistic transaction")
 	}
+	if lockCtx.InShareMode && txn.IsPipelined() {
+		return errors.New("shared lock is not supported in pipelined transaction")
+	}
 
 	if lockCtx.InShareMode {
 		// create shared lock span in tracing.
@@ -1396,7 +1407,7 @@ func (txn *KVTxn) lockKeys(ctx context.Context, lockCtx *tikv.LockCtx, fn func()
 
 		// Shared lock in aggressive locking mode is not supported.
 		if txn.IsInAggressiveLockingMode() {
-			txn.DoneAggressiveLocking(ctx)
+			return errors.New("shared lock is not supported in aggressive/fair locking mode")
 		}
 	}
 

--- a/txnkv/transaction/txn_test.go
+++ b/txnkv/transaction/txn_test.go
@@ -1,0 +1,247 @@
+// Copyright 2025 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transaction
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/internal/client"
+	"github.com/tikv/client-go/v2/internal/locate"
+	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/oracle"
+	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
+	pd "github.com/tikv/pd/client"
+	"github.com/tikv/pd/client/clients/router"
+	"github.com/tikv/pd/client/opt"
+	"github.com/tikv/pd/client/pkg/caller"
+)
+
+type mockPDClient struct {
+	unimplementedPDClient
+}
+
+func (c *mockPDClient) GetRegion(ctx context.Context, key []byte, opts ...opt.GetRegionOption) (*router.Region, error) {
+	peer := &metapb.Peer{Id: 1, StoreId: 1}
+	return &router.Region{
+		Meta: &metapb.Region{
+			Id:       1,
+			StartKey: []byte{},
+			EndKey:   []byte{},
+			Peers:    []*metapb.Peer{peer},
+		},
+		Leader: peer,
+	}, nil
+}
+
+func (c *mockPDClient) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error) {
+	return &metapb.Store{
+		Id:      storeID,
+		Address: "mock-store",
+	}, nil
+}
+
+func (c *mockPDClient) WithCallerComponent(caller.Component) pd.Client {
+	return c
+}
+
+type fnClient struct {
+	unimplementedKVClient
+
+	onSend func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error)
+}
+
+func (c *fnClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	return c.onSend(ctx, addr, req, timeout)
+}
+
+type mockStore struct {
+	unimplementedKVStore
+
+	cache  *locate.RegionCache
+	client fnClient
+}
+
+func (m *mockStore) GetRegionCache() *locate.RegionCache {
+	return m.cache
+}
+
+func (m *mockStore) GetTiKVClient() client.Client {
+	return &m.client
+}
+
+func (m *mockStore) GetOracle() oracle.Oracle {
+	return nil
+}
+
+type testTxn struct {
+	*KVTxn
+
+	store    *mockStore
+	snapshot *txnsnapshot.KVSnapshot
+}
+
+func newTestTxn(t *testing.T, startTS uint64) *testTxn {
+	pd := &mockPDClient{}
+	cache := locate.NewTestRegionCache()
+	cache.SetPDClient(pd)
+	store := &mockStore{cache: cache}
+	snapshot := txnsnapshot.NewTiKVSnapshot(store, startTS, 0)
+	txn, err := NewTiKVTxn(store, snapshot, startTS, &TxnOptions{StartTS: &startTS})
+	require.NoError(t, err)
+	return &testTxn{
+		KVTxn:    txn,
+		store:    store,
+		snapshot: snapshot,
+	}
+}
+
+func TestLockKeys(t *testing.T) {
+
+	requireNoRequest := func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+		require.FailNow(t, "locking keys in optimistic mode do not invoke SendRequest")
+		return nil, errors.New("mock error")
+	}
+
+	t.Run("OptimisticExclusive", func(t *testing.T) {
+		key := []byte("k")
+		txn := newTestTxn(t, 1)
+		txn.store.client.onSend = requireNoRequest
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key))
+		flags, err := txn.GetMemBuffer().GetFlags(key)
+		require.NoError(t, err)
+		require.True(t, flags.HasLocked())
+		require.False(t, flags.HasLockedInShareMode())
+	})
+
+	t.Run("OptimisticShared", func(t *testing.T) {
+		key := []byte("k")
+		txn := newTestTxn(t, 1)
+		txn.store.client.onSend = requireNoRequest
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		lockCtx.InShareMode = true
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key))
+		flags, err := txn.GetMemBuffer().GetFlags(key)
+		require.NoError(t, err)
+		require.True(t, flags.HasLocked())
+		require.False(t, flags.HasLockedInShareMode()) // shared lock is not supported in optimistic txn for now
+	})
+
+	var expectedLockType kvrpcpb.Op
+	handlePessimisticLock := func(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+		if req.Type != tikvrpc.CmdPessimisticLock {
+			require.FailNow(t, "locking keys only send PessimisticLock request")
+			return nil, errors.New("mock error")
+		}
+		lockReq := req.PessimisticLock()
+		require.Len(t, lockReq.Mutations, 1)
+		require.Equal(t, expectedLockType, lockReq.Mutations[0].Op)
+		return &tikvrpc.Response{Resp: &kvrpcpb.PessimisticLockResponse{}}, nil
+	}
+
+	t.Run("PessimisticExclusive", func(t *testing.T) {
+		key := []byte("k")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.store.client.onSend = handlePessimisticLock
+
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key))
+		flags, err := txn.GetMemBuffer().GetFlags(key)
+		require.NoError(t, err)
+		require.True(t, flags.HasLocked())
+		require.False(t, flags.HasLockedInShareMode())
+	})
+
+	t.Run("PessimisticShared", func(t *testing.T) {
+		key1 := []byte("k1")
+		key2 := []byte("k2")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.store.client.onSend = handlePessimisticLock
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+
+		// shared-locked key cannot be primary key thus `lockKeys` fails.
+		lockCtx.InShareMode = true
+		err := txn.lockKeys(context.TODO(), lockCtx, nil, key1)
+		require.ErrorContains(t, err, "pessimistic lock in share mode requires primary key to be selected")
+
+		// `lockKeys` in exclusive mode to ensure primary key is selected.
+		lockCtx.InShareMode = false
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key2))
+
+		// `lockKeys` in share mode again.
+		lockCtx.InShareMode = true
+		expectedLockType = kvrpcpb.Op_SharedPessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key1))
+		flags, err := txn.GetMemBuffer().GetFlags(key1)
+		require.NoError(t, err)
+		require.True(t, flags.HasLocked())
+		require.True(t, flags.HasLockedInShareMode())
+	})
+
+	t.Run("UpgradeSharedToExclusive", func(t *testing.T) {
+		key1 := []byte("k1")
+		key2 := []byte("k2")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.store.client.onSend = handlePessimisticLock
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+
+		// `lockKeys` in exclusive mode on k2 to ensure primary key is selected.
+		lockCtx.InShareMode = false
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key2))
+
+		// `lockKeys` in share mode on k1.
+		lockCtx.InShareMode = true
+		expectedLockType = kvrpcpb.Op_SharedPessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key1))
+		flags, err := txn.GetMemBuffer().GetFlags(key1)
+		require.NoError(t, err)
+		require.True(t, flags.HasLocked())
+		require.True(t, flags.HasLockedInShareMode())
+
+		// `lockKeys` in exclusive mode again on k1 to upgrade the lock.
+		lockCtx.InShareMode = false
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		err = txn.lockKeys(context.TODO(), lockCtx, nil, key1)
+		require.ErrorContains(t, err, "upgrading a shared lock to an exclusive lock is not supported")
+
+		done := make(chan struct{})
+		go func() {
+			txn.us.GetMemBuffer().Delete(key1)
+			defer close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			require.FailNow(t, "lockKeys holds rlock after returning error")
+		}
+	})
+}

--- a/txnkv/transaction/txn_test.go
+++ b/txnkv/transaction/txn_test.go
@@ -100,12 +100,16 @@ type testTxn struct {
 }
 
 func newTestTxn(t *testing.T, startTS uint64) *testTxn {
+	return newTestTxnWithOptions(t, startTS, &TxnOptions{StartTS: &startTS})
+}
+
+func newTestTxnWithOptions(t *testing.T, startTS uint64, options *TxnOptions) *testTxn {
 	pd := &mockPDClient{}
 	cache := locate.NewTestRegionCache()
 	cache.SetPDClient(pd)
 	store := &mockStore{cache: cache}
 	snapshot := txnsnapshot.NewTiKVSnapshot(store, startTS, 0)
-	txn, err := NewTiKVTxn(store, snapshot, startTS, &TxnOptions{StartTS: &startTS})
+	txn, err := NewTiKVTxn(store, snapshot, startTS, options)
 	require.NoError(t, err)
 	return &testTxn{
 		KVTxn:    txn,
@@ -204,6 +208,45 @@ func TestLockKeys(t *testing.T) {
 		require.True(t, flags.HasLockedInShareMode())
 	})
 
+	t.Run("PessimisticSharedRejectsAggressiveLocking", func(t *testing.T) {
+		key1 := []byte("k1")
+		key2 := []byte("k2")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.store.client.onSend = handlePessimisticLock
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		expectedLockType = kvrpcpb.Op_PessimisticLock
+		require.NoError(t, txn.lockKeys(context.TODO(), lockCtx, nil, key2))
+
+		txn.StartAggressiveLocking()
+		lockCtx.InShareMode = true
+		err := txn.lockKeys(context.TODO(), lockCtx, nil, key1)
+		require.ErrorContains(t, err, "shared lock is not supported in aggressive/fair locking mode")
+		require.True(t, txn.IsInAggressiveLockingMode())
+		txn.CancelAggressiveLocking(context.Background())
+	})
+
+	t.Run("PessimisticSharedRejectsPipelinedTxn", func(t *testing.T) {
+		startTS := uint64(1)
+		key := []byte("k")
+		txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+			StartTS: &startTS,
+			PipelinedTxn: PipelinedTxnOptions{
+				Enable:                 true,
+				FlushConcurrency:       1,
+				ResolveLockConcurrency: 1,
+			},
+		})
+		txn.store.client.onSend = requireNoRequest
+		defer txn.pipelinedCancel()
+
+		lockCtx := kv.NewLockCtx(2, kv.LockNoWait, time.Now())
+		lockCtx.InShareMode = true
+		err := txn.lockKeys(context.TODO(), lockCtx, nil, key)
+		require.ErrorContains(t, err, "shared lock is not supported in pipelined transaction")
+	})
+
 	t.Run("UpgradeSharedToExclusive", func(t *testing.T) {
 		key1 := []byte("k1")
 		key2 := []byte("k2")
@@ -243,5 +286,70 @@ func TestLockKeys(t *testing.T) {
 		case <-time.After(time.Second):
 			require.FailNow(t, "lockKeys holds rlock after returning error")
 		}
+	})
+}
+
+func TestSharedLockCommitterIncompatibilities(t *testing.T) {
+	t.Run("RejectSharedLockPrimaryKey", func(t *testing.T) {
+		key := []byte("shared-key")
+		txn := newTestTxn(t, 1)
+		txn.SetPessimistic(true)
+		txn.GetMemBuffer().UpdateFlags(key, kv.SetKeyLocked, kv.SetKeyLockedInShareMode)
+
+		committer, err := newTwoPhaseCommitter(txn.KVTxn, 1)
+		require.NoError(t, err)
+		committer.primaryKey = key
+		err = committer.initKeysAndMutations(context.Background())
+		require.ErrorContains(t, err, "shared lock key cannot be used as transaction primary key")
+	})
+
+	t.Run("DisableAsyncCommitAndOnePC", func(t *testing.T) {
+		startTS := uint64(1)
+		newGlobalTxn := func() *testTxn {
+			txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+				TxnScope: oracle.GlobalTxnScope,
+				StartTS:  &startTS,
+			})
+			txn.SetPessimistic(true)
+			txn.SetEnableAsyncCommit(true)
+			txn.SetEnable1PC(true)
+			return txn
+		}
+
+		plainTxn := newGlobalTxn()
+		plainTxn.GetMemBuffer().UpdateFlags([]byte("primary-key"), kv.SetKeyLocked)
+		plainCommitter, err := TxnProbe{KVTxn: plainTxn.KVTxn}.NewCommitter(1)
+		require.NoError(t, err)
+		require.True(t, plainCommitter.CheckAsyncCommit())
+		require.True(t, plainCommitter.CheckOnePC())
+
+		sharedTxn := newGlobalTxn()
+		sharedTxn.GetMemBuffer().UpdateFlags([]byte("primary-key"), kv.SetKeyLocked)
+		sharedTxn.GetMemBuffer().UpdateFlags([]byte("shared-key"), kv.SetKeyLocked, kv.SetKeyLockedInShareMode)
+		sharedCommitter, err := TxnProbe{KVTxn: sharedTxn.KVTxn}.NewCommitter(1)
+		require.NoError(t, err)
+		require.False(t, sharedCommitter.CheckAsyncCommit())
+		require.False(t, sharedCommitter.CheckOnePC())
+	})
+
+	t.Run("RejectPipelinedFlush", func(t *testing.T) {
+		startTS := uint64(1)
+		key := []byte("shared-key")
+		txn := newTestTxnWithOptions(t, startTS, &TxnOptions{
+			StartTS: &startTS,
+			PipelinedTxn: PipelinedTxnOptions{
+				Enable:                 true,
+				FlushConcurrency:       1,
+				ResolveLockConcurrency: 1,
+			},
+		})
+		defer txn.pipelinedCancel()
+		require.NoError(t, txn.GetMemBuffer().SetWithFlags(key, []byte("value"), kv.SetKeyLocked, kv.SetKeyLockedInShareMode))
+
+		flushed, err := txn.GetMemBuffer().Flush(true)
+		require.NoError(t, err)
+		require.True(t, flushed)
+		err = txn.GetMemBuffer().FlushWait()
+		require.ErrorContains(t, err, "shared lock is not supported in pipelined transaction")
 	})
 }

--- a/txnkv/transaction/txn_test.go
+++ b/txnkv/transaction/txn_test.go
@@ -52,7 +52,7 @@ func (c *mockPDClient) GetRegion(ctx context.Context, key []byte, opts ...opt.Ge
 	}, nil
 }
 
-func (c *mockPDClient) GetStore(ctx context.Context, storeID uint64, opts ...opt.GetStoreOption) (*metapb.Store, error) {
+func (c *mockPDClient) GetStore(ctx context.Context, storeID uint64) (*metapb.Store, error) {
 	return &metapb.Store{
 		Id:      storeID,
 		Address: "mock-store",

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -199,6 +199,16 @@ type Lock struct {
 	MinCommitTS     uint64
 }
 
+func (l *Lock) IsPessimistic() bool {
+	return l.LockType == kvrpcpb.Op_PessimisticLock || l.LockType == kvrpcpb.Op_SharedPessimisticLock
+}
+
+// IsShared returns true if the lock is a shared lock wrapper.
+// Note that embedded locks can only be either pessimistic or prewrite locks.
+func (l *Lock) IsShared() bool {
+	return l.LockType == kvrpcpb.Op_SharedLock
+}
+
 func (l *Lock) String() string {
 	buf := bytes.NewBuffer(make([]byte, 0, 128))
 	buf.WriteString("key: ")
@@ -279,6 +289,11 @@ func (lr *LockResolver) BatchResolveLocks(bo *retry.Backoffer, locks []*Lock, lo
 	for _, l := range expiredLocks {
 		logutil.Logger(bo.GetCtx()).Debug("BatchResolveLocks handling lock", zap.Stringer("lock", l))
 
+		if l.IsShared() {
+			logutil.Logger(bo.GetCtx()).Warn("cannot resolve a shared lock directly, should extract the inner locks and resolve them one by one", zap.Stack("stack"))
+			return false, errors.New("misuse of BatchResolveLocks: trying to resolve a shared lock directly")
+		}
+
 		if _, ok := txnInfos[l.TxnID]; ok {
 			continue
 		}
@@ -290,7 +305,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *retry.Backoffer, locks []*Lock, lo
 			return false, err
 		}
 
-		if l.LockType == kvrpcpb.Op_PessimisticLock {
+		if l.IsPessimistic() {
 			// BatchResolveLocks forces resolving the locks ignoring whether whey are expired.
 			// For pessimistic locks, committing them makes no sense, but it won't affect transaction
 			// correctness if we always roll back them.
@@ -540,7 +555,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 		status, err := lr.getTxnStatusFromLock(bo, l, callerStartTS, forceSyncCommit, detail)
 
 		if _, ok := errors.Cause(err).(primaryMismatch); ok {
-			if l.LockType != kvrpcpb.Op_PessimisticLock {
+			if !l.IsPessimistic() {
 				logutil.BgLogger().Info("unexpected primaryMismatch error occurred on a non-pessimistic lock", zap.Stringer("lock", l), zap.Error(err))
 				return TxnStatus{}, err
 			}
@@ -583,7 +598,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			}
 			return status, err
 		}
-		if l.LockType == kvrpcpb.Op_PessimisticLock {
+		if l.IsPessimistic() {
 			// pessimistic locks don't block read so it needn't be async.
 			if pessimisticRegionResolve {
 				pessimisticCleanRegions, exists := pessimisticCleanTxns[l.TxnID]
@@ -617,6 +632,10 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 
 	var canIgnore, canAccess []uint64
 	for _, l := range locks {
+		if l.IsShared() {
+			logutil.Logger(bo.GetCtx()).Warn("cannot resolve a shared lock directly, should extract the inner locks and resolve them one by one", zap.Stack("stack"))
+			return ResolveLockResult{}, errors.New("misuse of resolveLocks: trying to resolve a shared lock directly")
+		}
 		status, err := resolve(l, false)
 		if err != nil {
 			msBeforeTxnExpired.update(0)
@@ -761,7 +780,7 @@ func (lr *LockResolver) getTxnStatusFromLock(bo *retry.Backoffer, l *Lock, calle
 				zap.Uint64("CallerStartTs", callerStartTS),
 				zap.Stringer("lock str", l),
 				zap.Stringer("status", status))
-			if l.LockType == kvrpcpb.Op_PessimisticLock {
+			if l.IsPessimistic() {
 				if _, err := util.EvalFailpoint("txnExpireRetTTL"); err == nil {
 					return TxnStatus{action: kvrpcpb.Action_LockNotExistDoNothing},
 						errors.New("error txn not found and lock expired")
@@ -776,7 +795,7 @@ func (lr *LockResolver) getTxnStatusFromLock(bo *retry.Backoffer, l *Lock, calle
 			// has no related information. There are possibilities that some other transactions do checkTxnStatus on these
 			// locks and they will be blocked ttl time, so let the transaction retries to do pessimistic lock if txn not found
 			// and the lock does not expire yet.
-			if l.LockType == kvrpcpb.Op_PessimisticLock {
+			if l.IsPessimistic() {
 				return TxnStatus{ttl: l.TTL}, nil
 			}
 		}
@@ -828,7 +847,8 @@ func (lr *LockResolver) getTxnStatus(bo *retry.Backoffer, txnID uint64, primary 
 	// 2.3 No lock -- pessimistic lock rollback, concurrence prewrite.
 
 	var status TxnStatus
-	resolvingPessimisticLock := lockInfo != nil && lockInfo.LockType == kvrpcpb.Op_PessimisticLock
+
+	resolvingPessimisticLock := lockInfo != nil && lockInfo.IsPessimistic()
 	req := tikvrpc.NewRequest(tikvrpc.CmdCheckTxnStatus, &kvrpcpb.CheckTxnStatusRequest{
 		PrimaryKey:               primary,
 		LockTs:                   txnID,


### PR DESCRIPTION
## Problem

`release-nextgen-202603-ticdc` is missing shared-lock transaction support that is already present on `release-nextgen-202603`.

## Summary

- Pick the shared lock implementation for pessimistic transactions.
- Pick ForceLock/shared-lock conflict handling.
- Pick guards for unsupported shared-lock paths, including pipelined transactions, aggressive/fair locking, 1PC, async commit, and shared-lock primary keys.
- Add a small release-branch adaptation for current PD client and snapshot APIs, and align the integration-test kvproto dependency with the shared-lock proto used by the main module.

## Tests

- `go test -count=1 ./kv ./txnkv/transaction ./txnkv/txnlock`
- `go test -count=1 ./tikv -run "^$"`
- `cd integration_tests && go test -count=1 ./...`
