### PR TITLE
fix(tikvrpc): attach context to lock wait info requests

### DIFF
--- a/tikvrpc/cmds_generated.go
+++ b/tikvrpc/cmds_generated.go
@@ -269,6 +269,15 @@ func patchCmdCtx(req *Request, cmd CmdType, ctx *kvrpcpb.Context) bool {
 			req.Req = &cmd
 		}
 		req.rev++
+	case CmdLockWaitInfo:
+		if req.rev == 0 {
+			req.LockWaitInfo().Context = ctx
+		} else {
+			cmd := *req.LockWaitInfo()
+			cmd.Context = ctx
+			req.Req = &cmd
+		}
+		req.rev++
 	case CmdCop:
 		if req.rev == 0 {
 			req.Cop().Context = ctx
@@ -442,6 +451,8 @@ func isValidReqType(cmd CmdType) bool {
 	case CmdRemoveLockObserver:
 		return true
 	case CmdPhysicalScanLock:
+		return true
+	case CmdLockWaitInfo:
 		return true
 	case CmdCop:
 		return true

--- a/tikvrpc/gen.sh
+++ b/tikvrpc/gen.sh
@@ -56,6 +56,7 @@ cmds=(
   CheckLockObserver
   RemoveLockObserver
   PhysicalScanLock
+  LockWaitInfo
   Cop
   BatchCop
   MvccGetByKey

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -59,6 +59,58 @@ func TestBatchResponse(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestAttachContextSetsRequestContext(t *testing.T) {
+	rpcCtx := kvrpcpb.Context{
+		RegionId:     123,
+		ApiVersion:   kvrpcpb.APIVersion_V2,
+		KeyspaceId:   456,
+		KeyspaceName: "test-keyspace",
+	}
+	nextRPCtx := kvrpcpb.Context{
+		RegionId:     789,
+		ApiVersion:   kvrpcpb.APIVersion_V2,
+		KeyspaceId:   101112,
+		KeyspaceName: "next-test-keyspace",
+	}
+
+	for _, tc := range []struct {
+		name string
+		req  *Request
+		ctx  func(*Request) *kvrpcpb.Context
+	}{
+		{
+			name: "get",
+			req:  NewRequest(CmdGet, &kvrpcpb.GetRequest{}),
+			ctx: func(req *Request) *kvrpcpb.Context {
+				return req.Get().GetContext()
+			},
+		},
+		{
+			name: "lock_wait_info",
+			req:  NewRequest(CmdLockWaitInfo, &kvrpcpb.GetLockWaitInfoRequest{}),
+			ctx: func(req *Request) *kvrpcpb.Context {
+				return req.LockWaitInfo().GetContext()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, AttachContext(tc.req, rpcCtx))
+			require.Equal(t, rpcCtx.GetRegionId(), tc.ctx(tc.req).GetRegionId())
+			require.Equal(t, rpcCtx.GetApiVersion(), tc.ctx(tc.req).GetApiVersion())
+			require.Equal(t, rpcCtx.GetKeyspaceId(), tc.ctx(tc.req).GetKeyspaceId())
+			require.Equal(t, rpcCtx.GetKeyspaceName(), tc.ctx(tc.req).GetKeyspaceName())
+
+			oldReq := tc.req.Req
+			require.True(t, AttachContext(tc.req, nextRPCtx))
+			require.NotSame(t, oldReq, tc.req.Req)
+			require.Equal(t, nextRPCtx.GetRegionId(), tc.ctx(tc.req).GetRegionId())
+			require.Equal(t, nextRPCtx.GetApiVersion(), tc.ctx(tc.req).GetApiVersion())
+			require.Equal(t, nextRPCtx.GetKeyspaceId(), tc.ctx(tc.req).GetKeyspaceId())
+			require.Equal(t, nextRPCtx.GetKeyspaceName(), tc.ctx(tc.req).GetKeyspaceName())
+		})
+	}
+}
+
 // https://github.com/pingcap/tidb/issues/51921
 func TestTiDB51921(t *testing.T) {
 	for _, r := range []*Request{


### PR DESCRIPTION
### What problem does this PR solve?

Cherry-pick #2006 to `release-nextgen-202603`.

Fixes tikv/client-go#2005.

Closes #2008.

### What changed and how does it work?

- Add `CmdLockWaitInfo` to generated context patching so lock wait info requests carry the request context.
- Treat `CmdLockWaitInfo` as a valid request type in generated request validation.
- Add a regression test covering repeated `AttachContext` calls for both `CmdGet` and `CmdLockWaitInfo`.

### Check List

Tests:

- `go generate ./tikvrpc`
- `go test --tags=intest ./tikvrpc`
- `go test --tags=intest ./...`
