### PR TITLE
resourcecontrol: settle batched cop tasks' execution details

### DIFF
--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -203,15 +203,29 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	}
 	// Parse the response to extract the info.
 	var (
-		readBytes uint64
-		detailsV2 *kvrpcpb.ExecDetailsV2
-		details   *kvrpcpb.ExecDetails
+		readBytes        uint64
+		detailsV2        *kvrpcpb.ExecDetailsV2
+		details          *kvrpcpb.ExecDetails
+		batchedReadBytes uint64
+		batchedKVCPU     time.Duration
 	)
 	switch r := resp.Resp.(type) {
 	case *coprocessor.Response:
 		detailsV2 = r.GetExecDetailsV2()
 		details = r.GetExecDetails()
 		readBytes = uint64(r.Data.Size())
+		// A batched coprocessor request answers several tasks in one response.
+		// Each nested response carries execution details that are not included
+		// in the top-level details, so account for every nested task.
+		for _, batchResp := range r.GetBatchResponses() {
+			batchDetailsV2 := batchResp.GetExecDetailsV2()
+			batchReadBytes := uint64(batchResp.Data.Size())
+			if scanDetail := batchDetailsV2.GetScanDetailV2(); scanDetail != nil {
+				batchReadBytes = scanDetailReadBytes(scanDetail)
+			}
+			batchedReadBytes += batchReadBytes
+			batchedKVCPU += getKVCPU(batchDetailsV2, nil)
+		}
 	case *tikvrpc.CopStreamResponse:
 		// Streaming request returns `io.EOF``, so the first `CopStreamResponse.Response`` may be nil.
 		if r.Response != nil {
@@ -237,8 +251,8 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	// Get the KV CPU time in milliseconds from the execution time details.
 	kvCPU := getKVCPU(detailsV2, details)
 	return &ResponseInfo{
-		readBytes: readBytes,
-		kvCPU:     kvCPU,
+		readBytes: readBytes + batchedReadBytes,
+		kvCPU:     kvCPU + batchedKVCPU,
 		respSize:  uint64(resp.GetSize()),
 	}
 }

--- a/internal/resourcecontrol/resource_control.go
+++ b/internal/resourcecontrol/resource_control.go
@@ -232,27 +232,7 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 	// Try to get read bytes from the `detailsV2`.
 	// TODO: clarify whether we should count the underlying storage engine read bytes or not.
 	if scanDetail := detailsV2.GetScanDetailV2(); scanDetail != nil {
-		if config.NextGen {
-			// Using the total versions size as the read bytes, which includes not
-			// only processed versions size, but also skipped MVCC versions size.
-			// It can reflect the actual read bytes more accurately, especially for
-			// the request with a large number of MVCC versions.
-			//
-			// For compatibility with older versions of TiKV, if the
-			// processed versions size is greater than the total versions size,
-			// we use the processed versions size as the read bytes.
-			readBytes = max(scanDetail.GetTotalVersionsSize(), scanDetail.GetProcessedVersionsSize())
-		} else {
-			// NOTE: The original design intended to account for all MVCC read
-			// overhead, but TotalVersionsSize did not exist at the time, so
-			// ProcessedVersionsSize was used instead, which only counts the
-			// versions that are actually processed and excludes skipped MVCC
-			// versions. Since this behavior has already been released, switching
-			// to TotalVersionsSize would change the RU calculation. To avoid
-			// unexpected impact on existing users, we only fix this in NextGen
-			// and keep the legacy behavior here for now.
-			readBytes = scanDetail.GetProcessedVersionsSize()
-		}
+		readBytes = scanDetailReadBytes(scanDetail)
 	}
 	// Get the KV CPU time in milliseconds from the execution time details.
 	kvCPU := getKVCPU(detailsV2, details)
@@ -261,6 +241,30 @@ func MakeResponseInfo(resp *tikvrpc.Response) *ResponseInfo {
 		kvCPU:     kvCPU,
 		respSize:  uint64(resp.GetSize()),
 	}
+}
+
+// scanDetailReadBytes returns the read bytes a scan detail accounts for.
+func scanDetailReadBytes(scanDetail *kvrpcpb.ScanDetailV2) uint64 {
+	if config.NextGen {
+		// Using the total versions size as the read bytes, which includes not
+		// only processed versions size, but also skipped MVCC versions size.
+		// It can reflect the actual read bytes more accurately, especially for
+		// the request with a large number of MVCC versions.
+		//
+		// For compatibility with older versions of TiKV, if the
+		// processed versions size is greater than the total versions size,
+		// we use the processed versions size as the read bytes.
+		return max(scanDetail.GetTotalVersionsSize(), scanDetail.GetProcessedVersionsSize())
+	}
+	// NOTE: The original design intended to account for all MVCC read
+	// overhead, but TotalVersionsSize did not exist at the time, so
+	// ProcessedVersionsSize was used instead, which only counts the
+	// versions that are actually processed and excludes skipped MVCC
+	// versions. Since this behavior has already been released, switching
+	// to TotalVersionsSize would change the RU calculation. To avoid
+	// unexpected impact on existing users, we only fix this in NextGen
+	// and keep the legacy behavior here for now.
+	return scanDetail.GetProcessedVersionsSize()
 }
 
 // TODO: find out a more accurate way to get the actual KV CPU time.

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -2,6 +2,7 @@ package resourcecontrol
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -135,4 +136,51 @@ func TestResponseInfoReadBytes(t *testing.T) {
 		infoCompat := MakeResponseInfo(respCompat)
 		assert.Equal(t, uint64(100), infoCompat.ReadBytes())
 	}
+}
+
+func TestResponseInfoBatchedTasksTopLevelOnly(t *testing.T) {
+	// Characterize the existing settlement behavior before changing it:
+	// MakeResponseInfo accounts for only the top-level response details and
+	// ignores the nested responses of batched coprocessor tasks.
+	resp := &tikvrpc.Response{
+		Resp: &coprocessor.Response{
+			ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+				ScanDetailV2: &kvrpcpb.ScanDetailV2{
+					TotalVersionsSize:     100,
+					ProcessedVersionsSize: 80,
+				},
+				TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 1000},
+			},
+			BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+				{
+					Data: []byte("data"),
+					ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+						ScanDetailV2: &kvrpcpb.ScanDetailV2{
+							TotalVersionsSize:     15,
+							ProcessedVersionsSize: 10,
+						},
+						TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 100},
+					},
+				},
+				{
+					ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
+						ScanDetailV2: &kvrpcpb.ScanDetailV2{
+							TotalVersionsSize:     25,
+							ProcessedVersionsSize: 20,
+						},
+						TimeDetailV2: &kvrpcpb.TimeDetailV2{ProcessWallTimeNs: 200},
+					},
+				},
+				{Data: []byte("12345678")},
+			},
+		},
+	}
+
+	info := MakeResponseInfo(resp)
+	if config.NextGen {
+		assert.Equal(t, uint64(100), info.ReadBytes())
+	} else {
+		assert.Equal(t, uint64(80), info.ReadBytes())
+	}
+	assert.Equal(t, time.Duration(1000), info.KVCPU())
 }

--- a/internal/resourcecontrol/resource_control_test.go
+++ b/internal/resourcecontrol/resource_control_test.go
@@ -138,10 +138,9 @@ func TestResponseInfoReadBytes(t *testing.T) {
 	}
 }
 
-func TestResponseInfoBatchedTasksTopLevelOnly(t *testing.T) {
-	// Characterize the existing settlement behavior before changing it:
-	// MakeResponseInfo accounts for only the top-level response details and
-	// ignores the nested responses of batched coprocessor tasks.
+func TestResponseInfoBatchedTasks(t *testing.T) {
+	// Every nested batched response must contribute scan bytes and KV CPU
+	// because the top-level execution details do not include that work.
 	resp := &tikvrpc.Response{
 		Resp: &coprocessor.Response{
 			ExecDetailsV2: &kvrpcpb.ExecDetailsV2{
@@ -177,10 +176,10 @@ func TestResponseInfoBatchedTasksTopLevelOnly(t *testing.T) {
 	}
 
 	info := MakeResponseInfo(resp)
+	expectedReadBytes := uint64(80 + 10 + 20 + 8)
 	if config.NextGen {
-		assert.Equal(t, uint64(100), info.ReadBytes())
-	} else {
-		assert.Equal(t, uint64(80), info.ReadBytes())
+		expectedReadBytes = 100 + 15 + 25 + 8
 	}
-	assert.Equal(t, time.Duration(1000), info.KVCPU())
+	assert.Equal(t, expectedReadBytes, info.ReadBytes())
+	assert.Equal(t, time.Duration(1000+100+200), info.KVCPU())
 }


### PR DESCRIPTION
## Problem

`MakeResponseInfo` reads execution details only from the top-level
coprocessor response. A `StoreBatchTasks` response represents several logical
tasks, and each attached batch response carries its own scan detail and process
time. Ignoring those children undercounts read bytes and KV CPU during
resource-group settlement and RU-based runaway detection.

This replaces #2029 because its source branch cannot be updated.

## Reviewed snapshot

- Base: `341d4692ec5791de8d5784764c616bc2a46eb434`
- Head: `b09e63bd485b1e51801b5ea523e4c2f6b826e53f`
- The three commits are patch-identical to the prior #2032 head by
  `git range-diff`.

## What changed

Sum every attached batch response's execution details into the response
information used for resource-control settlement. When a child has no scan
detail, use its data length as the same fallback already used for the top-level
response.

The replacement branch is based on the client-go revision now pinned by TiDB,
so updating that consumer adds only this patch rather than unrelated client
changes. Production behavior is identical to #2029; the tests and comments make
the ordinary and NextGen accounting rules explicit.

## Compatibility

There is no public API or wire-format change. Non-batched responses retain their
existing accounting. Resource usage for batched coprocessor responses can
increase to include work that was previously omitted; this is the intended
compatibility impact for TiDB resource control. Other consumers are unaffected
unless they use this internal batched-response settlement path.

## Tests

- `go test ./internal/resourcecontrol -count=1`
- `go test -tags nextgen ./internal/resourcecontrol -count=1`
- `go test -race -tags intest ./internal/resourcecontrol -run '^TestResponseInfo(ReadBytes|BatchedTasks)$' -count=1`
- `git range-diff 01bd8f99f4da..2c6b86ff97b1 341d4692ec57..b09e63bd485b`
- `git diff --check`
- `gofmt` on the changed files

## Related changes

- Protocol negotiation: pingcap/kvproto#1497
- TiKV implementation: a live successor is still required; #19871 closed
  unmerged
- TiDB caller: pingcap/tidb#70055
- Cross-repository design proposal: pingcap/tidb#70059
