### PR TITLE
internal/locate: probe follower once when the cached leader keeps rejecting leader reads with ServerIsBusy(0)

### DIFF
--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -640,7 +640,10 @@ func (r *replica) onUpdateLeader() {
 		r.attempts = maxReplicaAttempt - 1
 		r.attemptedTime = 0
 	}
+	// The replica is confirmed to be the leader by a NotLeader hint, so it is no longer
+	// suspected of having lost leadership.
 	r.deleteFlag(notLeaderFlag)
+	r.deleteFlag(suspectNotLeaderFlag)
 }
 
 const (
@@ -648,6 +651,7 @@ const (
 	dataIsNotReadyFlag                                // dataIsNotReadyFlag indicates the replica is already tried, but the received data is not ready error.
 	notLeaderFlag                                     // notLeaderFlag indicates the replica is already tried, but the received not leader error.
 	serverIsBusyFlag                                  // serverIsBusyFlag indicates the replica is already tried, but the received server is busy error.
+	suspectNotLeaderFlag                              // suspectNotLeaderFlag indicates the cached leader keeps rejecting leader reads with ServerIsBusy(0), so it is suspected to have lost leadership (tikv/client-go#2028).
 )
 
 func (r *replica) addFlag(flag uint8) {

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -40,6 +40,11 @@ type replicaSelector struct {
 	proxy                     *replica
 	attempts                  int
 	regionInvalidatedForRetry bool // set when region is hard-invalidated but this selector should still retry on leader
+	// leaderBusyCount counts the ServerIsBusy(0) errors received on the cached leader, and
+	// leaderBusyProbed records whether a suspect-not-leader probe has been fired. Both are
+	// per-selector states used to work around tikv/client-go#2028, see onServerIsBusy.
+	leaderBusyCount  int
+	leaderBusyProbed bool
 }
 
 // disableReadFeaturesForNextGen disables replica-read and stale-read feature
@@ -244,7 +249,10 @@ type ReplicaSelectLeaderStrategy struct {
 
 func (s ReplicaSelectLeaderStrategy) next(replicas []*replica) *replica {
 	leader := replicas[s.leaderIdx]
-	if isLeaderCandidate(leader) {
+	// Skip a leader replica flagged with suspectNotLeaderFlag, so that the selector falls
+	// back to the mixed strategy and probes a follower to trigger a NotLeader reply which
+	// heals the region cache (tikv/client-go#2028).
+	if isLeaderCandidate(leader) && !leader.hasFlag(suspectNotLeaderFlag) {
 		return leader
 	}
 	return nil
@@ -583,6 +591,25 @@ func (s *replicaSelector) onServerIsBusy(
 		} else {
 			// Mark the server is busy (the next incoming READs could be redirected to expected followers.)
 			ctx.Store.healthStatus.markAlreadySlow()
+			// Workaround for tikv/client-go#2028: if the store's read pool is wedged, leader
+			// reads are rejected with ServerIsBusy(0) at the pool entrance, so the request
+			// never reaches the raft layer and no NotLeader error is returned even if PD has
+			// already moved the leader away. Retrying the cached leader then hammers the
+			// half-dead store indefinitely. After 2 consecutive such rejections on the cached
+			// leader, mark it suspect-not-leader so that the next attempt probes a follower
+			// with the leader read (req.ReplicaRead is kept unchanged). The follower replies
+			// NotLeader with the real leader hint, which heals the shared region cache via
+			// onNotLeader/updateLeader. Probe at most once per selector; if the store is
+			// still the leader, the hint points back to it, onUpdateLeader clears the flag,
+			// and the only cost is one rejected RPC.
+			if s.replicaReadType == kv.ReplicaReadLeader && !s.isStaleRead && !s.option.leaderOnly &&
+				s.target != nil && s.target.peer.Id == s.region.GetLeaderPeerID() && !s.leaderBusyProbed {
+				s.leaderBusyCount++
+				if s.leaderBusyCount >= 2 {
+					s.target.addFlag(suspectNotLeaderFlag)
+					s.leaderBusyProbed = true
+				}
+			}
 		}
 	}
 	backoffErr := newBackoffErrWithRPCContext("server is busy", ctx)

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -609,8 +609,9 @@ func (s *replicaSelector) onServerIsBusy(
 			// reads are rejected with ServerIsBusy(0) at the pool entrance, so the request
 			// never reaches the raft layer and no NotLeader error is returned even if PD has
 			// already moved the leader away. Retrying the cached leader then hammers the
-			// half-dead store indefinitely. After 2 consecutive such rejections on the cached
-			// leader, mark it suspect-not-leader so that the next attempt probes a follower
+			// half-dead store indefinitely. After 2 such rejections from the same cached
+			// leader within this selector (the count restarts only when the cached leader
+			// changes), mark it suspect-not-leader so that the next attempt probes a follower
 			// with the leader read (req.ReplicaRead is kept unchanged). The follower replies
 			// NotLeader with the real leader hint, which heals the shared region cache via
 			// onNotLeader/updateLeader. Probe at most once per selector; if the store is

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -584,6 +584,10 @@ func (s *replicaSelector) onRegionNotFound(
 	return false, nil
 }
 
+// leaderBusyProbeThreshold is the number of ServerIsBusy(0) errors received from the same
+// cached leader within one selector that triggers a suspect-not-leader probe.
+const leaderBusyProbeThreshold = 2
+
 func (s *replicaSelector) onServerIsBusy(
 	bo *retry.Backoffer, ctx *RPCContext, req *tikvrpc.Request, serverIsBusy *errorpb.ServerIsBusy,
 ) (shouldRetry bool, err error) {
@@ -617,18 +621,18 @@ func (s *replicaSelector) onServerIsBusy(
 			// onNotLeader/updateLeader. Probe at most once per selector; if the store is
 			// still the leader, the hint points back to it, onUpdateLeader clears the flag,
 			// and the only cost is one rejected RPC.
+			leaderPeerID := s.region.GetLeaderPeerID()
 			if s.replicaReadType == kv.ReplicaReadLeader && !s.isStaleRead && !s.option.leaderOnly &&
-				s.target != nil && s.target.peer.Id == s.region.GetLeaderPeerID() && !s.leaderBusyProbed {
+				s.target != nil && s.target.peer != nil && s.target.peer.Id == leaderPeerID && !s.leaderBusyProbed {
 				// The count belongs to a specific cached leader: whenever the cached leader
 				// changes (e.g. switched by a NotLeader hint), restart the count for the new
 				// leader so that it won't be marked after inheriting the old leader's count.
-				leaderPeerID := s.region.GetLeaderPeerID()
 				if s.leaderBusyPeerID != leaderPeerID {
 					s.leaderBusyPeerID = leaderPeerID
 					s.leaderBusyCount = 0
 				}
 				s.leaderBusyCount++
-				if s.leaderBusyCount >= 2 {
+				if s.leaderBusyCount >= leaderBusyProbeThreshold {
 					s.target.addFlag(suspectNotLeaderFlag)
 					s.leaderBusyProbed = true
 				}

--- a/internal/locate/replica_selector.go
+++ b/internal/locate/replica_selector.go
@@ -43,7 +43,10 @@ type replicaSelector struct {
 	// leaderBusyCount counts the ServerIsBusy(0) errors received on the cached leader, and
 	// leaderBusyProbed records whether a suspect-not-leader probe has been fired. Both are
 	// per-selector states used to work around tikv/client-go#2028, see onServerIsBusy.
+	// leaderBusyPeerID is the peer the count belongs to: the count restarts whenever the
+	// cached leader changes, so a new leader won't inherit the old leader's count.
 	leaderBusyCount  int
+	leaderBusyPeerID uint64
 	leaderBusyProbed bool
 }
 
@@ -328,6 +331,17 @@ func (s *ReplicaSelectMixedStrategy) next(selector *replicaSelector) *replica {
 		// when can't find an idle replica, no need to invalidate region.
 		return nil
 	}
+	// The leader is skipped only because it is suspected to have lost leadership. When there
+	// is no other replica to probe (single-replica region, or all followers are
+	// unreachable/stale/exhausted) or the probe turns out fruitless, restore the leader and
+	// fall back to the existing backoff-retry behavior instead of invalidating the region
+	// and reloading it from PD for nothing (tikv/client-go#2028).
+	if leader := replicas[s.leaderIdx]; leader.hasFlag(suspectNotLeaderFlag) {
+		leader.deleteFlag(suspectNotLeaderFlag)
+		if isLeaderCandidate(leader) {
+			return leader
+		}
+	}
 	// when meet deadline exceeded error, do fast retry without invalidate region cache.
 	if !hasDeadlineExceededError(selector.replicas) {
 		selector.invalidateRegion()
@@ -604,6 +618,14 @@ func (s *replicaSelector) onServerIsBusy(
 			// and the only cost is one rejected RPC.
 			if s.replicaReadType == kv.ReplicaReadLeader && !s.isStaleRead && !s.option.leaderOnly &&
 				s.target != nil && s.target.peer.Id == s.region.GetLeaderPeerID() && !s.leaderBusyProbed {
+				// The count belongs to a specific cached leader: whenever the cached leader
+				// changes (e.g. switched by a NotLeader hint), restart the count for the new
+				// leader so that it won't be marked after inheriting the old leader's count.
+				leaderPeerID := s.region.GetLeaderPeerID()
+				if s.leaderBusyPeerID != leaderPeerID {
+					s.leaderBusyPeerID = leaderPeerID
+					s.leaderBusyCount = 0
+				}
 				s.leaderBusyCount++
 				if s.leaderBusyCount >= 2 {
 					s.target.addFlag(suspectNotLeaderFlag)

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -2534,7 +2534,7 @@ func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
 		},
 		afterRun: func(selector *replicaSelector) {
 			s.True(selector.leaderBusyProbed)
-			s.Equal(2, selector.leaderBusyCount)
+			s.Equal(leaderBusyProbeThreshold, selector.leaderBusyCount)
 			s.True(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
 			selector.invalidateRegion() // invalidate region to reload for next test case.
 		},
@@ -2604,7 +2604,7 @@ func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
 		afterRun: func(selector *replicaSelector) {
 			s.True(selector.leaderBusyProbed)
 			// The busy count doesn't grow anymore once the probe is fired.
-			s.Equal(2, selector.leaderBusyCount)
+			s.Equal(leaderBusyProbeThreshold, selector.leaderBusyCount)
 			// The suspect flag is cleared since the hint confirms store1 is the leader.
 			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
 			s.Equal(uint64(1), selector.region.GetLeaderStoreID())
@@ -2660,11 +2660,72 @@ func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
 		},
 		afterRun: func(selector *replicaSelector) {
 			s.True(selector.leaderBusyProbed)
-			s.Equal(2, selector.leaderBusyCount)
+			s.Equal(leaderBusyProbeThreshold, selector.leaderBusyCount)
 			// The count and the suspect flag belong to the peer in store2.
 			s.Equal(selector.replicas[1].peer.Id, selector.leaderBusyPeerID)
 			s.True(selector.replicas[1].hasFlag(suspectNotLeaderFlag))
 			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// The busy count is cumulative per cached leader and doesn't require consecutive
+	// attempts: a busy(0) interleaved with other errors still counts, and the probe fires
+	// once the count reaches the threshold.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyWithEstimatedWaitMsErr, ServerIsBusyErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}", // busy(0), count(store1)=1.
+				"{addr: store1, replica-read: false, stale-read: false}", // busy with EstimatedWaitMs!=0, not counted.
+				"{addr: store1, replica-read: false, stale-read: false}", // busy(0) again, count(store1)=2, mark and probe.
+				"{addr: store2, replica-read: false, stale-read: false}", // probe a follower.
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      3,
+			backoffDetail:   []string{"tikvServerBusy+3"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			s.Equal(leaderBusyProbeThreshold, selector.leaderBusyCount)
+			s.True(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// Both probed followers reply NotLeader without a hint: the leader is restored (the
+	// suspect flag is cleared) instead of invalidating the region, and the next attempt
+	// selects the old leader again.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr, NotLeaderErr, NotLeaderErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store2, replica-read: false, stale-read: false}", // probe, NotLeader without a hint.
+				"{addr: store3, replica-read: false, stale-read: false}", // probe, NotLeader without a hint either.
+				"{addr: store1, replica-read: false, stale-read: false}", // no probe result: the leader is restored.
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      4,
+			backoffDetail:   []string{"regionScheduling+2", "tikvServerBusy+2"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			// The suspect flag is cleared when the leader is restored as the only choice.
+			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			// The cached leader is not switched since no hint is received.
+			s.Equal(uint64(1), selector.region.GetLeaderStoreID())
 			selector.invalidateRegion() // invalidate region to reload for next test case.
 		},
 	}

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -1348,16 +1348,26 @@ func testReplicaReadAccessPathByLeaderCase(s *testReplicaSelectorSuite) {
 				"{addr: store1, replica-read: false, stale-read: false}",
 				"{addr: store1, replica-read: false, stale-read: false}",
 				// After 2 consecutive ServerIsBusy(0) on the cached leader, it is marked
-				// suspect-not-leader and the followers are probed instead of hammering the
-				// leader (tikv/client-go#2028).
+				// suspect-not-leader and the followers are probed (tikv/client-go#2028).
 				"{addr: store2, replica-read: false, stale-read: false}",
 				"{addr: store3, replica-read: false, stale-read: false}",
+				// The probe is fruitless since every store is busy: the leader is restored
+				// and retried with the plain backoff-retry behavior until it succeeds or is
+				// exhausted naturally, instead of invalidating the region and reloading PD.
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
 			},
 			respErr:         "",
-			respRegionError: fakeEpochNotMatch,
-			backoffCnt:      4,
-			backoffDetail:   []string{"tikvServerBusy+4"},
-			regionIsValid:   false,
+			respRegionError: nil,
+			backoffCnt:      11,
+			backoffDetail:   []string{"tikvServerBusy+11"},
+			regionIsValid:   true,
 		},
 	}
 	s.True(s.runCaseAndCompare(ca))
@@ -2627,6 +2637,39 @@ func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
 	}
 	s.True(s.runCaseAndCompare(ca))
 
+	// The busy count is tied to the cached leader: after the cached leader is switched by a
+	// NotLeader hint, the count restarts, so the new leader is only marked after its own 2
+	// consecutive busy(0).
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, NotLeaderWithNewLeader2Err, ServerIsBusyErr, ServerIsBusyErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}", // busy(0), count(store1)=1.
+				"{addr: store1, replica-read: false, stale-read: false}", // NotLeader, the hint switches the leader to store2.
+				"{addr: store2, replica-read: false, stale-read: false}", // busy(0), the count restarts: count(store2)=1, no probe.
+				"{addr: store2, replica-read: false, stale-read: false}", // busy(0) again, count(store2)=2, mark and probe.
+				"{addr: store3, replica-read: false, stale-read: false}", // probe the remaining follower.
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      3,
+			backoffDetail:   []string{"tikvServerBusy+3"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			s.Equal(2, selector.leaderBusyCount)
+			// The count and the suspect flag belong to the peer in store2.
+			s.Equal(selector.replicas[1].peer.Id, selector.leaderBusyPeerID)
+			s.True(selector.replicas[1].hasFlag(suspectNotLeaderFlag))
+			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
 	if !config.NextGen {
 		// Stale read never triggers the probe even if busy(0) is received on the leader.
 		ca = replicaSelectorAccessPathCase{
@@ -2693,6 +2736,51 @@ func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
 		s.False(selector.replicas[leaderIdx].hasFlag(suspectNotLeaderFlag))
 		s.False(selector.leaderBusyProbed)
 	}
+
+	// Single-replica region: there is no follower to probe, so after the leader is marked,
+	// the next attempt restores it and falls back to the plain backoff-retry behavior
+	// instead of invalidating the region.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr, ServerIsBusyErr},
+		beforeRun: func() {
+			s.resetStoreState()
+			// Remove all followers from the region, leaving the leader as the only peer.
+			rc := s.getRegion()
+			s.NotNil(rc)
+			for _, peer := range rc.meta.Peers {
+				if peer.StoreId != 1 {
+					s.cluster.RemovePeer(rc.meta.Id, peer.Id)
+				}
+			}
+			s.cache.InvalidateCachedRegion(rc.VerID())
+		},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}", // 2nd busy(0), the leader is marked.
+				"{addr: store1, replica-read: false, stale-read: false}", // no probe target, the leader is restored.
+				"{addr: store1, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      3,
+			backoffDetail:   []string{"tikvServerBusy+3"},
+			regionIsValid:   true, // the region is never invalidated.
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			// The suspect flag is cleared when the leader is restored as the only choice.
+			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			// Restore the removed followers for other test cases.
+			for _, storeID := range []uint64{2, 3} {
+				s.cluster.AddPeer(s.regionID, storeID, s.cluster.AllocID())
+			}
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
 }
 
 func TestReplicaReadAccessPathByFlashbackInProgressCase(t *testing.T) {

--- a/internal/locate/replica_selector_test.go
+++ b/internal/locate/replica_selector_test.go
@@ -1347,22 +1347,17 @@ func testReplicaReadAccessPathByLeaderCase(s *testReplicaSelectorSuite) {
 			accessPath: []string{
 				"{addr: store1, replica-read: false, stale-read: false}",
 				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
+				// After 2 consecutive ServerIsBusy(0) on the cached leader, it is marked
+				// suspect-not-leader and the followers are probed instead of hammering the
+				// leader (tikv/client-go#2028).
 				"{addr: store2, replica-read: false, stale-read: false}",
 				"{addr: store3, replica-read: false, stale-read: false}",
 			},
 			respErr:         "",
-			respRegionError: nil,
-			backoffCnt:      9,
-			backoffDetail:   []string{"tikvServerBusy+9"},
-			regionIsValid:   true,
+			respRegionError: fakeEpochNotMatch,
+			backoffCnt:      4,
+			backoffDetail:   []string{"tikvServerBusy+4"},
+			regionIsValid:   false,
 		},
 	}
 	s.True(s.runCaseAndCompare(ca))
@@ -2373,7 +2368,9 @@ func TestReplicaReadAccessPathByTryIdleReplicaCase(t *testing.T) {
 			accessPath: []string{
 				"{addr: store1, replica-read: false, stale-read: false}",
 				"{addr: store1, replica-read: false, stale-read: false}",
-				"{addr: store1, replica-read: false, stale-read: false}",
+				// After 2 consecutive ServerIsBusy(0) on the cached leader, a follower is
+				// probed (tikv/client-go#2028).
+				"{addr: store2, replica-read: false, stale-read: false}",
 			},
 			respErr:         "",
 			respRegionError: nil,
@@ -2465,6 +2462,237 @@ func TestReplicaReadAccessPathByTryIdleReplicaCase(t *testing.T) {
 		},
 	}
 	s.True(s.runCaseAndCompare(ca))
+}
+
+// TestReplicaSelectorLeaderBusyProbe covers the workaround for tikv/client-go#2028: when a
+// half-dead store keeps rejecting leader reads with ServerIsBusy(0) at the read-pool
+// entrance, the request never reaches the raft layer and no NotLeader error is returned,
+// so the cached leader is hammered indefinitely. After 2 consecutive such rejections, the
+// selector marks the cached leader suspect-not-leader and probes a follower once, so that
+// a NotLeader reply with the real leader hint can heal the shared region cache.
+func TestReplicaSelectorLeaderBusyProbe(t *testing.T) {
+	s := new(testReplicaSelectorSuite)
+	s.SetupTest(t)
+	defer s.TearDownTest()
+
+	assertNotProbed := func(selector *replicaSelector) {
+		s.False(selector.leaderBusyProbed)
+		leaderIdx := selector.region.getStore().workTiKVIdx
+		s.False(selector.replicas[leaderIdx].hasFlag(suspectNotLeaderFlag))
+		selector.invalidateRegion() // invalidate region to reload for next test case.
+	}
+
+	// A single ServerIsBusy(0) on the cached leader doesn't trigger the probe: the next
+	// attempt still selects the leader.
+	ca := replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      1,
+			backoffDetail:   []string{"tikvServerBusy+1"},
+			regionIsValid:   true,
+		},
+		afterRun: assertNotProbed,
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// 2 consecutive ServerIsBusy(0) on the cached leader mark it suspect-not-leader, so the
+	// next attempt probes a follower. req.ReplicaRead is kept false to keep the leader-read
+	// semantics, and the follower is expected to reply NotLeader with the real leader hint.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store2, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      2,
+			backoffDetail:   []string{"tikvServerBusy+2"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			s.Equal(2, selector.leaderBusyCount)
+			s.True(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// The probed follower replies NotLeader with a hint pointing to the real leader in
+	// store3: the shared region cache is healed, and a new selector directly selects the
+	// new leader.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr, NotLeaderWithNewLeader3Err},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store2, replica-read: false, stale-read: false}",
+				"{addr: store3, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      2,
+			backoffDetail:   []string{"tikvServerBusy+2"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			// The NotLeader hint from the probed follower heals the shared region cache.
+			s.Equal(uint64(3), selector.region.GetLeaderStoreID())
+			// A new selector on the healed cache directly selects the new leader.
+			req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")})
+			req.ReplicaReadType = kv.ReplicaReadLeader
+			newSelector, err := newReplicaSelector(s.cache, selector.region.VerID(), req)
+			s.Nil(err)
+			s.NotNil(newSelector)
+			rpcCtx, err := newSelector.next(s.bo, req)
+			s.Nil(err)
+			s.NotNil(rpcCtx)
+			s.Equal("store3", rpcCtx.Addr)
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// Misjudgment case: the store is still the leader, so the probed follower's NotLeader
+	// hint points back to it. The leader is restored as a candidate, and later busy(0)
+	// errors won't trigger the probe again since it's fired at most once per selector.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr, NotLeaderWithNewLeader1Err, ServerIsBusyErr, ServerIsBusyErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store2, replica-read: false, stale-read: false}", // probe, but the hint points back to store1.
+				"{addr: store1, replica-read: false, stale-read: false}", // the leader is restored as a candidate.
+				"{addr: store1, replica-read: false, stale-read: false}", // busy(0) again, no more probe.
+				"{addr: store1, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      4,
+			backoffDetail:   []string{"tikvServerBusy+4"},
+			regionIsValid:   true,
+		},
+		afterRun: func(selector *replicaSelector) {
+			s.True(selector.leaderBusyProbed)
+			// The busy count doesn't grow anymore once the probe is fired.
+			s.Equal(2, selector.leaderBusyCount)
+			// The suspect flag is cleared since the hint confirms store1 is the leader.
+			s.False(selector.replicas[0].hasFlag(suspectNotLeaderFlag))
+			s.Equal(uint64(1), selector.region.GetLeaderStoreID())
+			selector.invalidateRegion() // invalidate region to reload for next test case.
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	// The probed follower replies NotLeader without a hint: backoff BoRegionScheduling and
+	// keep retrying the remaining replicas.
+	ca = replicaSelectorAccessPathCase{
+		reqType:   tikvrpc.CmdGet,
+		readType:  kv.ReplicaReadLeader,
+		accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr, NotLeaderErr},
+		expect: &accessPathResult{
+			accessPath: []string{
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store1, replica-read: false, stale-read: false}",
+				"{addr: store2, replica-read: false, stale-read: false}",
+				// No leader hint: the leader is still suspect and store2 replied NotLeader,
+				// so the remaining follower in store3 is tried.
+				"{addr: store3, replica-read: false, stale-read: false}",
+			},
+			respErr:         "",
+			respRegionError: nil,
+			backoffCnt:      3,
+			backoffDetail:   []string{"regionScheduling+1", "tikvServerBusy+2"},
+			regionIsValid:   true,
+		},
+	}
+	s.True(s.runCaseAndCompare(ca))
+
+	if !config.NextGen {
+		// Stale read never triggers the probe even if busy(0) is received on the leader.
+		ca = replicaSelectorAccessPathCase{
+			reqType:   tikvrpc.CmdGet,
+			readType:  kv.ReplicaReadMixed,
+			staleRead: true,
+			accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr},
+			expect: &accessPathResult{
+				accessPath: []string{
+					"{addr: store1, replica-read: false, stale-read: true}",
+					"{addr: store2, replica-read: false, stale-read: true}",
+					"{addr: store3, replica-read: false, stale-read: true}",
+				},
+				respErr:         "",
+				respRegionError: nil,
+				backoffCnt:      0,
+				backoffDetail:   []string{},
+				regionIsValid:   true,
+			},
+			afterRun: assertNotProbed,
+		}
+		s.True(s.runCaseAndCompare(ca))
+
+		// Follower read never triggers the probe.
+		ca = replicaSelectorAccessPathCase{
+			reqType:   tikvrpc.CmdGet,
+			readType:  kv.ReplicaReadFollower,
+			accessErr: []RegionErrorType{ServerIsBusyErr, ServerIsBusyErr},
+			expect: &accessPathResult{
+				accessPath: []string{
+					"{addr: store2, replica-read: true, stale-read: false}",
+					"{addr: store3, replica-read: true, stale-read: false}",
+					"{addr: store1, replica-read: false, stale-read: false}",
+				},
+				respErr:         "",
+				respRegionError: nil,
+				backoffCnt:      0,
+				backoffDetail:   []string{},
+				regionIsValid:   true,
+			},
+			afterRun: assertNotProbed,
+		}
+		s.True(s.runCaseAndCompare(ca))
+	}
+
+	// Requests with the leaderOnly option never trigger the probe.
+	rc := s.getRegion()
+	s.NotNil(rc)
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{Key: []byte("key")})
+	req.ReplicaReadType = kv.ReplicaReadLeader
+	selector, err := newReplicaSelector(s.cache, rc.VerID(), req, WithLeaderOnly())
+	s.Nil(err)
+	s.NotNil(selector)
+	leaderIdx := selector.region.getStore().workTiKVIdx
+	bo := retry.NewBackoffer(context.Background(), -1)
+	for i := 0; i < 3; i++ {
+		rpcCtx, err := selector.next(bo, req)
+		s.Nil(err)
+		s.NotNil(rpcCtx)
+		s.Equal(selector.region.GetLeaderPeerID(), rpcCtx.Peer.Id)
+		shouldRetry, err := selector.onServerIsBusy(bo, rpcCtx, req, &errorpb.ServerIsBusy{})
+		s.Nil(err)
+		s.True(shouldRetry)
+		s.False(selector.replicas[leaderIdx].hasFlag(suspectNotLeaderFlag))
+		s.False(selector.leaderBusyProbed)
+	}
 }
 
 func TestReplicaReadAccessPathByFlashbackInProgressCase(t *testing.T) {
@@ -3474,7 +3702,7 @@ func TestTiKVClientReadTimeout(t *testing.T) {
 
 func TestReplicaFlag(t *testing.T) {
 	r := &replica{}
-	allFlags := []uint8{deadlineErrUsingConfTimeoutFlag, dataIsNotReadyFlag, notLeaderFlag, serverIsBusyFlag}
+	allFlags := []uint8{deadlineErrUsingConfTimeoutFlag, dataIsNotReadyFlag, notLeaderFlag, serverIsBusyFlag, suspectNotLeaderFlag}
 	for i, flag := range allFlags {
 		if i > 0 {
 			require.True(t, flag > allFlags[i-1])


### PR DESCRIPTION
Close tikv/client-go#2028

## Problem

When a TiKV store becomes half-dead (e.g. unified read pool wedged, tikv/tikv#18491),
leader reads are rejected at the read-pool entrance with `ServerIsBusy` and
`EstimatedWaitMs == 0`, before the request reaches the raft layer. Even after PD has
moved the leader away, the store keeps answering gRPC with `ServerIsBusy(0)` instead of
`NotLeader`. The client only marks the store slow and backs off, retrying the same
cached leader indefinitely — a production incident lasted ~25 minutes and ended only
when the store became fully unreachable.

## Fix

"Sleep first, probe once":

- The 1st `ServerIsBusy(0)` on the cached leader behaves exactly as today (mark slow +
  backoff + retry leader) — transient busyness costs nothing.
- On the 2nd `ServerIsBusy(0)` from the same cached leader within one selector,
  mark the leader replica with a new dedicated `suspectNotLeaderFlag` (at most once
  per selector; the count restarts only when the cached leader changes).
- The next attempt skips the flagged leader, so the existing mixed strategy picks a
  follower with unchanged request semantics (`req.ReplicaRead` stays false). A follower
  can only reject a leader read with `NotLeader` + leader hint — never serve it — so
  there is no stale-read risk.
- The hint drives the existing `onNotLeader` → `updateLeader` path, healing the shared
  region cache for all subsequent requests. `onUpdateLeader` clears the flag, so a
  misjudgment (the store is still the leader) costs exactly one rejected RPC and the
  request reverts to today's behavior.
- If the followers yield no hint (election in progress, or followers also
  busy/exhausted), the selector restores the cached leader when the mixed strategy
  finds no candidate, instead of invalidating the region: it falls back to the plain
  backoff-and-retry loop, keeping essentially today's retry shape in an all-busy
  meltdown and adding no PD traffic. Region invalidation / PD reload still happen only
  through the pre-existing paths (e.g. after the leader exhausts its attempts).

No read/write semantics change, no extra PD traffic on the busy path, no new state
machines/timers/configs. Bounded extra cost: the probe fires at most once per
selector — when it succeeds (or is a misjudgment) it costs one rejected RPC; in the
worst case (all followers also busy) each follower is contacted once before the leader
is restored. Applies to reads and writes alike — a write rejected by a follower gets
the same NotLeader treatment.

## What it does NOT cover

The window where the wedged store is still the leader (before PD eviction): the hint
points back to the same store and behavior degrades to status quo; that window is
covered by PD slow-store eviction. Complementary to the server-side fix
tikv/tikv#19932 (return NotLeader at the rejection gate): that one heals old clients
on new TiKV, this one heals old TiKV on new clients.

The forwarding (proxy) path is out of scope: `EnableForwarding` defaults to false, and
this change is designed and tested for the default selection path only — its
interaction with `ReplicaSelectLeaderWithProxyStrategy` is not covered.

A compound failure — wedged old leader AND all followers also rejecting with
ServerIsBusy(0) AND PD has already moved the leader — is intentionally not cured
eagerly: the probe cannot obtain a hint, and invalidating/reloading would tax PD in
the (much more common) case where the cache is actually correct. The request falls
back to today's behavior; the cure arrives once any follower can answer again.

## Tests

`TestReplicaSelectorLeaderBusyProbe`: no probe on a single busy; probe on the 2nd busy
with leader-read semantics kept; cache healed via hint and a new selector goes
straight to the new leader; misjudgment restores the leader with no further probing;
no-hint goes through the region-scheduling backoff path; stale/follower/leaderOnly
reads never probe; a single-replica region (no probe target) restores the leader
without invalidating; the busy count restarts when the cached leader changes.

Two existing access-path tests were updated: their expectations encoded the old
behavior this PR removes (leader hammered until exhausted before trying a follower).
The all-busy meltdown case now ends with the leader restored — twelve accesses ending
in success with the region cache intact, essentially the same retry shape as before
this PR, with only one early fruitless probe of each follower.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request routing when a cached leader repeatedly reports that it is busy.
  - Temporarily probes an available follower and preserves leader-read behavior where appropriate.
  - Automatically recovers from stale or incorrect leader information.
  - Prevents unnecessary probing for stale reads, follower-only requests, leader-only requests, and single-replica configurations.
  - Improves handling of transient busy responses while avoiding false leader suspicions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->