### PR TITLE
[tidb-8.5] *: upgrade Go to 1.25.12

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.25.8"
+        go-version: "1.25.12"
 
     - name: Checkout Client-Go
       uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Test
         run: go test ./...
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Test
         run: go test ./... -race
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Fetch PD
         uses: shrink/actions-docker-extract@v1
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Fetch PD
         uses: shrink/actions-docker-extract@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Test
         run: go test --tags=intest ./...
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Test with race
         run: go test -race --tags=intest ./...
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.12
 
       - name: Go generate and check diff
         run: |

--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -1,6 +1,6 @@
 module gcworker
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -1,6 +1,6 @@
 module rawkv
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -1,6 +1,6 @@
 module 1pc_txn
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -1,6 +1,6 @@
 module async_commit
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -1,6 +1,6 @@
 module delete_range
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -1,6 +1,6 @@
 module txnkv
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -1,6 +1,6 @@
 module pessimistic_txn
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -1,6 +1,6 @@
 module unsafedestoryrange
 
-go 1.25.8
+go 1.25.12
 
 require github.com/tikv/client-go/v2 v2.0.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tikv/client-go/v2
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -1,6 +1,6 @@
 module integration_tests
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Ref: https://github.com/pingcap/tidb/issues/69335

## Problem

Upgrade the TiDB 8.5 client-go branch to Go 1.25.12 according to the ecosystem-wide upgrade plan.

## Changes

- set the root, integration-test, and example module Go versions to 1.25.12
- run GitHub Actions with Go 1.25.12
- no source-code or dependency changes

## Risk assessment

Low. This only updates Go version declarations and CI toolchain selection. Runtime behavior and module dependencies are unchanged.

## Tests

- GOTOOLCHAIN=go1.25.12 go test --tags=intest ./...
- GOTOOLCHAIN=go1.25.12 go test -run ^$ -tags=intest,nextgen ./...
- GOTOOLCHAIN=go1.25.12 go mod tidy -diff in the root and integration_tests modules