### PR TITLE
tikvrpc: avoid leaking stream RPC leases

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -94,6 +94,11 @@ const (
 // forwardMetadataKey is the key of gRPC metadata which represents a forwarded request.
 const forwardMetadataKey = "tikv-forwarded-host"
 
+const (
+	mvMaintenanceRequestSource = "internal_mv_maintain"
+	mvMaintenanceStreamHardTTL = time.Hour
+)
+
 // Client is a client that sends RPC.
 // It should not be used after calling Close().
 type Client interface {
@@ -686,6 +691,7 @@ func (c *RPCClient) getCopStreamResponse(ctx context.Context, client tikvpb.Tikv
 	copStream := resp.Resp.(*tikvrpc.CopStreamResponse)
 	copStream.Timeout = timeout
 	copStream.Lease.Cancel = cancel
+	setStreamHardTimeout(ctx, req, &copStream.Lease)
 	connArray.streamTimeout <- &copStream.Lease
 
 	// Read the first streaming response to get CopStreamResponse.
@@ -695,6 +701,7 @@ func (c *RPCClient) getCopStreamResponse(ctx context.Context, client tikvpb.Tikv
 	first, err = copStream.Recv()
 	if err != nil {
 		if errors.Cause(err) != io.EOF {
+			copStream.Close()
 			return nil, errors.WithStack(err)
 		}
 		logutil.BgLogger().Debug("copstream returns nothing for the request.")
@@ -721,6 +728,7 @@ func (c *RPCClient) getBatchCopStreamResponse(ctx context.Context, client tikvpb
 	copStream := resp.Resp.(*tikvrpc.BatchCopStreamResponse)
 	copStream.Timeout = timeout
 	copStream.Lease.Cancel = cancel
+	setStreamHardTimeout(ctx, req, &copStream.Lease)
 	connArray.streamTimeout <- &copStream.Lease
 
 	// Read the first streaming response to get CopStreamResponse.
@@ -730,6 +738,7 @@ func (c *RPCClient) getBatchCopStreamResponse(ctx context.Context, client tikvpb
 	first, err = copStream.Recv()
 	if err != nil {
 		if errors.Cause(err) != io.EOF {
+			copStream.Close()
 			return nil, errors.WithStack(err)
 		}
 		logutil.BgLogger().Debug("batch copstream returns nothing for the request.")
@@ -755,6 +764,7 @@ func (c *RPCClient) getMPPStreamResponse(ctx context.Context, client tikvpb.Tikv
 	copStream := resp.Resp.(*tikvrpc.MPPStreamResponse)
 	copStream.Timeout = timeout
 	copStream.Lease.Cancel = cancel
+	setStreamHardTimeout(ctx, req, &copStream.Lease)
 	connArray.streamTimeout <- &copStream.Lease
 
 	// Read the first streaming response to get CopStreamResponse.
@@ -764,11 +774,34 @@ func (c *RPCClient) getMPPStreamResponse(ctx context.Context, client tikvpb.Tikv
 	first, err = copStream.Recv()
 	if err != nil {
 		if errors.Cause(err) != io.EOF {
+			copStream.Close()
 			return nil, errors.WithStack(err)
 		}
 	}
 	copStream.MPPDataPacket = first
 	return resp, nil
+}
+
+func setStreamHardTimeout(ctx context.Context, req *tikvrpc.Request, lease *tikvrpc.Lease) {
+	reqSource := req.GetRequestSource()
+	ctxSource := util.RequestSourceFromCtx(ctx)
+	hardTTL := streamHardTTLBySources(reqSource, ctxSource)
+	lease.SetHardTimeout(hardTTL)
+}
+
+func streamHardTTL(ctx context.Context, req *tikvrpc.Request) time.Duration {
+	return streamHardTTLBySources(req.GetRequestSource(), util.RequestSourceFromCtx(ctx))
+}
+
+func streamHardTTLBySources(reqSource, ctxSource string) time.Duration {
+	if isMVMaintenanceRequestSource(reqSource) || isMVMaintenanceRequestSource(ctxSource) {
+		return mvMaintenanceStreamHardTTL
+	}
+	return 0
+}
+
+func isMVMaintenanceRequestSource(source string) bool {
+	return source == mvMaintenanceRequestSource || strings.HasPrefix(source, mvMaintenanceRequestSource+"_")
 }
 
 // Close closes all connections.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/kvproto/pkg/mpp"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -59,10 +60,117 @@ import (
 	"github.com/tikv/client-go/v2/internal/client/mockserver"
 	"github.com/tikv/client-go/v2/internal/logutil"
 	"github.com/tikv/client-go/v2/tikvrpc"
+	"github.com/tikv/client-go/v2/util"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 )
+
+type firstRecvErrTikvClient struct {
+	tikvpb.TikvClient
+	streamCtx context.Context
+	err       error
+}
+
+func (c *firstRecvErrTikvClient) CoprocessorStream(ctx context.Context, _ *coprocessor.Request, _ ...grpc.CallOption) (tikvpb.Tikv_CoprocessorStreamClient, error) {
+	c.streamCtx = ctx
+	return &firstRecvErrCopStream{err: c.err}, nil
+}
+
+func (c *firstRecvErrTikvClient) BatchCoprocessor(ctx context.Context, _ *coprocessor.BatchRequest, _ ...grpc.CallOption) (tikvpb.Tikv_BatchCoprocessorClient, error) {
+	c.streamCtx = ctx
+	return &firstRecvErrBatchCopStream{err: c.err}, nil
+}
+
+func (c *firstRecvErrTikvClient) EstablishMPPConnection(ctx context.Context, _ *mpp.EstablishMPPConnectionRequest, _ ...grpc.CallOption) (tikvpb.Tikv_EstablishMPPConnectionClient, error) {
+	c.streamCtx = ctx
+	return &firstRecvErrMPPStream{err: c.err}, nil
+}
+
+type firstRecvErrCopStream struct {
+	grpc.ClientStream
+	err error
+}
+
+func (s *firstRecvErrCopStream) Recv() (*coprocessor.Response, error) {
+	return nil, s.err
+}
+
+type firstRecvErrBatchCopStream struct {
+	grpc.ClientStream
+	err error
+}
+
+func (s *firstRecvErrBatchCopStream) Recv() (*coprocessor.BatchResponse, error) {
+	return nil, s.err
+}
+
+type firstRecvErrMPPStream struct {
+	grpc.ClientStream
+	err error
+}
+
+func (s *firstRecvErrMPPStream) Recv() (*mpp.MPPDataPacket, error) {
+	return nil, s.err
+}
+
+func TestStreamHardTTLForMVMaintenance(t *testing.T) {
+	req := tikvrpc.NewRequest(tikvrpc.CmdCopStream, &coprocessor.Request{})
+	require.Zero(t, streamHardTTL(context.Background(), req))
+
+	req.RequestSource = mvMaintenanceRequestSource
+	require.Equal(t, mvMaintenanceStreamHardTTL, streamHardTTL(context.Background(), req))
+
+	req.RequestSource = ""
+	ctx := util.WithInternalSourceType(context.Background(), "mv_maintain")
+	require.Equal(t, mvMaintenanceStreamHardTTL, streamHardTTL(ctx, req))
+}
+
+func TestStreamFirstRecvErrorClosesLease(t *testing.T) {
+	rpcClient := &RPCClient{}
+	recvErr := errors.New("first recv failed")
+	cases := []struct {
+		name string
+		req  *tikvrpc.Request
+		call func(*firstRecvErrTikvClient, *tikvrpc.Request, *connArray) (*tikvrpc.Response, error)
+	}{
+		{
+			name: "cop stream",
+			req:  tikvrpc.NewRequest(tikvrpc.CmdCopStream, &coprocessor.Request{}),
+			call: func(client *firstRecvErrTikvClient, req *tikvrpc.Request, connArray *connArray) (*tikvrpc.Response, error) {
+				return rpcClient.getCopStreamResponse(context.Background(), client, req, time.Minute, connArray)
+			},
+		},
+		{
+			name: "batch cop stream",
+			req:  tikvrpc.NewRequest(tikvrpc.CmdBatchCop, &coprocessor.BatchRequest{}),
+			call: func(client *firstRecvErrTikvClient, req *tikvrpc.Request, connArray *connArray) (*tikvrpc.Response, error) {
+				return rpcClient.getBatchCopStreamResponse(context.Background(), client, req, time.Minute, connArray)
+			},
+		},
+		{
+			name: "mpp stream",
+			req:  tikvrpc.NewRequest(tikvrpc.CmdMPPConn, &mpp.EstablishMPPConnectionRequest{}),
+			call: func(client *firstRecvErrTikvClient, req *tikvrpc.Request, connArray *connArray) (*tikvrpc.Response, error) {
+				return rpcClient.getMPPStreamResponse(context.Background(), client, req, time.Minute, connArray)
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &firstRecvErrTikvClient{err: recvErr}
+			connArray := &connArray{streamTimeout: make(chan *tikvrpc.Lease, 1)}
+
+			resp, err := tt.call(client, tt.req, connArray)
+
+			require.Nil(t, resp)
+			require.ErrorContains(t, err, recvErr.Error())
+			require.Equal(t, context.Canceled, client.streamCtx.Err())
+		})
+	}
+}
 
 func TestConn(t *testing.T) {
 	defer config.UpdateGlobal(func(conf *config.Config) {

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -1295,8 +1295,24 @@ func CallDebugRPC(ctx context.Context, client debugpb.DebugClient, req *Request)
 
 // Lease is used to implement grpc stream timeout.
 type Lease struct {
-	Cancel   context.CancelFunc
-	deadline int64 // A time.UnixNano value, if time.Now().UnixNano() > deadline, cancel() would be called.
+	Cancel context.CancelFunc
+	// deadline is the timeout for the current blocking Recv call.
+	// It is set before Recv and reset to 0 after Recv returns, so it does not
+	// expire an idle stream when no Recv is in progress.
+	deadline int64
+	// hardDeadline is the absolute maximum lifetime of the lease.
+	// It is independent of Recv state and is used as a guardrail to clean up
+	// leaked streams whose caller forgets to Close. 0 means disabled.
+	hardDeadline int64
+}
+
+// SetHardTimeout sets an absolute maximum lifetime for a stream lease.
+func (l *Lease) SetHardTimeout(timeout time.Duration) {
+	if timeout <= 0 {
+		atomic.StoreInt64(&l.hardDeadline, 0)
+		return
+	}
+	atomic.StoreInt64(&l.hardDeadline, time.Now().Add(timeout).UnixNano())
 }
 
 // Recv overrides the stream client Recv() function.
@@ -1397,6 +1413,11 @@ func keepOnlyActive(array []*Lease, now int64) []*Lease {
 	idx := 0
 	for i := 0; i < len(array); i++ {
 		item := array[i]
+		hardDeadline := atomic.LoadInt64(&item.hardDeadline)
+		if hardDeadline > 0 && hardDeadline <= now {
+			item.Cancel()
+			continue
+		}
 		deadline := atomic.LoadInt64(&item.deadline)
 		if deadline == 0 || deadline > now {
 			array[idx] = array[i]
@@ -1405,6 +1426,7 @@ func keepOnlyActive(array []*Lease, now int64) []*Lease {
 			item.Cancel()
 		}
 	}
+	clear(array[idx:])
 	return array[:idx]
 }
 

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -52,6 +53,36 @@ func TestBatchResponse(t *testing.T) {
 	batchResp, err := FromBatchCommandsResponse(resp)
 	assert.Nil(t, batchResp)
 	assert.NotNil(t, err)
+}
+
+func TestKeepOnlyActiveWithHardDeadline(t *testing.T) {
+	var canceled int32
+	activeLease := &Lease{Cancel: func() {}}
+	activeLease.SetHardTimeout(time.Hour)
+	expiredLease := &Lease{Cancel: func() { atomic.AddInt32(&canceled, 1) }}
+	atomic.StoreInt64(&expiredLease.hardDeadline, time.Now().Add(-time.Second).UnixNano())
+
+	leases := []*Lease{activeLease, expiredLease}
+	active := keepOnlyActive(leases, time.Now().UnixNano())
+
+	assert.Equal(t, []*Lease{activeLease}, active)
+	assert.Nil(t, leases[1])
+	assert.Equal(t, int32(1), atomic.LoadInt32(&canceled))
+}
+
+func TestKeepOnlyActiveHardDeadlineOverridesRecvDeadline(t *testing.T) {
+	var canceled int32
+	now := time.Now().UnixNano()
+	lease := &Lease{Cancel: func() { atomic.AddInt32(&canceled, 1) }}
+	atomic.StoreInt64(&lease.deadline, now+int64(time.Hour))
+	atomic.StoreInt64(&lease.hardDeadline, now-1)
+
+	leases := []*Lease{lease}
+	active := keepOnlyActive(leases, now)
+
+	assert.Empty(t, active)
+	assert.Nil(t, leases[0])
+	assert.Equal(t, int32(1), atomic.LoadInt32(&canceled))
 }
 
 // https://github.com/pingcap/tidb/issues/51921


### PR DESCRIPTION
Issue Number: ref #2018

Problem Summary:

Stream RPC leases can be retained indefinitely in `tikvrpc.CheckStreamTimeoutLoop` if a stream has been registered into `connArray.streamTimeout` but is not closed on some error/cancellation paths. One concrete case is the first `Recv()` error path for CopStream, BatchCopStream, and MPPStream: `Recv()` resets the lease deadline to `0`, then the setup path returns a non-EOF error without closing the stream. Since `keepOnlyActive` treats `deadline == 0` as active/idle, the stale lease can remain in the loop.

What is changed:

- Close CopStream, BatchCopStream, and MPPStream when the first `Recv()` returns a non-EOF error after the lease has been registered.
- Add an optional absolute hard lifetime to `tikvrpc.Lease`, so the timeout loop can cancel and remove selected stream leases even when `deadline == 0`.
- Enable the hard lifetime only for TiDB materialized-view maintenance stream RPCs, identified by request source or context source `internal_mv_maintain`.

Why this approach:

- Normal stream timeout behavior is unchanged when hard timeout is not set.
- The hard timeout is scoped to MV maintenance stream RPCs instead of all user queries.
- The hard timeout is an absolute lifetime guardrail rather than an idle timeout: selected MV maintenance streams can be canceled after the hard TTL even if a `Recv` is currently active.
- The first-Recv error path is closed immediately, so it does not rely on the hard timeout guardrail.

Tests:

- `go test ./tikvrpc -run '^(TestKeepOnlyActiveWithHardDeadline|TestKeepOnlyActiveHardDeadlineOverridesRecvDeadline)$'`
- `go test ./internal/client -run '^(TestStreamHardTTLForMVMaintenance|TestStreamFirstRecvErrorClosesLease)$'`
