### PR TITLE
txnkv: add readPoolTaskDetails to SnapshotRuntimeStats

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -1,6 +1,6 @@
 module gcworker
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -1,6 +1,6 @@
 module rawkv
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -1,6 +1,6 @@
 module 1pc_txn
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -1,6 +1,6 @@
 module async_commit
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -1,6 +1,6 @@
 module delete_range
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -1,9 +1,9 @@
 module txnkv
 
-go 1.25.8
+go 1.25.10
 
 require (
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368
 	github.com/tikv/client-go/v2 v2.0.0
 )
 
@@ -33,7 +33,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -45,10 +45,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -1,6 +1,6 @@
 module pessimistic_txn
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -1,6 +1,6 @@
 module unsafedestoryrange
 
-go 1.25.8
+go 1.25.10
 
 require github.com/tikv/client-go/v2 v2.0.0
 
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260601035955-b2b3bb492278 // indirect
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tiancaiamao/gp v0.0.0-20221230034425-4025bc8a4d4a // indirect
-	github.com/tikv/pd/client v0.0.0-20260601035915-3ef6a3b10c84 // indirect
+	github.com/tikv/pd/client v0.0.0-20260708075407-4e05b9d2c2d3 // indirect
 	github.com/twmb/murmur3 v1.1.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.10 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -43,10 +43,10 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
-	google.golang.org/grpc v1.75.1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 h1:qW0gHsqY3X3qmyiEfESqpYSF3Vu7agUiAyBnPWQXtm8=
+github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20260508054701-306e305bcf41
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0
+	github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368
 	github.com/pingcap/tidb v1.1.0-beta.0.20260715060322-10292a4f8697
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1452,8 +1452,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0 h1:MalBpLjhK/cS9ndCoSAg2C7aBzVojAqFVfzTKmuy0ho=
-github.com/pingcap/kvproto v0.0.0-20260622063236-b41e86365ce0/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
+github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368 h1:qW0gHsqY3X3qmyiEfESqpYSF3Vu7agUiAyBnPWQXtm8=
+github.com/pingcap/kvproto v0.0.0-20260721064811-683dad8fa368/go.mod h1:z6+aAHB7dBkA+LyinEX+48/ImRJ3jag0Hg0c7wkhEvE=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -427,6 +427,18 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 		"scan_detail: {total_process_keys: 20, total_process_keys_size: 20, total_keys: 30, get_snapshot_time: 1µs, " +
 		"rocksdb: {delete_skipped_count: 10, key_skipped_count: 2, block: {cache_hit_count: 20, read_count: 40, read_byte: 30 Bytes}}}"
 	s.Equal(expect, snapshot.FormatStats())
+
+	detail = &kvrpcpb.ExecDetailsV2{
+		ReadPoolTaskDetails: &kvrpcpb.PoolTaskDetails{
+			PollCount:     2,
+			DispatchCount: 1,
+		},
+	}
+	snapshot.MergeExecDetail(detail)
+	expect += ", read_pool:{tasks:1, poll_count:{total:2, avg:2, max:2, min:2}, " +
+		"dispatch_count:{total:1, max:1, min:1}, " +
+		"fair_queue:{enabled:false, waited_task_slices:{total:0, max:0, min:0}}}"
+	s.Equal(expect, snapshot.FormatStats())
 }
 
 func (s *testSnapshotSuite) TestRCRead() {

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -948,6 +948,12 @@ func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
 	}
 	s.mu.stats.scanDetail.MergeFromScanDetailV2(detail.ScanDetailV2)
 	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
+	if details := detail.GetReadPoolTaskDetails(); details != nil {
+		if s.mu.stats.readPoolTaskDetails == nil {
+			s.mu.stats.readPoolTaskDetails = &util.PoolTaskDetails{}
+		}
+		s.mu.stats.readPoolTaskDetails.MergeFromPB(details)
+	}
 }
 
 // Iter return a list of key-value pair after `k`.
@@ -1277,20 +1283,22 @@ func (s *KVSnapshot) SetPipelined(ts uint64) {
 
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats struct {
-	rpcStats          *locate.RegionRequestRuntimeStats
-	backoffSleepMS    map[string]int
-	backoffTimes      map[string]int
-	scanDetail        util.ScanDetail
-	timeDetail        util.TimeDetail
-	resolveLockDetail util.ResolveLockDetail
+	rpcStats            *locate.RegionRequestRuntimeStats
+	backoffSleepMS      map[string]int
+	backoffTimes        map[string]int
+	scanDetail          util.ScanDetail
+	timeDetail          util.TimeDetail
+	resolveLockDetail   util.ResolveLockDetail
+	readPoolTaskDetails *util.PoolTaskDetails
 }
 
 // Clone implements the RuntimeStats interface.
 func (rs *SnapshotRuntimeStats) Clone() *SnapshotRuntimeStats {
 	newRs := SnapshotRuntimeStats{
-		scanDetail:        rs.scanDetail,
-		timeDetail:        rs.timeDetail,
-		resolveLockDetail: rs.resolveLockDetail,
+		scanDetail:          rs.scanDetail,
+		timeDetail:          rs.timeDetail,
+		resolveLockDetail:   rs.resolveLockDetail,
+		readPoolTaskDetails: rs.readPoolTaskDetails.Clone(),
 	}
 	if rs.rpcStats != nil {
 		newRs.rpcStats = rs.rpcStats.Clone()
@@ -1333,6 +1341,13 @@ func (rs *SnapshotRuntimeStats) Merge(other *SnapshotRuntimeStats) {
 	rs.scanDetail.Merge(&other.scanDetail)
 	rs.timeDetail.Merge(&other.timeDetail)
 	rs.resolveLockDetail.Merge(&other.resolveLockDetail)
+	if !other.readPoolTaskDetails.Empty() {
+		if rs.readPoolTaskDetails == nil {
+			rs.readPoolTaskDetails = other.readPoolTaskDetails.Clone()
+		} else {
+			rs.readPoolTaskDetails.Merge(other.readPoolTaskDetails)
+		}
+	}
 }
 
 // String implements fmt.Stringer interface.
@@ -1369,12 +1384,24 @@ func (rs *SnapshotRuntimeStats) String() string {
 		buf.WriteString(", ")
 		buf.WriteString(scanDetail)
 	}
+	if !rs.readPoolTaskDetails.Empty() {
+		if buf.Len() > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString("read_pool:")
+		buf.WriteString(rs.readPoolTaskDetails.String())
+	}
 	return buf.String()
 }
 
 // GetTimeDetail returns the timeDetail
 func (rs *SnapshotRuntimeStats) GetTimeDetail() *util.TimeDetail {
 	return &rs.timeDetail
+}
+
+// GetReadPoolTaskDetails returns a copy of the aggregated read-pool task details.
+func (rs *SnapshotRuntimeStats) GetReadPoolTaskDetails() *util.PoolTaskDetails {
+	return rs.readPoolTaskDetails.Clone()
 }
 
 // GetCmdRPCCount returns the count of the corresponding kind of rpc requests

--- a/util/execdetails.go
+++ b/util/execdetails.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -455,6 +456,320 @@ func getUnit(d time.Duration) time.Duration {
 		return time.Microsecond
 	}
 	return time.Nanosecond
+}
+
+// PoolTaskDetails aggregates scheduling and execution details reported by
+// read-pool tasks.
+type PoolTaskDetails struct {
+	// TaskCount is the number of read-pool tasks whose details were reported.
+	TaskCount uint64 `json:"task_count"`
+	// PollCount is the sum of reported Future::poll counts.
+	PollCount uint64 `json:"poll_count"`
+	// MaxPollCount is the maximum reported Future::poll count in one sample.
+	MaxPollCount uint64 `json:"max_poll_count"`
+	// MinPollCount is the minimum reported Future::poll count in one sample.
+	MinPollCount uint64 `json:"min_poll_count"`
+	// DispatchCount is the sum of reported worker dispatch counts.
+	DispatchCount uint64 `json:"dispatch_count"`
+	// MaxDispatchCount is the maximum reported worker dispatch count in one sample.
+	MaxDispatchCount uint64 `json:"max_dispatch_count"`
+	// MinDispatchCount is the minimum reported worker dispatch count in one sample.
+	MinDispatchCount uint64 `json:"min_dispatch_count"`
+	// TotalWallTime is the sum of reported pool-task wall-time snapshots.
+	TotalWallTime time.Duration `json:"total_wall_time"`
+	// TaskWallTimeSampleCount is the number of samples with reported pool-task wall time.
+	TaskWallTimeSampleCount uint64 `json:"task_wall_time_sample_count"`
+	// MaxTaskWallTime is the maximum reported pool-task wall time in one sample.
+	MaxTaskWallTime time.Duration `json:"max_task_wall_time"`
+	// MinTaskWallTime is the minimum reported pool-task wall time in one sample.
+	MinTaskWallTime time.Duration `json:"min_task_wall_time"`
+	// TotalQueueWaitTime is the sum of reported ready-queue wait times.
+	TotalQueueWaitTime time.Duration `json:"total_queue_wait_time"`
+	// MaxQueueWaitTime is the maximum ready-queue wait time.
+	MaxQueueWaitTime time.Duration `json:"max_queue_wait_time"`
+	// MinQueueWaitTime is the minimum ready-queue wait time among recorded samples.
+	MinQueueWaitTime time.Duration `json:"min_queue_wait_time"`
+	// TotalWakeWaitTime is the sum of reported times from a pending poll to rescheduling.
+	TotalWakeWaitTime time.Duration `json:"total_wake_wait_time"`
+	// MaxWakeWaitTime is the maximum time from a pending poll to rescheduling.
+	MaxWakeWaitTime time.Duration `json:"max_wake_wait_time"`
+	// MinWakeWaitTime is the minimum time from a pending poll to rescheduling among recorded samples.
+	MinWakeWaitTime time.Duration `json:"min_wake_wait_time"`
+	// FairQueueSampleCount is the number of recorded fair-queue wait samples.
+	FairQueueSampleCount uint64 `json:"fair_queue_sample_count"`
+	// TotalFairQueueWaitedTaskSlices is the sum of reported task slices dispatched
+	// ahead of the sampled tasks while they waited in the fair queue.
+	TotalFairQueueWaitedTaskSlices uint64 `json:"total_fair_queue_waited_task_slices"`
+	// MaxFairQueueWaitedTaskSlices is the maximum number of task slices dispatched
+	// ahead of a sampled task during one fair-queue wait.
+	MaxFairQueueWaitedTaskSlices uint64 `json:"max_fair_queue_waited_task_slices"`
+	// MinFairQueueWaitedTaskSlices is the minimum number of task slices dispatched
+	// ahead of a sampled task during one fair-queue wait.
+	MinFairQueueWaitedTaskSlices uint64 `json:"min_fair_queue_waited_task_slices"`
+	// PollCPUTime is the sum of reported thread CPU time consumed by Future::poll calls.
+	PollCPUTime time.Duration `json:"poll_cpu_time"`
+	// MaxPollCPUTime is the maximum thread CPU time consumed by one Future::poll call.
+	MaxPollCPUTime time.Duration `json:"max_poll_cpu_time"`
+	// MinPollCPUTime is the minimum thread CPU time consumed by one Future::poll call.
+	MinPollCPUTime time.Duration `json:"min_poll_cpu_time"`
+	// PollWallTime is the sum of reported wall time consumed by Future::poll calls.
+	PollWallTime time.Duration `json:"poll_wall_time"`
+	// MinPollWallTime is the minimum wall time consumed by one Future::poll call.
+	MinPollWallTime time.Duration `json:"min_poll_wall_time"`
+	// MaxPollWallTime is the maximum wall time consumed by one Future::poll call.
+	MaxPollWallTime time.Duration `json:"max_poll_wall_time"`
+}
+
+// MergeFromPB merges one response's protobuf details into the aggregate.
+func (d *PoolTaskDetails) MergeFromPB(details *kvrpcpb.PoolTaskDetails) {
+	if d == nil || details == nil {
+		return
+	}
+	hadPollSamples := d.PollCount > 0
+	hadQueueWaitSamples := d.TotalQueueWaitTime > 0
+	hadWakeWaitSamples := d.TotalWakeWaitTime > 0
+	hadFairQueueSamples := d.FairQueueSampleCount > 0
+	hadTaskWallTimeSamples := d.TaskWallTimeSampleCount > 0
+	hadTasks := d.TaskCount > 0
+
+	d.TaskCount++
+	pollCount := details.GetPollCount()
+	d.PollCount += pollCount
+	d.MaxPollCount = max(d.MaxPollCount, pollCount)
+	d.MinPollCount = mergePoolTaskMinimum(d.MinPollCount, pollCount, hadTasks)
+	dispatchCount := details.GetDispatchCount()
+	d.DispatchCount += dispatchCount
+	d.MaxDispatchCount = max(d.MaxDispatchCount, dispatchCount)
+	d.MinDispatchCount = mergePoolTaskMinimum(d.MinDispatchCount, dispatchCount, hadTasks)
+	taskWallTime := time.Duration(details.GetTotalWallNanos())
+	d.TotalWallTime += taskWallTime
+	if taskWallTime > 0 {
+		d.TaskWallTimeSampleCount++
+		d.MaxTaskWallTime = max(d.MaxTaskWallTime, taskWallTime)
+		d.MinTaskWallTime = mergePoolTaskMinimum(d.MinTaskWallTime, taskWallTime, hadTaskWallTimeSamples)
+	}
+
+	d.TotalQueueWaitTime += time.Duration(details.GetTotalQueueWaitNanos())
+	d.MaxQueueWaitTime = max(d.MaxQueueWaitTime, time.Duration(details.GetMaxQueueWaitNanos()))
+	if details.GetTotalQueueWaitNanos() > 0 {
+		d.MinQueueWaitTime = mergePoolTaskMinimum(d.MinQueueWaitTime, time.Duration(details.GetMinQueueWaitNanos()), hadQueueWaitSamples)
+	}
+
+	d.TotalWakeWaitTime += time.Duration(details.GetTotalWakeWaitNanos())
+	d.MaxWakeWaitTime = max(d.MaxWakeWaitTime, time.Duration(details.GetMaxWakeWaitNanos()))
+	if details.GetTotalWakeWaitNanos() > 0 {
+		d.MinWakeWaitTime = mergePoolTaskMinimum(d.MinWakeWaitTime, time.Duration(details.GetMinWakeWaitNanos()), hadWakeWaitSamples)
+	}
+
+	if details.GetFairQueueEnabled() {
+		d.FairQueueSampleCount += dispatchCount
+		d.TotalFairQueueWaitedTaskSlices += details.GetTotalFairQueueWaitedTaskSlices()
+		d.MaxFairQueueWaitedTaskSlices = max(d.MaxFairQueueWaitedTaskSlices, details.GetMaxFairQueueWaitedTaskSlices())
+		d.MinFairQueueWaitedTaskSlices = mergePoolTaskMinimum(
+			d.MinFairQueueWaitedTaskSlices,
+			details.GetMinFairQueueWaitedTaskSlices(),
+			hadFairQueueSamples,
+		)
+	}
+
+	d.PollCPUTime += time.Duration(details.GetPollCpuNanos())
+	d.MaxPollCPUTime = max(d.MaxPollCPUTime, time.Duration(details.GetMaxPollCpuNanos()))
+	d.PollWallTime += time.Duration(details.GetPollWallNanos())
+	d.MaxPollWallTime = max(d.MaxPollWallTime, time.Duration(details.GetMaxPollWallNanos()))
+	if details.GetPollCount() > 0 {
+		d.MinPollCPUTime = mergePoolTaskMinimum(d.MinPollCPUTime, time.Duration(details.GetMinPollCpuNanos()), hadPollSamples)
+		d.MinPollWallTime = mergePoolTaskMinimum(d.MinPollWallTime, time.Duration(details.GetMinPollWallNanos()), hadPollSamples)
+	}
+}
+
+// Merge merges another aggregate into d.
+func (d *PoolTaskDetails) Merge(other *PoolTaskDetails) {
+	if d == nil || other == nil || other.Empty() {
+		return
+	}
+	hadPollSamples := d.PollCount > 0
+	hadQueueWaitSamples := d.TotalQueueWaitTime > 0
+	hadWakeWaitSamples := d.TotalWakeWaitTime > 0
+	hadFairQueueSamples := d.FairQueueSampleCount > 0
+	hadTaskWallTimeSamples := d.TaskWallTimeSampleCount > 0
+	hadTasks := d.TaskCount > 0
+
+	d.TaskCount += other.TaskCount
+	d.PollCount += other.PollCount
+	d.MaxPollCount = max(d.MaxPollCount, other.MaxPollCount)
+	d.MinPollCount = mergePoolTaskMinimum(d.MinPollCount, other.MinPollCount, hadTasks)
+	d.DispatchCount += other.DispatchCount
+	d.MaxDispatchCount = max(d.MaxDispatchCount, other.MaxDispatchCount)
+	d.MinDispatchCount = mergePoolTaskMinimum(d.MinDispatchCount, other.MinDispatchCount, hadTasks)
+	d.TotalWallTime += other.TotalWallTime
+	d.TaskWallTimeSampleCount += other.TaskWallTimeSampleCount
+	d.MaxTaskWallTime = max(d.MaxTaskWallTime, other.MaxTaskWallTime)
+	if other.TotalWallTime > 0 {
+		d.MinTaskWallTime = mergePoolTaskMinimum(d.MinTaskWallTime, other.MinTaskWallTime, hadTaskWallTimeSamples)
+	}
+	d.TotalQueueWaitTime += other.TotalQueueWaitTime
+	d.MaxQueueWaitTime = max(d.MaxQueueWaitTime, other.MaxQueueWaitTime)
+	if other.TotalQueueWaitTime > 0 {
+		d.MinQueueWaitTime = mergePoolTaskMinimum(d.MinQueueWaitTime, other.MinQueueWaitTime, hadQueueWaitSamples)
+	}
+	d.TotalWakeWaitTime += other.TotalWakeWaitTime
+	d.MaxWakeWaitTime = max(d.MaxWakeWaitTime, other.MaxWakeWaitTime)
+	if other.TotalWakeWaitTime > 0 {
+		d.MinWakeWaitTime = mergePoolTaskMinimum(d.MinWakeWaitTime, other.MinWakeWaitTime, hadWakeWaitSamples)
+	}
+	d.FairQueueSampleCount += other.FairQueueSampleCount
+	d.TotalFairQueueWaitedTaskSlices += other.TotalFairQueueWaitedTaskSlices
+	d.MaxFairQueueWaitedTaskSlices = max(d.MaxFairQueueWaitedTaskSlices, other.MaxFairQueueWaitedTaskSlices)
+	if other.FairQueueSampleCount > 0 {
+		d.MinFairQueueWaitedTaskSlices = mergePoolTaskMinimum(
+			d.MinFairQueueWaitedTaskSlices,
+			other.MinFairQueueWaitedTaskSlices,
+			hadFairQueueSamples,
+		)
+	}
+	d.PollCPUTime += other.PollCPUTime
+	d.MaxPollCPUTime = max(d.MaxPollCPUTime, other.MaxPollCPUTime)
+	d.PollWallTime += other.PollWallTime
+	d.MaxPollWallTime = max(d.MaxPollWallTime, other.MaxPollWallTime)
+	if other.PollCount > 0 {
+		d.MinPollCPUTime = mergePoolTaskMinimum(d.MinPollCPUTime, other.MinPollCPUTime, hadPollSamples)
+		d.MinPollWallTime = mergePoolTaskMinimum(d.MinPollWallTime, other.MinPollWallTime, hadPollSamples)
+	}
+}
+
+// Clone returns an independent copy of d.
+func (d *PoolTaskDetails) Clone() *PoolTaskDetails {
+	if d == nil {
+		return nil
+	}
+	clone := *d
+	return &clone
+}
+
+// Empty reports whether no pool-task details were collected.
+func (d *PoolTaskDetails) Empty() bool {
+	return d == nil || d.TaskCount == 0
+}
+
+// String returns a compact human-readable representation of the aggregate.
+func (d *PoolTaskDetails) String() string {
+	if d.Empty() {
+		return ""
+	}
+	var buf strings.Builder
+	buf.WriteString("{tasks:")
+	buf.WriteString(strconv.FormatUint(d.TaskCount, 10))
+	writePoolTaskCountStats(&buf, "poll_count", d.PollCount, d.TaskCount, d.MaxPollCount, d.MinPollCount)
+	writePoolTaskCountStats(&buf, "dispatch_count", d.DispatchCount, 0, d.MaxDispatchCount, d.MinDispatchCount)
+	writePoolTaskTimeStats(
+		&buf,
+		"task_wall_time",
+		d.TotalWallTime,
+		d.TaskWallTimeSampleCount,
+		d.MaxTaskWallTime,
+		d.MinTaskWallTime,
+	)
+	writePoolTaskTimeStats(
+		&buf,
+		"queue_wait",
+		d.TotalQueueWaitTime,
+		d.DispatchCount,
+		d.MaxQueueWaitTime,
+		d.MinQueueWaitTime,
+	)
+	wakeWaitCount := uint64(0)
+	if d.DispatchCount > d.TaskCount {
+		// Each task has one initial dispatch, which
+		// has no preceding pending-to-wake interval.
+		wakeWaitCount = d.DispatchCount - d.TaskCount
+	}
+	writePoolTaskTimeStats(
+		&buf,
+		"wake_wait",
+		d.TotalWakeWaitTime,
+		wakeWaitCount,
+		d.MaxWakeWaitTime,
+		d.MinWakeWaitTime,
+	)
+	buf.WriteString(", fair_queue:{enabled:")
+	buf.WriteString(strconv.FormatBool(d.FairQueueSampleCount > 0))
+	buf.WriteString(", waited_task_slices:{total:")
+	buf.WriteString(strconv.FormatUint(d.TotalFairQueueWaitedTaskSlices, 10))
+	if d.FairQueueSampleCount > 0 {
+		buf.WriteString(", avg:")
+		buf.WriteString(formatPoolTaskAverage(d.TotalFairQueueWaitedTaskSlices, d.FairQueueSampleCount))
+	}
+	buf.WriteString(", max:")
+	buf.WriteString(strconv.FormatUint(d.MaxFairQueueWaitedTaskSlices, 10))
+	buf.WriteString(", min:")
+	buf.WriteString(strconv.FormatUint(d.MinFairQueueWaitedTaskSlices, 10))
+	buf.WriteString("}}")
+	writePoolTaskTimeStats(&buf, "poll_cpu", d.PollCPUTime, d.PollCount, d.MaxPollCPUTime, d.MinPollCPUTime)
+	writePoolTaskTimeStats(&buf, "poll_wall", d.PollWallTime, d.PollCount, d.MaxPollWallTime, d.MinPollWallTime)
+	buf.WriteByte('}')
+	return buf.String()
+}
+
+func writePoolTaskCountStats(
+	buf *strings.Builder,
+	name string,
+	total uint64,
+	averageDivisor uint64,
+	maxCount uint64,
+	minCount uint64,
+) {
+	buf.WriteString(", ")
+	buf.WriteString(name)
+	buf.WriteString(":{total:")
+	buf.WriteString(strconv.FormatUint(total, 10))
+	if averageDivisor > 0 {
+		buf.WriteString(", avg:")
+		buf.WriteString(formatPoolTaskAverage(total, averageDivisor))
+	}
+	buf.WriteString(", max:")
+	buf.WriteString(strconv.FormatUint(maxCount, 10))
+	buf.WriteString(", min:")
+	buf.WriteString(strconv.FormatUint(minCount, 10))
+	buf.WriteByte('}')
+}
+
+func formatPoolTaskAverage(total, count uint64) string {
+	average := strconv.FormatFloat(float64(total)/float64(count), 'f', 2, 64)
+	average = strings.TrimRight(average, "0")
+	return strings.TrimRight(average, ".")
+}
+
+func writePoolTaskTimeStats(
+	buf *strings.Builder,
+	name string,
+	total time.Duration,
+	sampleCount uint64,
+	maxTime time.Duration,
+	minTime time.Duration,
+) {
+	if total == 0 {
+		return
+	}
+	buf.WriteString(", ")
+	buf.WriteString(name)
+	buf.WriteString(":{total:")
+	buf.WriteString(FormatDuration(total))
+	if sampleCount > 0 {
+		buf.WriteString(", avg:")
+		buf.WriteString(FormatDuration(total / time.Duration(sampleCount)))
+	}
+	buf.WriteString(", max:")
+	buf.WriteString(FormatDuration(maxTime))
+	buf.WriteString(", min:")
+	buf.WriteString(FormatDuration(minTime))
+	buf.WriteByte('}')
+}
+
+func mergePoolTaskMinimum[T time.Duration | uint64](current, candidate T, hasCurrent bool) T {
+	if !hasCurrent || candidate < current {
+		return candidate
+	}
+	return current
 }
 
 // ScanDetail contains coprocessor scan detail information.

--- a/util/execdetails_test.go
+++ b/util/execdetails_test.go
@@ -87,6 +87,402 @@ func TestRUDetailsCloneAndMergeRawRUV2(t *testing.T) {
 	assert.Equal(t, uint64(7), rightDrained.WriteRpcCount)
 }
 
+func TestPoolTaskDetailsStringUsesAverageTimes(t *testing.T) {
+	details := &PoolTaskDetails{
+		TaskCount:                      2,
+		PollCount:                      8,
+		MaxPollCount:                   5,
+		MinPollCount:                   3,
+		DispatchCount:                  6,
+		MaxDispatchCount:               4,
+		MinDispatchCount:               2,
+		TotalWallTime:                  20 * time.Millisecond,
+		TaskWallTimeSampleCount:        2,
+		MaxTaskWallTime:                12 * time.Millisecond,
+		MinTaskWallTime:                8 * time.Millisecond,
+		TotalQueueWaitTime:             12 * time.Millisecond,
+		MaxQueueWaitTime:               4 * time.Millisecond,
+		MinQueueWaitTime:               time.Millisecond,
+		TotalWakeWaitTime:              8 * time.Millisecond,
+		MaxWakeWaitTime:                3 * time.Millisecond,
+		MinWakeWaitTime:                time.Millisecond,
+		FairQueueSampleCount:           6,
+		TotalFairQueueWaitedTaskSlices: 18,
+		MaxFairQueueWaitedTaskSlices:   5,
+		MinFairQueueWaitedTaskSlices:   2,
+		PollCPUTime:                    8 * time.Millisecond,
+		MaxPollCPUTime:                 2 * time.Millisecond,
+		MinPollCPUTime:                 500 * time.Microsecond,
+		PollWallTime:                   12 * time.Millisecond,
+		MaxPollWallTime:                3 * time.Millisecond,
+		MinPollWallTime:                750 * time.Microsecond,
+	}
+
+	assert.Equal(t,
+		"{tasks:2, poll_count:{total:8, avg:4, max:5, min:3}, "+
+			"dispatch_count:{total:6, max:4, min:2}, "+
+			"task_wall_time:{total:20ms, avg:10ms, max:12ms, min:8ms}, "+
+			"queue_wait:{total:12ms, avg:2ms, max:4ms, min:1ms}, "+
+			"wake_wait:{total:8ms, avg:2ms, max:3ms, min:1ms}, "+
+			"fair_queue:{enabled:true, "+
+			"waited_task_slices:{total:18, avg:3, max:5, min:2}}, "+
+			"poll_cpu:{total:8ms, avg:1ms, max:2ms, min:500\u00b5s}, "+
+			"poll_wall:{total:12ms, avg:1.5ms, max:3ms, min:750\u00b5s}}",
+		details.String(),
+	)
+}
+
+func TestPoolTaskDetailsStringOmitsZeroTimes(t *testing.T) {
+	details := &PoolTaskDetails{
+		TaskCount:        1,
+		PollCount:        2,
+		MaxPollCount:     2,
+		MinPollCount:     2,
+		DispatchCount:    2,
+		MaxDispatchCount: 2,
+		MinDispatchCount: 2,
+	}
+
+	assert.Equal(t,
+		"{tasks:1, poll_count:{total:2, avg:2, max:2, min:2}, "+
+			"dispatch_count:{total:2, max:2, min:2}, "+
+			"fair_queue:{enabled:false, waited_task_slices:{total:0, max:0, min:0}}}",
+		details.String(),
+	)
+}
+
+func TestPoolTaskDetailsStringOmitsAverageWithNoSamples(t *testing.T) {
+	details := &PoolTaskDetails{
+		TaskCount:          1,
+		TotalQueueWaitTime: 2 * time.Millisecond,
+		MaxQueueWaitTime:   2 * time.Millisecond,
+		MinQueueWaitTime:   2 * time.Millisecond,
+	}
+
+	assert.Equal(t,
+		"{tasks:1, poll_count:{total:0, avg:0, max:0, min:0}, "+
+			"dispatch_count:{total:0, max:0, min:0}, "+
+			"queue_wait:{total:2ms, max:2ms, min:2ms}, "+
+			"fair_queue:{enabled:false, waited_task_slices:{total:0, max:0, min:0}}}",
+		details.String(),
+	)
+}
+
+func TestPoolTaskDetailsMergeFromPBAndMerge(t *testing.T) {
+	details := &PoolTaskDetails{}
+	details.MergeFromPB(&kvrpcpb.PoolTaskDetails{
+		PollCount:                      5,
+		DispatchCount:                  3,
+		TotalWallNanos:                 uint64((10 * time.Millisecond).Nanoseconds()),
+		TotalQueueWaitNanos:            uint64((6 * time.Millisecond).Nanoseconds()),
+		MaxQueueWaitNanos:              uint64((3 * time.Millisecond).Nanoseconds()),
+		MinQueueWaitNanos:              uint64(time.Millisecond.Nanoseconds()),
+		TotalWakeWaitNanos:             uint64((4 * time.Millisecond).Nanoseconds()),
+		MaxWakeWaitNanos:               uint64((3 * time.Millisecond).Nanoseconds()),
+		MinWakeWaitNanos:               uint64(time.Millisecond.Nanoseconds()),
+		FairQueueEnabled:               true,
+		TotalFairQueueWaitedTaskSlices: 9,
+		MaxFairQueueWaitedTaskSlices:   5,
+		MinFairQueueWaitedTaskSlices:   1,
+		PollCpuNanos:                   uint64((5 * time.Millisecond).Nanoseconds()),
+		MaxPollCpuNanos:                uint64((2 * time.Millisecond).Nanoseconds()),
+		MinPollCpuNanos:                uint64((500 * time.Microsecond).Nanoseconds()),
+		PollWallNanos:                  uint64((8 * time.Millisecond).Nanoseconds()),
+		MaxPollWallNanos:               uint64((4 * time.Millisecond).Nanoseconds()),
+		MinPollWallNanos:               uint64(time.Millisecond.Nanoseconds()),
+	})
+	details.MergeFromPB(&kvrpcpb.PoolTaskDetails{
+		PollCount:                      2,
+		DispatchCount:                  1,
+		TotalQueueWaitNanos:            uint64((2 * time.Millisecond).Nanoseconds()),
+		MaxQueueWaitNanos:              uint64((2 * time.Millisecond).Nanoseconds()),
+		MinQueueWaitNanos:              uint64((2 * time.Millisecond).Nanoseconds()),
+		FairQueueEnabled:               false,
+		TotalFairQueueWaitedTaskSlices: 100,
+		MaxFairQueueWaitedTaskSlices:   100,
+		MinFairQueueWaitedTaskSlices:   100,
+		PollCpuNanos:                   uint64((2 * time.Millisecond).Nanoseconds()),
+		MaxPollCpuNanos:                uint64((1500 * time.Microsecond).Nanoseconds()),
+		MinPollCpuNanos:                uint64((400 * time.Microsecond).Nanoseconds()),
+		PollWallNanos:                  uint64((3 * time.Millisecond).Nanoseconds()),
+		MaxPollWallNanos:               uint64((2 * time.Millisecond).Nanoseconds()),
+		MinPollWallNanos:               uint64((800 * time.Microsecond).Nanoseconds()),
+	})
+
+	assert.Equal(t, &PoolTaskDetails{
+		TaskCount:                      2,
+		PollCount:                      7,
+		MaxPollCount:                   5,
+		MinPollCount:                   2,
+		DispatchCount:                  4,
+		MaxDispatchCount:               3,
+		MinDispatchCount:               1,
+		TotalWallTime:                  10 * time.Millisecond,
+		TaskWallTimeSampleCount:        1,
+		MaxTaskWallTime:                10 * time.Millisecond,
+		MinTaskWallTime:                10 * time.Millisecond,
+		TotalQueueWaitTime:             8 * time.Millisecond,
+		MaxQueueWaitTime:               3 * time.Millisecond,
+		MinQueueWaitTime:               time.Millisecond,
+		TotalWakeWaitTime:              4 * time.Millisecond,
+		MaxWakeWaitTime:                3 * time.Millisecond,
+		MinWakeWaitTime:                time.Millisecond,
+		FairQueueSampleCount:           3,
+		TotalFairQueueWaitedTaskSlices: 9,
+		MaxFairQueueWaitedTaskSlices:   5,
+		MinFairQueueWaitedTaskSlices:   1,
+		PollCPUTime:                    7 * time.Millisecond,
+		MaxPollCPUTime:                 2 * time.Millisecond,
+		MinPollCPUTime:                 400 * time.Microsecond,
+		PollWallTime:                   11 * time.Millisecond,
+		MaxPollWallTime:                4 * time.Millisecond,
+		MinPollWallTime:                800 * time.Microsecond,
+	}, details)
+
+	other := &PoolTaskDetails{}
+	other.MergeFromPB(&kvrpcpb.PoolTaskDetails{
+		PollCount:                      8,
+		DispatchCount:                  4,
+		TotalWallNanos:                 uint64((20 * time.Millisecond).Nanoseconds()),
+		TotalQueueWaitNanos:            uint64((12 * time.Millisecond).Nanoseconds()),
+		MaxQueueWaitNanos:              uint64((5 * time.Millisecond).Nanoseconds()),
+		MinQueueWaitNanos:              uint64((2 * time.Millisecond).Nanoseconds()),
+		TotalWakeWaitNanos:             uint64((6 * time.Millisecond).Nanoseconds()),
+		MaxWakeWaitNanos:               uint64((4 * time.Millisecond).Nanoseconds()),
+		MinWakeWaitNanos:               uint64((2 * time.Millisecond).Nanoseconds()),
+		FairQueueEnabled:               true,
+		TotalFairQueueWaitedTaskSlices: 8,
+		MaxFairQueueWaitedTaskSlices:   4,
+		MinFairQueueWaitedTaskSlices:   0,
+		PollCpuNanos:                   uint64((8 * time.Millisecond).Nanoseconds()),
+		MaxPollCpuNanos:                uint64((3 * time.Millisecond).Nanoseconds()),
+		MinPollCpuNanos:                uint64((300 * time.Microsecond).Nanoseconds()),
+		PollWallNanos:                  uint64((10 * time.Millisecond).Nanoseconds()),
+		MaxPollWallNanos:               uint64((5 * time.Millisecond).Nanoseconds()),
+		MinPollWallNanos:               uint64((700 * time.Microsecond).Nanoseconds()),
+	})
+	details.Merge(other)
+
+	assert.Equal(t, &PoolTaskDetails{
+		TaskCount:                      3,
+		PollCount:                      15,
+		MaxPollCount:                   8,
+		MinPollCount:                   2,
+		DispatchCount:                  8,
+		MaxDispatchCount:               4,
+		MinDispatchCount:               1,
+		TotalWallTime:                  30 * time.Millisecond,
+		TaskWallTimeSampleCount:        2,
+		MaxTaskWallTime:                20 * time.Millisecond,
+		MinTaskWallTime:                10 * time.Millisecond,
+		TotalQueueWaitTime:             20 * time.Millisecond,
+		MaxQueueWaitTime:               5 * time.Millisecond,
+		MinQueueWaitTime:               time.Millisecond,
+		TotalWakeWaitTime:              10 * time.Millisecond,
+		MaxWakeWaitTime:                4 * time.Millisecond,
+		MinWakeWaitTime:                time.Millisecond,
+		FairQueueSampleCount:           7,
+		TotalFairQueueWaitedTaskSlices: 17,
+		MaxFairQueueWaitedTaskSlices:   5,
+		MinFairQueueWaitedTaskSlices:   0,
+		PollCPUTime:                    15 * time.Millisecond,
+		MaxPollCPUTime:                 3 * time.Millisecond,
+		MinPollCPUTime:                 300 * time.Microsecond,
+		PollWallTime:                   21 * time.Millisecond,
+		MaxPollWallTime:                5 * time.Millisecond,
+		MinPollWallTime:                700 * time.Microsecond,
+	}, details)
+}
+
+func TestPoolTaskDetailsMergeMinimumPresence(t *testing.T) {
+	mergeSequentiallyAndByAggregate := func(
+		t *testing.T,
+		first *kvrpcpb.PoolTaskDetails,
+		second *kvrpcpb.PoolTaskDetails,
+	) *PoolTaskDetails {
+		t.Helper()
+
+		sequential := &PoolTaskDetails{}
+		sequential.MergeFromPB(first)
+		sequential.MergeFromPB(second)
+
+		left := &PoolTaskDetails{}
+		left.MergeFromPB(first)
+		right := &PoolTaskDetails{}
+		right.MergeFromPB(second)
+		left.Merge(right)
+
+		assert.Equal(t, sequential, left)
+		return sequential
+	}
+
+	t.Run("absent wait samples do not pin minimum to zero", func(t *testing.T) {
+		details := mergeSequentiallyAndByAggregate(t,
+			&kvrpcpb.PoolTaskDetails{
+				PollCount:       2,
+				DispatchCount:   1,
+				TotalWallNanos:  uint64((3 * time.Millisecond).Nanoseconds()),
+				PollCpuNanos:    uint64(time.Millisecond.Nanoseconds()),
+				MaxPollCpuNanos: uint64(time.Millisecond.Nanoseconds()),
+				PollWallNanos:   uint64((2 * time.Millisecond).Nanoseconds()),
+				MaxPollWallNanos: uint64(
+					(2 * time.Millisecond).Nanoseconds(),
+				),
+			},
+			&kvrpcpb.PoolTaskDetails{
+				PollCount:                      3,
+				DispatchCount:                  2,
+				TotalWallNanos:                 uint64((25 * time.Millisecond).Nanoseconds()),
+				TotalQueueWaitNanos:            uint64((10 * time.Millisecond).Nanoseconds()),
+				MaxQueueWaitNanos:              uint64((7 * time.Millisecond).Nanoseconds()),
+				MinQueueWaitNanos:              uint64((3 * time.Millisecond).Nanoseconds()),
+				TotalWakeWaitNanos:             uint64((2 * time.Millisecond).Nanoseconds()),
+				MaxWakeWaitNanos:               uint64((2 * time.Millisecond).Nanoseconds()),
+				MinWakeWaitNanos:               uint64((2 * time.Millisecond).Nanoseconds()),
+				FairQueueEnabled:               true,
+				TotalFairQueueWaitedTaskSlices: 4,
+				MaxFairQueueWaitedTaskSlices:   3,
+				MinFairQueueWaitedTaskSlices:   1,
+				PollCpuNanos:                   uint64((6 * time.Millisecond).Nanoseconds()),
+				MaxPollCpuNanos:                uint64((3 * time.Millisecond).Nanoseconds()),
+				MinPollCpuNanos:                uint64(time.Millisecond.Nanoseconds()),
+				PollWallNanos:                  uint64((9 * time.Millisecond).Nanoseconds()),
+				MaxPollWallNanos:               uint64((4 * time.Millisecond).Nanoseconds()),
+				MinPollWallNanos:               uint64((2 * time.Millisecond).Nanoseconds()),
+			},
+		)
+
+		assert.Equal(t, 3*time.Millisecond, details.MinQueueWaitTime)
+		assert.Equal(t, 2*time.Millisecond, details.MinWakeWaitTime)
+		assert.Equal(t, uint64(1), details.MinFairQueueWaitedTaskSlices)
+		// The first response contains a poll sample, so its zero-valued CPU and
+		// wall-time minima are real samples rather than missing values.
+		assert.Zero(t, details.MinPollCPUTime)
+		assert.Zero(t, details.MinPollWallTime)
+	})
+
+	t.Run("recorded zero minimum remains zero", func(t *testing.T) {
+		details := mergeSequentiallyAndByAggregate(t,
+			&kvrpcpb.PoolTaskDetails{
+				PollCount:                      3,
+				DispatchCount:                  3,
+				TotalWallNanos:                 uint64((10 * time.Millisecond).Nanoseconds()),
+				TotalQueueWaitNanos:            uint64(time.Millisecond.Nanoseconds()),
+				MaxQueueWaitNanos:              uint64(time.Millisecond.Nanoseconds()),
+				MinQueueWaitNanos:              0,
+				TotalWakeWaitNanos:             uint64(time.Millisecond.Nanoseconds()),
+				MaxWakeWaitNanos:               uint64(time.Millisecond.Nanoseconds()),
+				MinWakeWaitNanos:               0,
+				FairQueueEnabled:               true,
+				TotalFairQueueWaitedTaskSlices: 0,
+				MaxFairQueueWaitedTaskSlices:   0,
+				MinFairQueueWaitedTaskSlices:   0,
+				PollCpuNanos:                   uint64(time.Millisecond.Nanoseconds()),
+				MaxPollCpuNanos:                uint64(time.Millisecond.Nanoseconds()),
+				MinPollCpuNanos:                0,
+				PollWallNanos:                  uint64(time.Millisecond.Nanoseconds()),
+				MaxPollWallNanos:               uint64(time.Millisecond.Nanoseconds()),
+				MinPollWallNanos:               0,
+			},
+			&kvrpcpb.PoolTaskDetails{
+				PollCount:                      2,
+				DispatchCount:                  2,
+				TotalWallNanos:                 uint64((10 * time.Millisecond).Nanoseconds()),
+				TotalQueueWaitNanos:            uint64((4 * time.Millisecond).Nanoseconds()),
+				MaxQueueWaitNanos:              uint64((3 * time.Millisecond).Nanoseconds()),
+				MinQueueWaitNanos:              uint64(time.Millisecond.Nanoseconds()),
+				TotalWakeWaitNanos:             uint64(time.Millisecond.Nanoseconds()),
+				MaxWakeWaitNanos:               uint64(time.Millisecond.Nanoseconds()),
+				MinWakeWaitNanos:               uint64(time.Millisecond.Nanoseconds()),
+				FairQueueEnabled:               true,
+				TotalFairQueueWaitedTaskSlices: 3,
+				MaxFairQueueWaitedTaskSlices:   2,
+				MinFairQueueWaitedTaskSlices:   1,
+				PollCpuNanos:                   uint64((2 * time.Millisecond).Nanoseconds()),
+				MaxPollCpuNanos:                uint64(time.Millisecond.Nanoseconds()),
+				MinPollCpuNanos:                uint64(time.Millisecond.Nanoseconds()),
+				PollWallNanos:                  uint64((2 * time.Millisecond).Nanoseconds()),
+				MaxPollWallNanos:               uint64(time.Millisecond.Nanoseconds()),
+				MinPollWallNanos:               uint64(time.Millisecond.Nanoseconds()),
+			},
+		)
+
+		assert.Zero(t, details.MinQueueWaitTime)
+		assert.Zero(t, details.MinWakeWaitTime)
+		assert.Zero(t, details.MinFairQueueWaitedTaskSlices)
+		assert.Zero(t, details.MinPollCPUTime)
+		assert.Zero(t, details.MinPollWallTime)
+	})
+}
+
+func TestPoolTaskDetailsStringFormatsFractionalCountAverages(t *testing.T) {
+	details := &PoolTaskDetails{
+		TaskCount:                      3,
+		PollCount:                      8,
+		MaxPollCount:                   5,
+		MinPollCount:                   1,
+		DispatchCount:                  3,
+		MaxDispatchCount:               1,
+		MinDispatchCount:               1,
+		FairQueueSampleCount:           3,
+		TotalFairQueueWaitedTaskSlices: 7,
+		MaxFairQueueWaitedTaskSlices:   4,
+		MinFairQueueWaitedTaskSlices:   0,
+	}
+
+	assert.Equal(t,
+		"{tasks:3, poll_count:{total:8, avg:2.67, max:5, min:1}, "+
+			"dispatch_count:{total:3, max:1, min:1}, "+
+			"fair_queue:{enabled:true, waited_task_slices:{total:7, avg:2.33, max:4, min:0}}}",
+		details.String(),
+	)
+}
+
+func TestPoolTaskDetailsStringKeepsZeroFairQueueWait(t *testing.T) {
+	details := &PoolTaskDetails{
+		TaskCount:            1,
+		PollCount:            2,
+		MaxPollCount:         2,
+		MinPollCount:         2,
+		DispatchCount:        2,
+		MaxDispatchCount:     2,
+		MinDispatchCount:     2,
+		FairQueueSampleCount: 2,
+	}
+
+	assert.Equal(t,
+		"{tasks:1, poll_count:{total:2, avg:2, max:2, min:2}, "+
+			"dispatch_count:{total:2, max:2, min:2}, "+
+			"fair_queue:{enabled:true, waited_task_slices:{total:0, avg:0, max:0, min:0}}}",
+		details.String(),
+	)
+}
+
+func TestPoolTaskDetailsEmptyAndClone(t *testing.T) {
+	var nilDetails *PoolTaskDetails
+	assert.True(t, nilDetails.Empty())
+	assert.Empty(t, nilDetails.String())
+	assert.Nil(t, nilDetails.Clone())
+
+	details := &PoolTaskDetails{}
+	details.MergeFromPB(nil)
+	assert.True(t, details.Empty())
+
+	details.MergeFromPB(&kvrpcpb.PoolTaskDetails{PollCount: 1, DispatchCount: 1})
+	assert.False(t, details.Empty())
+
+	clone := details.Clone()
+	assert.Equal(t, details, clone)
+	assert.NotSame(t, details, clone)
+	clone.PollCount++
+	assert.NotEqual(t, details.PollCount, clone.PollCount)
+
+	beforeMerge := details.Clone()
+	details.Merge(nil)
+	details.Merge(&PoolTaskDetails{})
+	assert.Equal(t, beforeMerge, details)
+}
+
 func TestScanDetailMergeFromScanDetailV2IncludesIAFields(t *testing.T) {
 	scanDetail := &kvrpcpb.ScanDetailV2{
 		ProcessedVersions:         10,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/tidbcloud/cloud-storage-engine/issues/5480

Problem Summary:

TiKV/CSE can now return optional request-level read-pool scheduling and execution metrics in `ExecDetailsV2.read_pool_task_details`. client-go currently drops these details, so TiDB and other downstream consumers cannot include read-pool queueing, wakeup, dispatch/poll, and CPU/wall-time breakdowns in snapshot runtime diagnostics.

### What is changed and how it works?

- Bump kvproto to the revision that adds `PoolTaskDetails` to `ExecDetailsV2`.
- Add `util.PoolTaskDetails` to aggregate reported task samples, including:
  - task, poll, and dispatch counts;
  - task wall time, queue wait, wake wait, and poll CPU/wall time;
  - total, minimum, and maximum values;
  - fair-queue waited-task-slice statistics.
- Merge `read_pool_task_details` from responses into `SnapshotRuntimeStats`.
- Support cloning, merging, empty checks, and compact string formatting for the aggregate.
- Expose `GetReadPoolTaskDetails()` as a defensive copy so callers cannot mutate the stored runtime stats.
- Keep the field lazy and backward-compatible: responses from older servers do not allocate or print empty read-pool statistics.
- Refresh root, integration-test, and example module metadata for the new kvproto revision.

The aggregation operates on reported response samples because the protobuf currently carries no task identity or delta information.

### Check List

- [x] Unit tests
  - `go test ./util ./txnkv/txnsnapshot`
  - `go test --tags=intest ./util ./txnkv/txnsnapshot`
- [x] Backward compatibility
  - The protobuf field is additive and optional.
  - Existing behavior is unchanged when `read_pool_task_details` is absent.

### Related changes

- https://github.com/pingcap/kvproto/pull/1502
- https://github.com/tidbcloud/cloud-storage-engine/pull/5646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced snapshot runtime statistics to include read-pool task details (poll/dispatch and related timing/wait metrics).
  * Added aggregation support so read-pool details can be merged, cloned, formatted, and retrieved from runtime stats.
* **Maintenance**
  * Bumped Go toolchain and refreshed several indirect module versions across examples and integration.
  * Updated the primary kv-proto dependency revision.
* **Tests**
  * Added unit and integration test coverage for read-pool metric aggregation, formatting, merge/clone behavior, and empty-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
