### PR TITLE
resourcecontrol: settle batched cop tasks' execution details

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -203,15 +203,29 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	}
 	// Parse the response to extract the info.
 	var (
-		readBytes uint64
-		detailsV2 *kvrpcpb.ExecDetailsV2
-		details   *kvrpcpb.ExecDetails
+		readBytes        uint64
+		detailsV2        *kvrpcpb.ExecDetailsV2
+		details          *kvrpcpb.ExecDetails
+		batchedReadBytes uint64
+		batchedKVCPU     time.Duration
 	)
 	switch r := resp.Resp.(type) {
 	case *coprocessor.Response:
 		detailsV2 = r.GetExecDetailsV2()
 		details = r.GetExecDetails()
 		readBytes = uint64(r.Data.Size())
+		// A batched coprocessor request answers several tasks in one response.
+		// Each nested response carries execution details that are not included
+		// in the top-level details, so account for every nested task.
+		for _, batchResp := range r.GetBatchResponses() {
+			batchDetailsV2 := batchResp.GetExecDetailsV2()
+			batchReadBytes := uint64(batchResp.Data.Size())
+			if scanDetail := batchDetailsV2.GetScanDetailV2(); scanDetail != nil {
+				batchReadBytes = scanDetailReadBytes(scanDetail)
+			}
+			batchedReadBytes += batchReadBytes
+			batchedKVCPU += getKVCPU(batchDetailsV2, nil)
+		}
 	case *tikvrpc.CopStreamResponse:
 		// Streaming request returns `io.EOF``, so the first `CopStreamResponse.Response`` may be nil.
 		if r.Response != nil {
@@ -232,35 +246,39 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	// Try to get read bytes from the `detailsV2`.
 	// TODO: clarify whether we should count the underlying storage engine read bytes or not.
 	if scanDetail := detailsV2.GetScanDetailV2(); scanDetail != nil {
-		if config.NextGen {
-			// Using the total versions size as the read bytes, which includes not
-			// only processed versions size, but also skipped MVCC versions size.
-			// It can reflect the actual read bytes more accurately, especially for
-			// the request with a large number of MVCC versions.
-			//
-			// For compatibility with older versions of TiKV, if the
-			// processed versions size is greater than the total versions size,
-			// we use the processed versions size as the read bytes.
-			readBytes = max(scanDetail.GetTotalVersionsSize(), scanDetail.GetProcessedVersionsSize())
-		} else {
-			// NOTE: The original design intended to account for all MVCC read
-			// overhead, but TotalVersionsSize did not exist at the time, so
-			// ProcessedVersionsSize was used instead, which only counts the
-			// versions that are actually processed and excludes skipped MVCC
-			// versions. Since this behavior has already been released, switching
-			// to TotalVersionsSize would change the RU calculation. To avoid
-			// unexpected impact on existing users, we only fix this in NextGen
-			// and keep the legacy behavior here for now.
-			readBytes = scanDetail.GetProcessedVersionsSize()
-		}
+		readBytes = scanDetailReadBytes(scanDetail)
 	}
 	// Get the KV CPU time in milliseconds from the execution time details.
 	kvCPU := getKVCPU(detailsV2, details)
 	return &ResponseInfo{
-		readBytes: readBytes,
-		kvCPU:     kvCPU,
+		readBytes: readBytes + batchedReadBytes,
+		kvCPU:     kvCPU + batchedKVCPU,
 		respSize:  uint64(resp.GetSize()),
 	}
+}
+
+// scanDetailReadBytes returns the read bytes a scan detail accounts for.
+func scanDetailReadBytes(scanDetail *kvrpcpb.ScanDetailV2) uint64 {
+	if config.NextGen {
+		// Using the total versions size as the read bytes, which includes not
+		// only processed versions size, but also skipped MVCC versions size.
+		// It can reflect the actual read bytes more accurately, especially for
+		// the request with a large number of MVCC versions.
+		//
+		// For compatibility with older versions of TiKV, if the
+		// processed versions size is greater than the total versions size,
+		// we use the processed versions size as the read bytes.
+		return max(scanDetail.GetTotalVersionsSize(), scanDetail.GetProcessedVersionsSize())
+	}
+	// NOTE: The original design intended to account for all MVCC read
+	// overhead, but TotalVersionsSize did not exist at the time, so
+	// ProcessedVersionsSize was used instead, which only counts the
+	// versions that are actually processed and excludes skipped MVCC
+	// versions. Since this behavior has already been released, switching
+	// to TotalVersionsSize would change the RU calculation. To avoid
+	// unexpected impact on existing users, we only fix this in NextGen
+	// and keep the legacy behavior here for now.
+	return scanDetail.GetProcessedVersionsSize()
 }
 
 // TODO: find out a more accurate way to get the actual KV CPU time.

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -2,6 +2,7 @@ package resourcecontrol
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -135,4 +136,50 @@ func TestResponseInfoReadBytes(t *testing.T) {
 		infoCompat := MakeResponseInfo(respCompat)
 		assert.Equal(t, uint64(100), infoCompat.ReadBytes())
 	}
+}
+
+func TestResponseInfoBatchedTasks(t *testing.T) {
+	// Every nested batched response must contribute scan bytes and KV CPU
+	// because the top-level execution details do not include that work.
+	resp := &tikvrpc.Response{
+		Resp: &coprocessor.Response{
+			ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+				ScanDetailV2: &kvrpcpb.ScanDetailV2{
+					TotalVersionsSize:     100,
+					ProcessedVersionsSize: 80,
+				},
+				TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 1000},
+			},
+			BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+				{
+					Data: []byte("data"),
+					ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+						ScanDetailV2: &kvrpcpb.ScanDetailV2{
+							TotalVersionsSize:     15,
+							ProcessedVersionsSize: 10,
+						},
+						TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 100},
+					},
+				},
+				{
+					ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+						ScanDetailV2: &kvrpcpb.ScanDetailV2{
+							TotalVersionsSize:     25,
+							ProcessedVersionsSize: 20,
+						},
+						TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 200},
+					},
+				},
+				{Data: []byte("12345678")},
+			},
+		},
+	}
+
+	info := MakeResponseInfo(resp)
+	expectedReadBytes := uint64(80 + 10 + 20 + 8)
+	if config.NextGen {
+		expectedReadBytes = 100 + 15 + 25 + 8
+	}
+	assert.Equal(t, expectedReadBytes, info.ReadBytes())
+	assert.Equal(t, time.Duration(1000+100+200), info.KVCPU())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #2043

`MakeResponseInfo` ignores execution details from nested batched coprocessor responses, causing resource control to undercount read bytes and KV CPU.

### What is changed and how does it work?

- Include scan bytes and KV CPU from every nested batch response.
- Fall back to response data size when scan details are unavailable.
- Preserve the existing legacy and NextGen scan-byte accounting rules.

There is no public API or wire-format change.

### Tests

- `go test ./internal/resourcecontrol -count=1`
- `go test -tags nextgen ./internal/resourcecontrol -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource usage reporting for batched coprocessor responses.
  * Read-byte metrics now accurately include embedded batch results, with appropriate fallbacks when scan details are unavailable.
  * KV CPU time reporting now includes processing time from all batched tasks.
  * Preserved existing read-byte behavior for legacy scan responses.
  * Improved accuracy of performance metrics across both newer and legacy scan processing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->