### PR TITLE
retry: delegate killed checks to signal handler

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -447,7 +447,7 @@ func (b *Backoffer) CheckKilled() error {
 	if b.vars == nil {
 		return nil
 	}
-	if handler := b.vars.LoadKillSignalHandler(); handler != nil {
+	if handler := b.vars.KillSignalHandler; handler != nil {
 		return handler.HandleSignal()
 	}
 	if b.vars.Killed != nil {

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -447,9 +447,6 @@ func (b *Backoffer) CheckKilled() error {
 	if b.vars == nil {
 		return nil
 	}
-	if handler := b.vars.KillSignalHandler; handler != nil {
-		return handler.HandleSignal()
-	}
 	if b.vars.Killed != nil {
 		killed := atomic.LoadUint32(b.vars.Killed)
 		if killed != 0 {
@@ -459,6 +456,9 @@ func (b *Backoffer) CheckKilled() error {
 			)
 			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: killed})
 		}
+	}
+	if b.vars.KillSignalHandler != nil {
+		return b.vars.KillSignalHandler.HandleSignal()
 	}
 	return nil
 }

--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -444,7 +444,13 @@ func (b *Backoffer) longestSleepCfg() (*Config, int) {
 }
 
 func (b *Backoffer) CheckKilled() error {
-	if b.vars != nil && b.vars.Killed != nil {
+	if b.vars == nil {
+		return nil
+	}
+	if handler := b.vars.LoadKillSignalHandler(); handler != nil {
+		return handler.HandleSignal()
+	}
+	if b.vars.Killed != nil {
 		killed := atomic.LoadUint32(b.vars.Killed)
 		if killed != 0 {
 			logutil.BgLogger().Info(

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -60,14 +60,14 @@ func TestCheckKilled(t *testing.T) {
 	called := 0
 	killed := uint32(7)
 	vars := kv.NewVariables(&killed)
-	vars.SetKillSignalHandler(killSignalHandlerFunc(func() error {
+	vars.KillSignalHandler = killSignalHandlerFunc(func() error {
 		called++
 		return handlerErr
-	}))
+	})
 	bo := NewBackofferWithVars(context.Background(), 1, vars)
 	assert.ErrorIs(t, bo.CheckKilled(), handlerErr)
 	assert.Equal(t, 1, called)
-	vars.SetKillSignalHandler(nil)
+	vars.KillSignalHandler = nil
 	err := bo.CheckKilled()
 	var interrupted tikverr.ErrQueryInterruptedWithSignal
 	assert.ErrorAs(t, err, &interrupted)

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -65,11 +65,18 @@ func TestCheckKilled(t *testing.T) {
 		return handlerErr
 	})
 	bo := NewBackofferWithVars(context.Background(), 1, vars)
+	err := bo.CheckKilled()
+	var interrupted tikverr.ErrQueryInterruptedWithSignal
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+	assert.Equal(t, 0, called)
+
+	killed = 0
 	assert.ErrorIs(t, bo.CheckKilled(), handlerErr)
 	assert.Equal(t, 1, called)
 	vars.KillSignalHandler = nil
-	err := bo.CheckKilled()
-	var interrupted tikverr.ErrQueryInterruptedWithSignal
+	killed = 7
+	err = bo.CheckKilled()
 	assert.ErrorAs(t, err, &interrupted)
 	assert.Equal(t, killed, interrupted.Signal)
 

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -55,12 +55,6 @@ func (f killSignalHandlerFunc) HandleSignal() error {
 	return f()
 }
 
-type pointerKillSignalHandler struct{}
-
-func (*pointerKillSignalHandler) HandleSignal() error {
-	return errors.New("unexpected call to a typed nil handler")
-}
-
 func TestCheckKilled(t *testing.T) {
 	handlerErr := errors.New("killed by handler")
 	called := 0
@@ -76,13 +70,6 @@ func TestCheckKilled(t *testing.T) {
 	vars.SetKillSignalHandler(nil)
 	err := bo.CheckKilled()
 	var interrupted tikverr.ErrQueryInterruptedWithSignal
-	assert.ErrorAs(t, err, &interrupted)
-	assert.Equal(t, killed, interrupted.Signal)
-
-	var nilHandler *pointerKillSignalHandler
-	vars.SetKillSignalHandler(nilHandler)
-	assert.Nil(t, vars.LoadKillSignalHandler())
-	err = bo.CheckKilled()
 	assert.ErrorAs(t, err, &interrupted)
 	assert.Equal(t, killed, interrupted.Signal)
 

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -39,6 +39,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,7 +47,85 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/assert"
 	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/kv"
 )
+
+type killSignalHandlerFunc func() error
+
+func (f killSignalHandlerFunc) HandleSignal() error {
+	return f()
+}
+
+func TestCheckKilled(t *testing.T) {
+	handlerErr := errors.New("killed by handler")
+	called := 0
+	killed := uint32(7)
+	vars := kv.NewVariables(&killed)
+	vars.SetKillSignalHandler(killSignalHandlerFunc(func() error {
+		called++
+		return handlerErr
+	}))
+	bo := NewBackofferWithVars(context.Background(), 1, vars)
+	assert.ErrorIs(t, bo.CheckKilled(), handlerErr)
+	assert.Equal(t, 1, called)
+	vars.SetKillSignalHandler(nil)
+	err := bo.CheckKilled()
+	var interrupted tikverr.ErrQueryInterruptedWithSignal
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	bo = NewBackofferWithVars(context.Background(), 1, kv.NewVariables(&killed))
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	assert.NoError(t, NewBackofferWithVars(context.Background(), 1, nil).CheckKilled())
+}
+
+func TestCheckKilledConcurrentHandlerUpdate(t *testing.T) {
+	firstErr := errors.New("killed by first handler")
+	secondErr := errors.New("killed by second handler")
+	firstHandler := killSignalHandlerFunc(func() error { return firstErr })
+	secondHandler := killSignalHandlerFunc(func() error { return secondErr })
+
+	vars := kv.NewVariables(nil)
+	vars.SetKillSignalHandler(firstHandler)
+	bo := NewBackofferWithVars(context.Background(), 1, vars)
+
+	const iterations = 10000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	start := make(chan struct{})
+	unexpectedErr := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			vars.SetKillSignalHandler(firstHandler)
+			vars.SetKillSignalHandler(secondHandler)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			err := bo.CheckKilled()
+			if !errors.Is(err, firstErr) && !errors.Is(err, secondErr) {
+				select {
+				case unexpectedErr <- err:
+				default:
+				}
+				return
+			}
+		}
+	}()
+	close(start)
+	wg.Wait()
+	close(unexpectedErr)
+	for err := range unexpectedErr {
+		assert.NoError(t, err)
+	}
+}
 
 func TestBackoffWithMax(t *testing.T) {
 	b := NewBackofferWithVars(context.TODO(), 2000, nil)

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -39,7 +39,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"sync"
 	"testing"
 	"time"
 
@@ -54,6 +53,12 @@ type killSignalHandlerFunc func() error
 
 func (f killSignalHandlerFunc) HandleSignal() error {
 	return f()
+}
+
+type pointerKillSignalHandler struct{}
+
+func (*pointerKillSignalHandler) HandleSignal() error {
+	return errors.New("unexpected call to a typed nil handler")
 }
 
 func TestCheckKilled(t *testing.T) {
@@ -74,57 +79,19 @@ func TestCheckKilled(t *testing.T) {
 	assert.ErrorAs(t, err, &interrupted)
 	assert.Equal(t, killed, interrupted.Signal)
 
+	var nilHandler *pointerKillSignalHandler
+	vars.SetKillSignalHandler(nilHandler)
+	assert.Nil(t, vars.LoadKillSignalHandler())
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
 	bo = NewBackofferWithVars(context.Background(), 1, kv.NewVariables(&killed))
 	err = bo.CheckKilled()
 	assert.ErrorAs(t, err, &interrupted)
 	assert.Equal(t, killed, interrupted.Signal)
 
 	assert.NoError(t, NewBackofferWithVars(context.Background(), 1, nil).CheckKilled())
-}
-
-func TestCheckKilledConcurrentHandlerUpdate(t *testing.T) {
-	firstErr := errors.New("killed by first handler")
-	secondErr := errors.New("killed by second handler")
-	firstHandler := killSignalHandlerFunc(func() error { return firstErr })
-	secondHandler := killSignalHandlerFunc(func() error { return secondErr })
-
-	vars := kv.NewVariables(nil)
-	vars.SetKillSignalHandler(firstHandler)
-	bo := NewBackofferWithVars(context.Background(), 1, vars)
-
-	const iterations = 10000
-	var wg sync.WaitGroup
-	wg.Add(2)
-	start := make(chan struct{})
-	unexpectedErr := make(chan error, 1)
-	go func() {
-		defer wg.Done()
-		<-start
-		for i := 0; i < iterations; i++ {
-			vars.SetKillSignalHandler(firstHandler)
-			vars.SetKillSignalHandler(secondHandler)
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		<-start
-		for i := 0; i < iterations; i++ {
-			err := bo.CheckKilled()
-			if !errors.Is(err, firstErr) && !errors.Is(err, secondErr) {
-				select {
-				case unexpectedErr <- err:
-				default:
-				}
-				return
-			}
-		}
-	}()
-	close(start)
-	wg.Wait()
-	close(unexpectedErr)
-	for err := range unexpectedErr {
-		assert.NoError(t, err)
-	}
 }
 
 func TestBackoffWithMax(t *testing.T) {

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -34,6 +34,15 @@
 
 package kv
 
+import "sync/atomic"
+
+// KillSignalHandler handles kill signals at interruptible KV request checkpoints.
+// Implementations must be safe for concurrent use.
+type KillSignalHandler interface {
+	// HandleSignal returns an error when the current operation should stop.
+	HandleSignal() error
+}
+
 // Variables defines the variables used by KV storage.
 type Variables struct {
 	// BackoffLockFast specifies the LockFast backoff base duration in milliseconds.
@@ -56,6 +65,30 @@ type Variables struct {
 	// TxnFileMinMutationSize is the minimum size of mutations to use file-based txn.
 	// When its value is 0, use the config of "txn-file-min-mutation-size".
 	TxnFileMinMutationSize uint64
+
+	// killSignalHandler takes precedence over Killed when it is set. It is stored
+	// atomically because Variables can be shared by concurrent backoffers.
+	killSignalHandler atomic.Pointer[KillSignalHandler]
+}
+
+// SetKillSignalHandler atomically sets the handler used at interruptible KV request
+// checkpoints. Passing nil clears the handler.
+func (v *Variables) SetKillSignalHandler(handler interface{ HandleSignal() error }) {
+	if handler == nil {
+		v.killSignalHandler.Store(nil)
+		return
+	}
+	typedHandler := KillSignalHandler(handler)
+	v.killSignalHandler.Store(&typedHandler)
+}
+
+// LoadKillSignalHandler atomically loads the handler used at interruptible KV request checkpoints.
+func (v *Variables) LoadKillSignalHandler() KillSignalHandler {
+	handler := v.killSignalHandler.Load()
+	if handler == nil {
+		return nil
+	}
+	return *handler
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -64,20 +64,9 @@ type Variables struct {
 	// When its value is 0, use the config of "txn-file-min-mutation-size".
 	TxnFileMinMutationSize uint64
 
-	// killSignalHandler takes precedence over Killed when it is set.
+	// KillSignalHandler takes precedence over Killed when it is set.
 	// It must be configured before Variables is used by concurrent requests.
-	killSignalHandler KillSignalHandler
-}
-
-// SetKillSignalHandler sets the handler used at interruptible KV request checkpoints.
-// It must not be called concurrently with requests using v. Passing nil clears the handler.
-func (v *Variables) SetKillSignalHandler(handler KillSignalHandler) {
-	v.killSignalHandler = handler
-}
-
-// LoadKillSignalHandler returns the handler used at interruptible KV request checkpoints.
-func (v *Variables) LoadKillSignalHandler() KillSignalHandler {
-	return v.killSignalHandler
+	KillSignalHandler KillSignalHandler
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -34,8 +34,6 @@
 
 package kv
 
-import "reflect"
-
 // KillSignalHandler handles kill signals at interruptible KV request checkpoints.
 // Implementations must be safe for concurrent use.
 type KillSignalHandler interface {
@@ -72,33 +70,14 @@ type Variables struct {
 }
 
 // SetKillSignalHandler sets the handler used at interruptible KV request checkpoints.
-// It must not be called concurrently with requests using v. Passing nil or a typed
-// nil clears the handler.
+// It must not be called concurrently with requests using v. Passing nil clears the handler.
 func (v *Variables) SetKillSignalHandler(handler interface{ HandleSignal() error }) {
-	if isNilKillSignalHandler(handler) {
-		v.killSignalHandler = nil
-		return
-	}
 	v.killSignalHandler = handler
 }
 
 // LoadKillSignalHandler returns the handler used at interruptible KV request checkpoints.
 func (v *Variables) LoadKillSignalHandler() KillSignalHandler {
 	return v.killSignalHandler
-}
-
-func isNilKillSignalHandler(handler KillSignalHandler) bool {
-	if handler == nil {
-		return true
-	}
-	value := reflect.ValueOf(handler)
-	switch value.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
-		reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
-		return value.IsNil()
-	default:
-		return false
-	}
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -71,7 +71,7 @@ type Variables struct {
 
 // SetKillSignalHandler sets the handler used at interruptible KV request checkpoints.
 // It must not be called concurrently with requests using v. Passing nil clears the handler.
-func (v *Variables) SetKillSignalHandler(handler interface{ HandleSignal() error }) {
+func (v *Variables) SetKillSignalHandler(handler KillSignalHandler) {
 	v.killSignalHandler = handler
 }
 

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -34,7 +34,7 @@
 
 package kv
 
-import "sync/atomic"
+import "reflect"
 
 // KillSignalHandler handles kill signals at interruptible KV request checkpoints.
 // Implementations must be safe for concurrent use.
@@ -66,29 +66,39 @@ type Variables struct {
 	// When its value is 0, use the config of "txn-file-min-mutation-size".
 	TxnFileMinMutationSize uint64
 
-	// killSignalHandler takes precedence over Killed when it is set. It is stored
-	// atomically because Variables can be shared by concurrent backoffers.
-	killSignalHandler atomic.Pointer[KillSignalHandler]
+	// killSignalHandler takes precedence over Killed when it is set.
+	// It must be configured before Variables is used by concurrent requests.
+	killSignalHandler KillSignalHandler
 }
 
-// SetKillSignalHandler atomically sets the handler used at interruptible KV request
-// checkpoints. Passing nil clears the handler.
+// SetKillSignalHandler sets the handler used at interruptible KV request checkpoints.
+// It must not be called concurrently with requests using v. Passing nil or a typed
+// nil clears the handler.
 func (v *Variables) SetKillSignalHandler(handler interface{ HandleSignal() error }) {
-	if handler == nil {
-		v.killSignalHandler.Store(nil)
+	if isNilKillSignalHandler(handler) {
+		v.killSignalHandler = nil
 		return
 	}
-	typedHandler := KillSignalHandler(handler)
-	v.killSignalHandler.Store(&typedHandler)
+	v.killSignalHandler = handler
 }
 
-// LoadKillSignalHandler atomically loads the handler used at interruptible KV request checkpoints.
+// LoadKillSignalHandler returns the handler used at interruptible KV request checkpoints.
 func (v *Variables) LoadKillSignalHandler() KillSignalHandler {
-	handler := v.killSignalHandler.Load()
+	return v.killSignalHandler
+}
+
+func isNilKillSignalHandler(handler KillSignalHandler) bool {
 	if handler == nil {
-		return nil
+		return true
 	}
-	return *handler
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1138,22 +1138,9 @@ func (c *twoPhaseCommitter) doActionOnBatches(
 	bo *retry.Backoffer, action twoPhaseCommitAction,
 	batches []batchMutations,
 ) error {
-	// killSignal should never be nil for TiDB
-	if c.txn != nil && c.txn.vars != nil && c.txn.vars.Killed != nil {
-		// Do not reset the killed flag here. Let the upper layer reset the flag.
-		// Before it resets, any request is considered valid to be killed if the
-		// corresponding action is interruptible.
-		status := atomic.LoadUint32(c.txn.vars.Killed)
-		if status != 0 && action.isInterruptible() {
-			logutil.BgLogger().Info(
-				"query is killed", zap.Uint32(
-					"signal",
-					status,
-				),
-			)
-			// TODO: There might be various signals besides a query interruption,
-			// but we are unable to differentiate them, because the definition is in TiDB.
-			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: status})
+	if action.isInterruptible() {
+		if err := bo.CheckKilled(); err != nil {
+			return err
 		}
 	}
 	if len(batches) == 0 {


### PR DESCRIPTION
## Problem

TiDB needs to run richer kill-signal handling at interruptible TiKV retry checkpoints so it can cooperatively detect a disconnected client while a statement is blocked in TiKV. The existing client-go code only reads the legacy `Killed` flag, and the 2PC path duplicates that check.

This is needed by [pingcap/tidb#68682](https://github.com/pingcap/tidb/issues/68682).

Downstream integration: [pingcap/tidb#70343](https://github.com/pingcap/tidb/pull/70343).

## What changed

- Add the optional `kv.KillSignalHandler` interface to `kv.Variables`.
- Let `Backoffer.CheckKilled` delegate to the handler when configured, while preserving the existing `Killed` fallback for compatibility.
- Reuse `Backoffer.CheckKilled` for interruptible 2PC actions instead of duplicating the atomic kill-flag check.
- Add unit coverage for handler precedence, legacy fallback, and nil variables.

## Compatibility

This is an additive API change. Existing callers that only populate `Variables.Killed` keep the previous behavior. TiDB can opt in by installing its SQL kill-signal handler.

## Tests

- `go test ./config/retry ./txnkv/transaction`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for kill signals during interruptible operations.
  * Kill-signal handlers can now provide custom interruption errors.
  * Existing kill-state behavior remains supported as a fallback.

* **Bug Fixes**
  * Improved cancellation checks before processing transaction batches.
  * Correctly reports query interruptions caused by kill signals.
  * Avoids unnecessary checks when kill-related settings are unavailable.
  * Improved reliability when kill-signal handling changes during concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->