### PR TITLE
util/async: avoid blocking Append on Exec cancellation

### DIFF
--- a/util/async/runloop.go
+++ b/util/async/runloop.go
@@ -37,7 +37,11 @@ type RunLoop struct {
 	ready    chan struct{}
 	runnable []func()
 	running  []func()
-	state    State
+
+	// state and ready form a notification handshake. Under Exec's single-goroutine contract, while Exec is waiting,
+	// Append is the only concurrent operation that may change StateWaiting to StateIdle. Exactly the Append that performs
+	// the transition sends one notification on ready after releasing lock.
+	state State
 }
 
 // NewRunLoop creates a new run-loop.
@@ -114,8 +118,17 @@ func (l *RunLoop) Exec(ctx context.Context) (int, error) {
 				continue
 			case <-ctx.Done():
 				l.lock.Lock()
-				l.state = StateIdle // waiting -> idle
-				l.lock.Unlock()
+				if l.state == StateWaiting {
+					// No Append has committed to sending a notification.
+					l.state = StateIdle // waiting -> idle
+					l.lock.Unlock()
+				} else {
+					// SAFETY: Under Exec's single-goroutine contract, Append is the only concurrent operation that can
+					// change StateWaiting to StateIdle. Exactly one Append performed that transition and must send one
+					// notification after releasing lock. Consume it before returning so the sender cannot be stranded.
+					l.lock.Unlock()
+					<-l.ready
+				}
 				return 0, ctx.Err()
 			}
 		} else {

--- a/util/async/runloop_test.go
+++ b/util/async/runloop_test.go
@@ -141,24 +141,89 @@ func TestExecCancelWhileWaiting(t *testing.T) {
 	require.Equal(t, 0, n)
 }
 
-func TestExecConcurrent(t *testing.T) {
-	defaultMaxProcs := runtime.GOMAXPROCS(0)
+func TestExecCancelWhileAppendNotifying(t *testing.T) {
+	defaultMaxProcs := runtime.GOMAXPROCS(1)
 	defer runtime.GOMAXPROCS(defaultMaxProcs)
-	runtime.GOMAXPROCS(1)
-	l := NewRunLoop()
-	l.Append(func() {
-		time.Sleep(time.Millisecond)
-	})
-	done := make(chan struct{})
-	go func() {
+
+	for attempt := 0; attempt < 100; attempt++ {
+		l := NewRunLoop()
+		called := false
+		ctx, cancel := context.WithCancel(context.Background())
+		execDone := make(chan error, 1)
+		go func() {
+			_, err := l.Exec(ctx)
+			execDone <- err
+		}()
+
+		require.Eventually(t, func() bool {
+			return l.State() == StateWaiting
+		}, time.Second, time.Millisecond, "run loop did not enter waiting state")
+
+		// Queue Append on the mutex before waking Exec through cancellation. If Append acquires the mutex first, it
+		// changes the state to idle and then tries to notify an Exec that has already selected ctx.Done().
+		l.lock.Lock()
+		appendDone := make(chan struct{})
+		go func() {
+			l.Append(func() {
+				called = true
+			})
+			close(appendDone)
+		}()
+		runtime.Gosched()
+		cancel()
+		runtime.Gosched()
+		l.lock.Unlock()
+
+		select {
+		case err := <-execDone:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Fatal("Exec did not return after cancellation")
+		}
+
+		select {
+		case <-appendDone:
+		case <-time.After(time.Second):
+			t.Fatalf("Append remained blocked after Exec cancellation on attempt %d", attempt+1)
+		}
+
+		require.Equal(t, StateIdle, l.State())
+		require.Equal(t, 1, l.NumRunnable())
+
 		n, err := l.Exec(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, 1, n)
-		close(done)
+		require.True(t, called)
+		require.Equal(t, StateIdle, l.State())
+		require.Equal(t, 0, l.NumRunnable())
+	}
+}
+
+func TestExecConcurrent(t *testing.T) {
+	l := NewRunLoop()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	l.Append(func() {
+		close(started)
+		<-release
+	})
+	type execResult struct {
+		n   int
+		err error
+	}
+	done := make(chan execResult, 1)
+	go func() {
+		n, err := l.Exec(context.Background())
+		done <- execResult{n: n, err: err}
 	}()
-	runtime.Gosched()
+
+	<-started
 	n, err := l.Exec(context.Background())
+	close(release)
+	result := <-done
+
 	require.Error(t, err)
 	require.Equal(t, 0, n)
-	<-done
+	require.NoError(t, result.err)
+	require.Equal(t, 1, result.n)
 }


### PR DESCRIPTION
Fix #2033

`RunLoop.Append` could block indefinitely when racing with cancellation of a waiting `RunLoop.Exec`.

`Append` changes the state from `StateWaiting` to `StateIdle` under the mutex, then sends a notification through the
unbuffered `ready` channel after releasing the mutex. If `Exec` selected `ctx.Done()` and returned before receiving that
notification, the `Append` caller was left blocked. When invoked from an async batch response callback, this could stop
the batch receive loop from retiring the request and processing later responses on the same stream.

Changes:
- Make the cancellation path distinguish between a run loop that is still waiting and one for which an `Append` has
  already committed to sending a notification.
- Consume the committed notification before returning from `Exec`, ensuring the notifying `Append` can complete.
- Document the notification handshake and its single-`Exec` safety invariant.
- Add regression coverage for the cancellation race, queued-task preservation, and subsequent `Exec` behavior.
- Make the concurrent `Exec` test deterministic by synchronizing on the first executor entering `StateRunning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run loop behavior when execution is cancelled while another task is being added.
  * Prevented potential hangs during concurrent task scheduling.
  * Ensured the run loop remains usable for subsequent executions after cancellation.

* **Tests**
  * Added coverage for cancellation and concurrent task execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->