### PR TITLE
tikv: support CSE keyspace-level transaction safepoint

### DIFF
--- a/tikv/compatible_txn_safe_point_loader.go
+++ b/tikv/compatible_txn_safe_point_loader.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
 	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/internal/apicodec"
 	"github.com/tikv/client-go/v2/util"
@@ -22,6 +23,19 @@ const (
 	unifiedTxnSafePointPath       = "/tidb/store/gcworker/saved_safe_point"
 	keyspaceLevelTxnSafePointPath = "/keyspaces/tidb/%d/tidb/store/gcworker/saved_safe_point"
 )
+
+// IsCESKeyspaceLevelGC reports whether a keyspace uses the CES keyspace-level GC metadata format.
+// TODO: Replace this implementation with pd.IsCESKeyspaceLevelGC after API v3 support is merged into client-go.
+func IsCESKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
+	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config["safe_point_version"] == "v2"
+}
+
+func compatibleTxnSafePointPath(keyspaceMeta *keyspacepb.KeyspaceMeta) string {
+	if pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) || IsCESKeyspaceLevelGC(keyspaceMeta) {
+		return fmt.Sprintf(keyspaceLevelTxnSafePointPath, keyspaceMeta.Id)
+	}
+	return unifiedTxnSafePointPath
+}
 
 // compatibleTxnSafePointLoader is used to load txn safe point from etcd for old versions where the GetGCState API
 // is not yet supported.
@@ -101,11 +115,7 @@ func (l *compatibleTxnSafePointLoader) loadTxnSafePoint(ctx context.Context) (ui
 		}
 	}
 
-	key := unifiedTxnSafePointPath
-	keyspaceMeta := l.codec.GetKeyspaceMeta()
-	if pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) {
-		key = fmt.Sprintf(keyspaceLevelTxnSafePointPath, keyspaceMeta.Id)
-	}
+	key := compatibleTxnSafePointPath(l.codec.GetKeyspaceMeta())
 
 	// Follow the same implementation as the EtcdSafePointKV by setting the timeout 5 seconds.
 	ctx, cancel := context.WithTimeout(ctx, time.Second*5)

--- a/tikv/compatible_txn_safe_point_loader.go
+++ b/tikv/compatible_txn_safe_point_loader.go
@@ -24,14 +24,14 @@ const (
 	keyspaceLevelTxnSafePointPath = "/keyspaces/tidb/%d/tidb/store/gcworker/saved_safe_point"
 )
 
-// IsCESKeyspaceLevelGC reports whether a keyspace uses the CES keyspace-level GC metadata format.
-// TODO: Replace this implementation with pd.IsCESKeyspaceLevelGC after API v3 support is merged into client-go.
-func IsCESKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
+// IsCSEKeyspaceLevelGC reports whether a keyspace uses the CSE keyspace-level GC metadata format.
+// TODO: Replace this implementation with pd.IsCSEKeyspaceLevelGC after API v3 support is merged into client-go.
+func IsCSEKeyspaceLevelGC(keyspaceMeta *keyspacepb.KeyspaceMeta) bool {
 	return keyspaceMeta != nil && keyspaceMeta.Config != nil && keyspaceMeta.Config["safe_point_version"] == "v2"
 }
 
 func compatibleTxnSafePointPath(keyspaceMeta *keyspacepb.KeyspaceMeta) string {
-	if pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) || IsCESKeyspaceLevelGC(keyspaceMeta) {
+	if pd.IsKeyspaceUsingKeyspaceLevelGC(keyspaceMeta) || IsCSEKeyspaceLevelGC(keyspaceMeta) {
 		return fmt.Sprintf(keyspaceLevelTxnSafePointPath, keyspaceMeta.Id)
 	}
 	return unifiedTxnSafePointPath

--- a/tikv/compatible_txn_safe_point_loader_test.go
+++ b/tikv/compatible_txn_safe_point_loader_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsCESKeyspaceLevelGC(t *testing.T) {
+func TestIsCSEKeyspaceLevelGC(t *testing.T) {
 	testCases := []struct {
 		name string
 		meta *keyspacepb.KeyspaceMeta
@@ -15,13 +15,13 @@ func TestIsCESKeyspaceLevelGC(t *testing.T) {
 	}{
 		{name: "nil keyspace"},
 		{name: "missing config", meta: &keyspacepb.KeyspaceMeta{}},
-		{name: "CES keyspace-level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
+		{name: "CSE keyspace-level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
 		{name: "case-sensitive version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "V2"}}},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, IsCESKeyspaceLevelGC(tc.meta))
+			require.Equal(t, tc.want, IsCSEKeyspaceLevelGC(tc.meta))
 		})
 	}
 }
@@ -42,7 +42,7 @@ func TestCompatibleTxnSafePointPath(t *testing.T) {
 			want: "/keyspaces/tidb/1/tidb/store/gcworker/saved_safe_point",
 		},
 		{
-			name: "CES keyspace-level GC",
+			name: "CSE keyspace-level GC",
 			meta: &keyspacepb.KeyspaceMeta{Id: 2, Config: map[string]string{"safe_point_version": "v2"}},
 			want: "/keyspaces/tidb/2/tidb/store/gcworker/saved_safe_point",
 		},

--- a/tikv/compatible_txn_safe_point_loader_test.go
+++ b/tikv/compatible_txn_safe_point_loader_test.go
@@ -1,0 +1,61 @@
+package tikv
+
+import (
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCESKeyspaceLevelGC(t *testing.T) {
+	testCases := []struct {
+		name string
+		meta *keyspacepb.KeyspaceMeta
+		want bool
+	}{
+		{name: "nil keyspace"},
+		{name: "missing config", meta: &keyspacepb.KeyspaceMeta{}},
+		{name: "CES keyspace-level GC", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "v2"}}, want: true},
+		{name: "case-sensitive version", meta: &keyspacepb.KeyspaceMeta{Config: map[string]string{"safe_point_version": "V2"}}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsCESKeyspaceLevelGC(tc.meta))
+		})
+	}
+}
+
+func TestCompatibleTxnSafePointPath(t *testing.T) {
+	testCases := []struct {
+		name string
+		meta *keyspacepb.KeyspaceMeta
+		want string
+	}{
+		{
+			name: "null keyspace",
+			want: unifiedTxnSafePointPath,
+		},
+		{
+			name: "native keyspace-level GC",
+			meta: &keyspacepb.KeyspaceMeta{Id: 1, Config: map[string]string{"gc_management_type": "keyspace_level"}},
+			want: "/keyspaces/tidb/1/tidb/store/gcworker/saved_safe_point",
+		},
+		{
+			name: "CES keyspace-level GC",
+			meta: &keyspacepb.KeyspaceMeta{Id: 2, Config: map[string]string{"safe_point_version": "v2"}},
+			want: "/keyspaces/tidb/2/tidb/store/gcworker/saved_safe_point",
+		},
+		{
+			name: "unified GC",
+			meta: &keyspacepb.KeyspaceMeta{Id: 3, Config: map[string]string{"gc_management_type": "unified"}},
+			want: unifiedTxnSafePointPath,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, compatibleTxnSafePointPath(tc.meta))
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this PR solve?

Related PD issue: tikv/pd#11108

Related downstream issue: pingcap/ticdc#5785

Essential v1 keyspaces advertise keyspace-level GC with `safe_point_version=v2`, while client-go only recognizes the native `gc_management_type=keyspace_level` metadata. The compatibility transaction safepoint loader therefore reads the unified GC key instead of the keyspace-scoped key.

## What is changed and how it works?

- Add `tikv.IsCSEKeyspaceLevelGC` locally so current client-go can recognize CSE metadata without pulling the API-v3 PD dependency graph.
- Route both native and CSE keyspace-level GC metadata to `/keyspaces/tidb/{id}/tidb/store/gcworker/saved_safe_point`.
- Keep all other keyspaces on the unified GC key.
- Document that the local helper should delegate to `pd.IsCSEKeyspaceLevelGC` after API-v3 support is merged into client-go.

The canonical PD helper remains in tikv/pd#11100. This PR intentionally has no module dependency changes.

## Tests

- `go test ./tikv -run "^(TestIsCSEKeyspaceLevelGC|TestCompatibleTxnSafePointPath)$" -count=1 -v`
- `gopls check tikv/compatible_txn_safe_point_loader.go tikv/compatible_txn_safe_point_loader_test.go`