### PR TITLE
integration_tests: remove temporary TiDB replaces

### DIFF
--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0
-	github.com/pingcap/tidb v1.1.0-beta.0.20260708073538-b6db59b2742a
+	github.com/pingcap/tidb v1.1.0-beta.0.20260715060322-10292a4f8697
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.14.4
-	github.com/tikv/client-go/v2 v2.0.8-0.20260617030124-661db4f5f4e8
+	github.com/tikv/client-go/v2 v2.0.8-0.20260708122311-01bd8f99f4da
 	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.79.3
@@ -116,7 +116,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 // indirect
 	github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 // indirect
 	github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 // indirect
-	github.com/pingcap/tidb/pkg/parser v0.0.0-20260708073538-b6db59b2742a // indirect
+	github.com/pingcap/tidb/pkg/parser v0.0.0-20260715060322-10292a4f8697 // indirect
 	github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -177,8 +177,5 @@ require (
 
 replace (
 	github.com/go-ldap/ldap/v3 => github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117
-	// Temporary until pingcap/tidb master adapts to the current PD client mock interfaces.
-	github.com/pingcap/tidb => github.com/YuhaoZhang00/tidb v0.0.0-20260702053009-6ce3a970ea5e
-	github.com/pingcap/tidb/pkg/parser => github.com/YuhaoZhang00/tidb/pkg/parser v0.0.0-20260702053009-6ce3a970ea5e
 	github.com/tikv/client-go/v2 => ../
 )

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -857,10 +857,6 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117 h1:+OqGGFc2YHFd82aSHmjlILVt1t4JWJjrNIfV8cVEPow=
 github.com/YangKeao/ldap/v3 v3.4.5-0.20230421065457-369a3bab1117/go.mod h1:bMGIq3AGbytbaMwf8wdv5Phdxz0FWHTIYMSzyrYgnQs=
-github.com/YuhaoZhang00/tidb v0.0.0-20260702053009-6ce3a970ea5e h1:9PvAIH8PpCPgOAqDTLuVLVg/oe5lqaRNyVTjOO5xhMM=
-github.com/YuhaoZhang00/tidb v0.0.0-20260702053009-6ce3a970ea5e/go.mod h1:Cx49dT+8NMIY/mrkFnL7Q3nva2QNewgkHKKY7bwUTsE=
-github.com/YuhaoZhang00/tidb/pkg/parser v0.0.0-20260702053009-6ce3a970ea5e h1:WOuVyohZ17fbRR8JSS4b9zCvrlzBQlgePMHZyR7kV90=
-github.com/YuhaoZhang00/tidb/pkg/parser v0.0.0-20260702053009-6ce3a970ea5e/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
@@ -1466,6 +1462,10 @@ github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d h1:5JCgncG9X7
 github.com/pingcap/metering_sdk v0.0.0-20260324055927-14fead745f1d/go.mod h1:HMNxmg0/lrn3SPGJ6LTZqP0WwEpcXMu9s/4TWJbzT8w=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3 h1:Q9CMGKUztbM0RWHdQu0pD9b9OC47sbISRiMvf9vJ2RY=
 github.com/pingcap/sysutil v1.0.1-0.20241113070546-23b50de46fd3/go.mod h1:tyo4AX5P7udiSKN0Mv3nD9DcUnuLLmFfE22+dEs4vbU=
+github.com/pingcap/tidb v1.1.0-beta.0.20260715060322-10292a4f8697 h1:l3n41AXornt+GTze4r3+otjJAvCITcL57A4BKLoin1s=
+github.com/pingcap/tidb v1.1.0-beta.0.20260715060322-10292a4f8697/go.mod h1:m3u3NygOY0KiSOVJcHIn26z2cx7sYrutXdcAwY6gOOI=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260715060322-10292a4f8697 h1:Wl+WUds9uSMaT3tEDtNRbe/dHfoaTT9K8L6RY3e/E1c=
+github.com/pingcap/tidb/pkg/parser v0.0.0-20260715060322-10292a4f8697/go.mod h1:zDLDsfNBU5+L6T4J9/OgWAHc/WZvMUjbpgHqQ/t3yKo=
 github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe h1:9I5GHZesmR+hv68t00BO7tayKMFfywi+hlpn119GscM=
 github.com/pingcap/tipb v0.0.0-20260623093813-5f9928e91afe/go.mod h1:RM8iRcMalzOthG2XJxnNBniM4xFGb/lDwHUwqkaVzt4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
### What changed

- Remove the temporary `github.com/YuhaoZhang00/tidb` replaces added by #1947.
- Point `github.com/pingcap/tidb` and `github.com/pingcap/tidb/pkg/parser` to the official TiDB master pseudo-version at `10292a4f8697`.
- Refresh the integration module dependency checksums.

### Why

#1947 temporarily used an adapted TiDB fork because TiDB master had not yet adopted the current PD client mock interfaces. The required TiDB adaptations have since merged in pingcap/tidb#67941, so the integration module no longer needs the fork overrides.

### Validation

- `go mod verify`
- `env GOCACHE=/tmp/client-go-remove-tidb-replace-gocache go test ./... -run "^$" -count=0`
- `git diff --check upstream/master...HEAD`

Related: #1947, pingcap/tidb#67941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated integration components to newer versions for improved compatibility and reliability.
  * Refined LDAP integration support.
  * Removed outdated integration-specific overrides and aligned parser components with the updated database integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->