### PR TITLE
fix(tikvrpc): attach context to lock wait info requests

### DIFF
--- a/tikvrpc/cmds_generated.go
+++ b/tikvrpc/cmds_generated.go
@@ -269,6 +269,15 @@ func patchCmdCtx(req *Request, cmd CmdType, ctx *kvrpcpb.Context) bool {
 			req.Req = &cmd
 		}
 		req.rev++
+	case CmdLockWaitInfo:
+		if req.rev == 0 {
+			req.LockWaitInfo().Context = ctx
+		} else {
+			cmd := *req.LockWaitInfo()
+			cmd.Context = ctx
+			req.Req = &cmd
+		}
+		req.rev++
 	case CmdCop:
 		if req.rev == 0 {
 			req.Cop().Context = ctx
@@ -442,6 +451,8 @@ func isValidReqType(cmd CmdType) bool {
 	case CmdRemoveLockObserver:
 		return true
 	case CmdPhysicalScanLock:
+		return true
+	case CmdLockWaitInfo:
 		return true
 	case CmdCop:
 		return true

--- a/tikvrpc/gen.sh
+++ b/tikvrpc/gen.sh
@@ -56,6 +56,7 @@ cmds=(
   CheckLockObserver
   RemoveLockObserver
   PhysicalScanLock
+  LockWaitInfo
   Cop
   BatchCop
   MvccGetByKey

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -121,6 +121,58 @@ func TestDefaultRequestOrigin(t *testing.T) {
 	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
 }
 
+func TestAttachContextSetsRequestContext(t *testing.T) {
+	rpcCtx := kvrpcpb.Context{
+		RegionId:     123,
+		ApiVersion:   kvrpcpb.APIVersion_V2,
+		KeyspaceId:   456,
+		KeyspaceName: "test-keyspace",
+	}
+	nextRPCtx := kvrpcpb.Context{
+		RegionId:     789,
+		ApiVersion:   kvrpcpb.APIVersion_V2,
+		KeyspaceId:   101112,
+		KeyspaceName: "next-test-keyspace",
+	}
+
+	for _, tc := range []struct {
+		name string
+		req  *Request
+		ctx  func(*Request) *kvrpcpb.Context
+	}{
+		{
+			name: "get",
+			req:  NewRequest(CmdGet, &kvrpcpb.GetRequest{}),
+			ctx: func(req *Request) *kvrpcpb.Context {
+				return req.Get().GetContext()
+			},
+		},
+		{
+			name: "lock_wait_info",
+			req:  NewRequest(CmdLockWaitInfo, &kvrpcpb.GetLockWaitInfoRequest{}),
+			ctx: func(req *Request) *kvrpcpb.Context {
+				return req.LockWaitInfo().GetContext()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, AttachContext(tc.req, rpcCtx))
+			require.Equal(t, rpcCtx.GetRegionId(), tc.ctx(tc.req).GetRegionId())
+			require.Equal(t, rpcCtx.GetApiVersion(), tc.ctx(tc.req).GetApiVersion())
+			require.Equal(t, rpcCtx.GetKeyspaceId(), tc.ctx(tc.req).GetKeyspaceId())
+			require.Equal(t, rpcCtx.GetKeyspaceName(), tc.ctx(tc.req).GetKeyspaceName())
+
+			oldReq := tc.req.Req
+			require.True(t, AttachContext(tc.req, nextRPCtx))
+			require.NotSame(t, oldReq, tc.req.Req)
+			require.Equal(t, nextRPCtx.GetRegionId(), tc.ctx(tc.req).GetRegionId())
+			require.Equal(t, nextRPCtx.GetApiVersion(), tc.ctx(tc.req).GetApiVersion())
+			require.Equal(t, nextRPCtx.GetKeyspaceId(), tc.ctx(tc.req).GetKeyspaceId())
+			require.Equal(t, nextRPCtx.GetKeyspaceName(), tc.ctx(tc.req).GetKeyspaceName())
+		})
+	}
+}
+
 // https://github.com/pingcap/tidb/issues/51921
 func TestTiDB51921(t *testing.T) {
 	for _, r := range []*Request{


### PR DESCRIPTION
## Summary

Fixes #2005

`CmdLockWaitInfo` is used by callers such as TiDB's `INFORMATION_SCHEMA.DATA_LOCK_WAITS` to read TiKV wait-table entries. In API v2 / next-gen TiKV, those requests need the same region and keyspace context as other KV requests.

Without the request context, the wait-table query can miss waits in the caller's keyspace.

This PR makes `CmdLockWaitInfo` participate in `tikvrpc.AttachContext` and adds regression coverage at the `tikvrpc` boundary.

## Changes

- Add `LockWaitInfo` to the generated `tikvrpc` command list that supports request-context attachment.
- Regenerate `tikvrpc/cmds_generated.go` so `CmdLockWaitInfo`:
  - is treated as a valid request type for context attachment
  - attaches context to `GetLockWaitInfoRequest`
  - follows the same reattach / copy-on-write behavior as other KV requests
- Add unit coverage for:
  - first-time context attachment
  - repeated context attachment on an existing request
  - `CmdLockWaitInfo` alongside a baseline `CmdGet` request

## Why

`DATA_LOCK_WAITS` needs complete wait-table visibility in API v2 / next-gen deployments. The request-side keyspace context determines which keyspace TiKV should read wait entries from.

Response key decoding for `CmdLockWaitInfo` is already covered in `internal/apicodec`; this PR complements that by fixing and covering the request-side context path.

## Tests

```bash
go test ./tikvrpc -run '^TestAttachContextSetsRequestContext$' -count=1
ok  	github.com/tikv/client-go/v2/tikvrpc	0.008s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lock wait information requests in command processing.

* **Tests**
  * Expanded test coverage for context attachment across multiple request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->