### PR TITLE
util: expose IA scan detail fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
+	github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 h1:VV03wSSG2XhOwhF79lvT88Z83lwzMT+aZHXrcCIN9B0=
-github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
+github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
+	github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0
 	github.com/pingcap/tidb v1.1.0-beta.0.20260603040045-b254c43931d9
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1445,8 +1445,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 h1:VV03wSSG2XhOwhF79lvT88Z83lwzMT+aZHXrcCIN9B0=
-github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
+github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -484,6 +484,14 @@ type ScanDetail struct {
 	RocksdbBlockReadDuration time.Duration
 	// GetSnapshotDuration is the time spent getting an engine snapshot.
 	GetSnapshotDuration time.Duration
+	// IaCacheHitCount is the total number of IA segment cache hits.
+	IaCacheHitCount uint64
+	// IaRemoteReadSegmentCount is the total number of IA remote segment reads.
+	IaRemoteReadSegmentCount uint64
+	// IaRemoteReadSegmentBytes is the total number of logical bytes returned from IA remote segment reads.
+	IaRemoteReadSegmentBytes uint64
+	// IaRemoteReadSegmentDuration is the total time spent serving IA remote segment reads.
+	IaRemoteReadSegmentDuration time.Duration
 }
 
 // Merge merges scan detail execution details into self.
@@ -498,6 +506,10 @@ func (sd *ScanDetail) Merge(scanDetail *ScanDetail) {
 	atomic.AddUint64(&sd.RocksdbBlockReadByte, scanDetail.RocksdbBlockReadByte)
 	atomic.AddInt64((*int64)(&sd.RocksdbBlockReadDuration), int64(scanDetail.RocksdbBlockReadDuration))
 	atomic.AddInt64((*int64)(&sd.GetSnapshotDuration), int64(scanDetail.GetSnapshotDuration))
+	atomic.AddUint64(&sd.IaCacheHitCount, scanDetail.IaCacheHitCount)
+	atomic.AddUint64(&sd.IaRemoteReadSegmentCount, scanDetail.IaRemoteReadSegmentCount)
+	atomic.AddUint64(&sd.IaRemoteReadSegmentBytes, scanDetail.IaRemoteReadSegmentBytes)
+	atomic.AddInt64((*int64)(&sd.IaRemoteReadSegmentDuration), int64(scanDetail.IaRemoteReadSegmentDuration))
 }
 
 var zeroScanDetail = ScanDetail{}
@@ -528,6 +540,33 @@ func (sd *ScanDetail) String() string {
 		buf.WriteString("get_snapshot_time: ")
 		buf.WriteString(FormatDuration(sd.GetSnapshotDuration))
 		buf.WriteString(", ")
+	}
+	if sd.IaCacheHitCount > 0 || sd.IaRemoteReadSegmentCount > 0 || sd.IaRemoteReadSegmentBytes > 0 || sd.IaRemoteReadSegmentDuration > 0 {
+		buf.WriteString("ia: {")
+		if sd.IaCacheHitCount > 0 {
+			buf.WriteString("cache_hit_count: ")
+			buf.WriteString(strconv.FormatUint(sd.IaCacheHitCount, 10))
+			buf.WriteString(", ")
+		}
+		if sd.IaRemoteReadSegmentCount > 0 {
+			buf.WriteString("remote_read_segment_count: ")
+			buf.WriteString(strconv.FormatUint(sd.IaRemoteReadSegmentCount, 10))
+			buf.WriteString(", ")
+		}
+		if sd.IaRemoteReadSegmentBytes > 0 {
+			buf.WriteString("remote_read_segment_bytes: ")
+			buf.WriteString(FormatBytes(int64(sd.IaRemoteReadSegmentBytes)))
+			buf.WriteString(", ")
+		}
+		if sd.IaRemoteReadSegmentDuration > 0 {
+			buf.WriteString("remote_read_segment_wait_time: ")
+			buf.WriteString(FormatDuration(sd.IaRemoteReadSegmentDuration))
+			buf.WriteString(", ")
+		}
+		if buf.Bytes()[buf.Len()-2] == ',' {
+			buf.Truncate(buf.Len() - 2)
+		}
+		buf.WriteString("}, ")
 	}
 	buf.WriteString("rocksdb: {")
 	if sd.RocksdbDeleteSkippedCount > 0 {
@@ -580,6 +619,10 @@ func (sd *ScanDetail) MergeFromScanDetailV2(scanDetail *kvrpcpb.ScanDetailV2) {
 		sd.RocksdbBlockReadByte += scanDetail.RocksdbBlockReadByte
 		sd.RocksdbBlockReadDuration += time.Duration(scanDetail.RocksdbBlockReadNanos) * time.Nanosecond
 		sd.GetSnapshotDuration += time.Duration(scanDetail.GetSnapshotNanos) * time.Nanosecond
+		sd.IaCacheHitCount += scanDetail.IaCacheHitCount
+		sd.IaRemoteReadSegmentCount += scanDetail.IaRemoteReadSegmentCount
+		sd.IaRemoteReadSegmentBytes += scanDetail.IaRemoteReadSegmentBytes
+		sd.IaRemoteReadSegmentDuration += time.Duration(scanDetail.IaRemoteReadSegmentNanos) * time.Nanosecond
 	}
 }
 

--- a/util/execdetails_test.go
+++ b/util/execdetails_test.go
@@ -87,6 +87,83 @@ func TestRUDetailsCloneAndMergeRawRUV2(t *testing.T) {
 	assert.Equal(t, uint64(7), rightDrained.WriteRpcCount)
 }
 
+func TestScanDetailMergeFromScanDetailV2IncludesIAFields(t *testing.T) {
+	scanDetail := &kvrpcpb.ScanDetailV2{
+		ProcessedVersions:         10,
+		ProcessedVersionsSize:     20,
+		TotalVersions:             30,
+		RocksdbDeleteSkippedCount: 4,
+		RocksdbKeySkippedCount:    5,
+		RocksdbBlockCacheHitCount: 6,
+		RocksdbBlockReadCount:     7,
+		RocksdbBlockReadByte:      8,
+		RocksdbBlockReadNanos:     uint64((9 * time.Microsecond).Nanoseconds()),
+		GetSnapshotNanos:          uint64((7 * time.Microsecond).Nanoseconds()),
+		IaCacheHitCount:           2,
+		IaRemoteReadSegmentCount:  3,
+		IaRemoteReadSegmentBytes:  128,
+		IaRemoteReadSegmentNanos:  uint64((5 * time.Microsecond).Nanoseconds()),
+	}
+
+	sd := &ScanDetail{}
+	sd.MergeFromScanDetailV2(scanDetail)
+
+	assert.Equal(t, int64(30), sd.TotalKeys)
+	assert.Equal(t, int64(10), sd.ProcessedKeys)
+	assert.Equal(t, int64(20), sd.ProcessedKeysSize)
+	assert.Equal(t, uint64(4), sd.RocksdbDeleteSkippedCount)
+	assert.Equal(t, uint64(5), sd.RocksdbKeySkippedCount)
+	assert.Equal(t, uint64(6), sd.RocksdbBlockCacheHitCount)
+	assert.Equal(t, uint64(7), sd.RocksdbBlockReadCount)
+	assert.Equal(t, uint64(8), sd.RocksdbBlockReadByte)
+	assert.Equal(t, 9*time.Microsecond, sd.RocksdbBlockReadDuration)
+	assert.Equal(t, 7*time.Microsecond, sd.GetSnapshotDuration)
+	assert.Equal(t, uint64(2), sd.IaCacheHitCount)
+	assert.Equal(t, uint64(3), sd.IaRemoteReadSegmentCount)
+	assert.Equal(t, uint64(128), sd.IaRemoteReadSegmentBytes)
+	assert.Equal(t, 5*time.Microsecond, sd.IaRemoteReadSegmentDuration)
+
+	str := sd.String()
+	assert.Contains(t, str, "total_process_keys: 10")
+	assert.Contains(t, str, "total_process_keys_size: 20")
+	assert.Contains(t, str, "total_keys: 30")
+	assert.Contains(t, str, "get_snapshot_time")
+	assert.Contains(t, str, "ia: {")
+	assert.Contains(t, str, "cache_hit_count: 2")
+	assert.Contains(t, str, "remote_read_segment_count: 3")
+	assert.Contains(t, str, "remote_read_segment_bytes: 128 Bytes")
+	assert.Contains(t, str, "remote_read_segment_wait_time")
+	assert.Contains(t, str, "rocksdb: {")
+	assert.Contains(t, str, "delete_skipped_count: 4")
+	assert.Contains(t, str, "key_skipped_count: 5")
+	assert.Contains(t, str, "cache_hit_count: 6")
+	assert.Contains(t, str, "read_count: 7")
+	assert.Contains(t, str, "read_byte: 8 Bytes")
+	assert.Contains(t, str, "read_time")
+}
+
+func TestScanDetailMergeIncludesIAFields(t *testing.T) {
+	left := &ScanDetail{
+		IaCacheHitCount:             1,
+		IaRemoteReadSegmentCount:    2,
+		IaRemoteReadSegmentBytes:    64,
+		IaRemoteReadSegmentDuration: 3 * time.Microsecond,
+	}
+	right := &ScanDetail{
+		IaCacheHitCount:             4,
+		IaRemoteReadSegmentCount:    5,
+		IaRemoteReadSegmentBytes:    256,
+		IaRemoteReadSegmentDuration: 7 * time.Microsecond,
+	}
+
+	left.Merge(right)
+
+	assert.Equal(t, uint64(5), left.IaCacheHitCount)
+	assert.Equal(t, uint64(7), left.IaRemoteReadSegmentCount)
+	assert.Equal(t, uint64(320), left.IaRemoteReadSegmentBytes)
+	assert.Equal(t, 10*time.Microsecond, left.IaRemoteReadSegmentDuration)
+}
+
 func TestLockKeysDetailsMerge(t *testing.T) {
 	a := &LockKeysDetails{
 		TotalTime:                  10 * time.Millisecond,


### PR DESCRIPTION
### What changed

This exposes IA scan detail counters from `kvrpcpb.ScanDetailV2` through `util.ScanDetail` and includes them in merge and string formatting. It also bumps `github.com/pingcap/kvproto` to a version that already contains the IA fields from pingcap/kvproto#1438.

### Validation

The util package tests pass. Full-tree tests are currently blocked by an existing `tikv` mockstore panic that reproduces on upstream/master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scan statistics shown in query output with additional IA (index/remote segment) metrics: cache hits, remote segment read count, bytes read, and remote read wait time.
  * Scan details now include an `ia: {...}` section when these IA metrics are available.

* **Bug Fixes**
  * Correctly aggregate the new IA metrics when merging scan details from different sources, ensuring combined results reflect remote-read behavior accurately.

* **Tests**
  * Added unit tests covering IA metric parsing and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->