### PR TITLE
txnkv: backport async and batched lite lock resolve

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -228,7 +228,7 @@ func DefaultTiKVClient() TiKVClient {
 		},
 		CoprReqTimeout: 60 * time.Second,
 
-		ResolveLockLiteThreshold:   16,
+		ResolveLockLiteThreshold:   512,
 		MaxConcurrencyRequestLimit: DefMaxConcurrencyRequestLimit,
 		EnableReplicaSelectorV2:    true,
 		RUV2:                       DefaultRUV2TiKVConfig(),

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1012,6 +1012,346 @@ func (s *testLockSuite) TestResolveLocksForRead() {
 	s.Equal(committedLocks, committed)
 }
 
+func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
+	if *withTiKV {
+		s.T().Skip("this test validates client-side ResolveLock request planning and avoids real TiKV split timing")
+	}
+
+	originalConf := *config.GetGlobalConfig()
+	testConf := originalConf
+	const resolveLiteThreshold = uint64(8)
+	testConf.TiKVClient.ResolveLockLiteThreshold = resolveLiteThreshold
+	config.StoreGlobalConfig(&testConf)
+	defer config.StoreGlobalConfig(&originalConf)
+
+	// Prewrite all keys but commit only the primary key. The secondary locks stay
+	// unresolved and become the inputs to ResolveLocksWithOpts below.
+	prepareTxn := func(primary []byte, secondaryKeys [][]byte, txnSize int) (uint64, uint64, []*txnkv.Lock) {
+		txn, err := s.store.Begin()
+		s.Nil(err)
+		s.Nil(txn.Set(primary, []byte("primary_value")))
+		for i, key := range secondaryKeys {
+			s.Nil(txn.Set(key, []byte(fmt.Sprintf("secondary_value_%d", i))))
+		}
+
+		committer, err := txn.NewCommitter(1)
+		s.Nil(err)
+		committer.SetPrimaryKey(primary)
+		committer.SetTxnSize(txnSize)
+		committer.SetLockTTL(3000)
+		s.Nil(committer.PrewriteAllMutations(context.Background()))
+
+		commitTS, err := s.store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+		s.Nil(err)
+		committer.SetCommitTS(commitTS)
+		s.Nil(committer.CommitMutations(context.Background()))
+
+		locks := make([]*txnkv.Lock, 0, len(secondaryKeys))
+		for _, key := range secondaryKeys {
+			locks = append(locks, s.mustGetLock(key))
+		}
+		return txn.StartTS(), commitTS, locks
+	}
+
+	pinLockTxnSize := func(locks []*txnkv.Lock, txnSize uint64) {
+		for _, lock := range locks {
+			lock.TxnSize = txnSize
+		}
+	}
+
+	runCase := func(name string, forRead bool) {
+		s.Run(name, func() {
+			key := func(suffix string) []byte {
+				return []byte(fmt.Sprintf("batch_lite_%s_%s", name, suffix))
+			}
+			scanStartKey := key("")
+			scanEndKey := []byte(fmt.Sprintf("batch_lite_%s_\xff", name))
+
+			// Split the keyspace so the multi-key lite transaction is resolved
+			// by one ResolveLock request per region.
+			splitKey := key("multi_m")
+			_, err := s.store.SplitRegions(context.Background(), [][]byte{splitKey}, false, nil)
+			s.Nil(err)
+
+			// A small transaction with multiple locks spanning two regions. It
+			// should be batched by txn and then split into region-level
+			// ResolveLock requests.
+			multiKeyTxnKeys := [][]byte{
+				key("multi_a1"),
+				key("multi_a2"),
+				key("multi_z1"),
+			}
+			multiKeyTxnID, multiKeyCommitTS, multiKeyLocks := prepareTxn(
+				key("multi_primary"),
+				multiKeyTxnKeys,
+				len(multiKeyTxnKeys)+1,
+			)
+
+			// A small transaction with one lock. It should keep the old
+			// single-key lite resolve shape.
+			singleKeyTxnKeys := [][]byte{key("single_secondary")}
+			singleKeyTxnID, singleKeyCommitTS, singleKeyLocks := prepareTxn(
+				key("single_primary"),
+				singleKeyTxnKeys,
+				len(singleKeyTxnKeys)+1,
+			)
+
+			// A large transaction. It should bypass the batched-lite path and
+			// use the original region-level resolve with empty Keys.
+			regionLevelTxnKeys := [][]byte{key("region_secondary")}
+			regionLevelTxnID, regionLevelCommitTS, regionLevelLocks := prepareTxn(
+				key("region_primary"),
+				regionLevelTxnKeys,
+				int(resolveLiteThreshold)+1,
+			)
+
+			// Pin the resolver branch condition directly on the Lock inputs.
+			// This keeps the test stable even if the default lite threshold changes.
+			pinLockTxnSize(multiKeyLocks, resolveLiteThreshold-1)
+			pinLockTxnSize(singleKeyLocks, resolveLiteThreshold-1)
+			pinLockTxnSize(regionLevelLocks, resolveLiteThreshold+1)
+
+			boForLocate := tikv.NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
+			loc1, err := s.store.GetRegionCache().LocateKey(boForLocate, multiKeyTxnKeys[0])
+			s.Nil(err)
+			loc2, err := s.store.GetRegionCache().LocateKey(boForLocate, multiKeyTxnKeys[2])
+			s.Nil(err)
+			s.NotEqual(loc1.Region.GetID(), loc2.Region.GetID())
+
+			resolver := s.store.NewLockResolver()
+			defer resolver.Close()
+			const expectedResolveReqCount = 4
+			const expectedLiteResolveReqCount = 3
+			asyncResolveTaskCountBefore := resolver.AsyncResolveTaskCount()
+			resolveLockLiteBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite)
+
+			// Capture ResolveLock RPCs after RegionRequestSender attaches region
+			// context. The hook blocks ResolveLock requests so the test can
+			// distinguish client-side async resolve from synchronous resolve.
+			var resolveReqMu sync.Mutex
+			var resolveReqs []*tikvrpc.Request
+			unblockResolveReqs := make(chan struct{})
+			var unblockResolveReqsOnce sync.Once
+			unblockResolveReqsFn := func() {
+				unblockResolveReqsOnce.Do(func() {
+					close(unblockResolveReqs)
+				})
+			}
+			defer unblockResolveReqsFn()
+			s.Nil(failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+			defer func() {
+				s.Nil(failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+			}()
+
+			ctx := util.WithInternalSourceType(context.Background(), fmt.Sprintf("batch_lite_resolve_%s", name))
+			ctx = context.WithValue(ctx, "sendReqToRegionHook", func(req *tikvrpc.Request) {
+				if req.Type == tikvrpc.CmdResolveLock {
+					resolveReqMu.Lock()
+					resolveReqs = append(resolveReqs, req)
+					resolveReqMu.Unlock()
+					if !forRead {
+						s.Equal(asyncResolveTaskCountBefore, resolver.AsyncResolveTaskCount())
+					}
+					<-unblockResolveReqs
+				}
+			})
+			getResolveReqs := func() []*tikvrpc.Request {
+				resolveReqMu.Lock()
+				defer resolveReqMu.Unlock()
+				return append([]*tikvrpc.Request(nil), resolveReqs...)
+			}
+			scanRemainingLocks := func() ([]*txnkv.Lock, error) {
+				scanTS, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+				if err != nil {
+					return nil, err
+				}
+				return s.store.ScanLocks(context.Background(), scanStartKey, scanEndKey, scanTS)
+			}
+
+			callerStartTS := uint64(0)
+			if forRead {
+				callerStartTS, err = s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+				s.Nil(err)
+			}
+
+			bo := tikv.NewBackofferWithVars(ctx, getMaxBackoff, nil)
+			locks := make([]*txnkv.Lock, 0, len(multiKeyLocks)+len(singleKeyLocks)+len(regionLevelLocks))
+			locks = append(locks, multiKeyLocks...)
+			locks = append(locks, singleKeyLocks...)
+			locks = append(locks, regionLevelLocks...)
+			if forRead {
+				resolver.SetAsyncResolveContext(ctx)
+			}
+			type resolveCallResult struct {
+				res txnlock.ResolveLockResult
+				err error
+			}
+			resolveDone := make(chan resolveCallResult, 1)
+			go func() {
+				res, err := resolver.ResolveLocksWithOpts(bo, txnlock.ResolveLocksOptions{
+					CallerStartTS: callerStartTS,
+					Locks:         locks,
+					ForRead:       forRead,
+				})
+				resolveDone <- resolveCallResult{res: res, err: err}
+			}()
+
+			waitResolveDone := func() resolveCallResult {
+				select {
+				case result := <-resolveDone:
+					return result
+				case <-time.After(5 * time.Second):
+					s.FailNow("ResolveLocksWithOpts did not return in time")
+					return resolveCallResult{}
+				}
+			}
+
+			if forRead {
+				// forRead uses client-side async resolve: ResolveLocksWithOpts
+				// should return while the ResolveLock RPCs are still blocked.
+				callResult := waitResolveDone()
+				s.Nil(callResult.err)
+				s.Equal(int64(0), callResult.res.TTL)
+				s.Eventually(func() bool {
+					return len(getResolveReqs()) >= expectedResolveReqCount
+				}, 5*time.Second, 10*time.Millisecond)
+				s.Equal(asyncResolveTaskCountBefore+expectedResolveReqCount, resolver.AsyncResolveTaskCount())
+				unblockResolveReqsFn()
+				s.Eventually(func() bool {
+					return resolver.AsyncResolveTaskCount() == asyncResolveTaskCountBefore
+				}, 5*time.Second, 10*time.Millisecond)
+			} else {
+				// Non-read resolve is synchronous: the call should be blocked by
+				// the first ResolveLock request until the hook is released.
+				s.Eventually(func() bool {
+					return len(getResolveReqs()) > 0
+				}, 5*time.Second, 10*time.Millisecond)
+				s.Equal(asyncResolveTaskCountBefore, resolver.AsyncResolveTaskCount())
+				select {
+				case callResult := <-resolveDone:
+					s.FailNow("synchronous ResolveLocksWithOpts returned before the blocked ResolveLock request was released", callResult)
+				case <-time.After(100 * time.Millisecond):
+				}
+				unblockResolveReqsFn()
+				callResult := waitResolveDone()
+				s.Nil(callResult.err)
+				s.Equal(int64(0), callResult.res.TTL)
+			}
+
+			reqsByTxn := make(map[uint64][]*tikvrpc.Request)
+			for _, req := range getResolveReqs() {
+				s.Equal(util.RequestSourceFromCtx(ctx), req.RequestSource)
+				resolveLock := req.ResolveLock()
+				reqsByTxn[resolveLock.StartVersion] = append(reqsByTxn[resolveLock.StartVersion], req)
+			}
+
+			s.Len(reqsByTxn, 3)
+			s.Equal(resolveLockLiteBefore+expectedLiteResolveReqCount, testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite))
+
+			// The multi-key lite txn is grouped by region. One region has two
+			// keys, and the other has one key.
+			multiKeyReqs := reqsByTxn[multiKeyTxnID]
+			s.Len(multiKeyReqs, 2)
+			var multiKeyResolvedKeys [][]byte
+			var multiKeyResolvedRegions []uint64
+			for _, req := range multiKeyReqs {
+				resolveLock := req.ResolveLock()
+				s.Equal(multiKeyCommitTS, resolveLock.CommitVersion)
+				s.False(resolveLock.GetIsAsync())
+				s.NotEmpty(resolveLock.Keys)
+				multiKeyResolvedKeys = append(multiKeyResolvedKeys, resolveLock.Keys...)
+				multiKeyResolvedRegions = append(multiKeyResolvedRegions, req.RegionId)
+			}
+			s.ElementsMatch(multiKeyTxnKeys, multiKeyResolvedKeys)
+			s.ElementsMatch([]uint64{loc1.Region.GetID(), loc2.Region.GetID()}, multiKeyResolvedRegions)
+
+			// The single-key lite txn still sends a single-key ResolveLock request.
+			singleKeyReqs := reqsByTxn[singleKeyTxnID]
+			s.Len(singleKeyReqs, 1)
+			s.Equal(singleKeyCommitTS, singleKeyReqs[0].ResolveLock().CommitVersion)
+			s.False(singleKeyReqs[0].ResolveLock().GetIsAsync())
+			s.ElementsMatch(singleKeyTxnKeys, singleKeyReqs[0].ResolveLock().Keys)
+
+			// The large txn keeps the original region-level resolve shape.
+			regionLevelReqs := reqsByTxn[regionLevelTxnID]
+			s.Len(regionLevelReqs, 1)
+			s.Equal(regionLevelCommitTS, regionLevelReqs[0].ResolveLock().CommitVersion)
+			s.Equal(forRead && config.NextGen, regionLevelReqs[0].ResolveLock().GetIsAsync())
+			s.Empty(regionLevelReqs[0].ResolveLock().Keys)
+
+			// Finally verify the ResolveLock requests actually clear every lock
+			// created by this test, including the keys that were grouped by
+			// region above.
+			remainingLocks, err := scanRemainingLocks()
+			s.Nil(err)
+			s.Empty(remainingLocks)
+		})
+	}
+
+	runCase("write", false)
+	runCase("for_read", true)
+}
+
+func (s *testLockSuite) TestBatchLiteResolveLocksForReadIgnoresInlineCleanupError() {
+	if *withTiKV {
+		s.T().Skip("this test relies on client-side failpoints for deterministic cleanup errors")
+	}
+
+	// This test covers the for-read fallback path where client-side async
+	// cleanup is rejected and the cleanup runs inline. Once CheckTxnStatus has
+	// confirmed the transaction status, the read can already proceed, so a later
+	// physical cleanup error should be swallowed instead of being returned to
+	// ResolveLocksForRead.
+	key := []byte("batch_lite_for_read_fallback_key")
+	primaryKey := []byte("batch_lite_for_read_fallback_primary")
+	startTS, _ := s.lockKey(key, []byte("value"), primaryKey, []byte("primary_value"), 3000, true, false)
+	lock := s.mustGetLock(key)
+	lock.TxnSize = 1
+
+	callerStartTS, err := s.store.CurrentTimestamp(oracle.GlobalTxnScope)
+	s.Nil(err)
+
+	resolver := s.store.NewLockResolver()
+	defer resolver.Close()
+	// A zero-sized pool rejects client-side async cleanup and forces the
+	// fallback path to execute cleanup inline.
+	resolver.SetAsyncResolvePoolSize(0)
+
+	injectResolveFailure := true
+	resolveFailureInjected := false
+	s.Nil(failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+	defer func() {
+		s.Nil(failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+		if resolveFailureInjected {
+			s.Nil(failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+		}
+	}()
+
+	ctx := context.WithValue(context.Background(), "sendReqToRegionHook", func(req *tikvrpc.Request) {
+		if req.Type == tikvrpc.CmdCheckTxnStatus && injectResolveFailure && !resolveFailureInjected {
+			// Inject the timeout only after the status check request is sent, so
+			// the injected error belongs to the following cleanup ResolveLock RPC.
+			resolveFailureInjected = true
+			s.Nil(failpoint.Enable("tikvclient/tikvStoreSendReqResult", `return("timeout")`))
+		}
+	})
+	bo := tikv.NewBackofferWithVars(ctx, getMaxBackoff, nil)
+	ttl, canIgnore, canAccess, err := resolver.ResolveLocksForRead(bo, callerStartTS, []*txnkv.Lock{lock}, true)
+	s.Nil(err)
+	s.Equal(int64(0), ttl)
+	s.Empty(canIgnore)
+	s.Equal([]uint64{startTS}, canAccess)
+	s.True(resolveFailureInjected)
+
+	injectResolveFailure = false
+	s.Nil(failpoint.Disable("tikvclient/tikvStoreSendReqResult"))
+	resolveFailureInjected = false
+	remainingLock := s.mustGetLock(key)
+	cleanupResolver := s.store.NewLockResolver()
+	defer cleanupResolver.Close()
+	s.Nil(cleanupResolver.ForceResolveLock(context.Background(), remainingLock))
+}
+
 func (s *testLockSuite) TestLockWaitTimeLimit() {
 	k1 := s.key("wait_limit_k1")
 	k2 := s.key("wait_limit_k2")
@@ -1809,6 +2149,13 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 		t.Skip()
 	}
 
+	originalConf := *config.GetGlobalConfig()
+	testConf := originalConf
+	const resolveLiteThreshold = uint64(16)
+	testConf.TiKVClient.ResolveLockLiteThreshold = resolveLiteThreshold
+	config.StoreGlobalConfig(&testConf)
+	defer config.StoreGlobalConfig(&originalConf)
+
 	for _, commitPrimary := range []bool{true, false} {
 		name := "primary_rollback"
 		if commitPrimary {
@@ -1838,7 +2185,7 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 				keys = append(keys, []byte(fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
 				values = append(values, []byte(fmt.Sprintf("value_%s_%03d", name, i)))
 			}
-			require.Greater(t, uint64(len(keys)), config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold)
+			require.Greater(t, uint64(len(keys)), resolveLiteThreshold)
 
 			// prewrite
 			txn, err := store.Begin()

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -49,11 +49,14 @@ import (
 	deadlockpb "github.com/pingcap/kvproto/pkg/deadlock"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/config/retry"
 	tikverr "github.com/tikv/client-go/v2/error"
 	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/metrics"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
@@ -1799,4 +1802,162 @@ func (s *testLockWithTiKVSuite) TestPessimisticLockMaxExecutionTime() {
 	s.NoError(txn5.Rollback())
 	s.NoError(txn6.Rollback())
 	s.NoError(txn7.Rollback())
+}
+
+func TestResolveLockWithTiKVSideAsync(t *testing.T) {
+	if !*withTiKV {
+		t.Skip()
+	}
+
+	for _, commitPrimary := range []bool{true, false} {
+		name := "primary_rollback"
+		if commitPrimary {
+			name = "primary_commit"
+		}
+
+		fetchTSO := func(store tikv.StoreProbe) uint64 {
+			ts, err := store.GetOracle().GetTimestamp(context.Background(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
+			require.NoError(t, err)
+			return ts
+		}
+
+		t.Run(name, func(t *testing.T) {
+			store := tikv.StoreProbe{KVStore: NewTestStore(t)}
+			defer func() {
+				require.NoError(t, store.Close())
+			}()
+
+			ctx := context.Background()
+			lockTTL := uint64(3000)
+			if !commitPrimary {
+				lockTTL = 1
+			}
+
+			keys, values := make([][]byte, 0, 20), make([][]byte, 0, 20)
+			for i := 0; i < cap(keys); i++ {
+				keys = append(keys, []byte(fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
+				values = append(values, []byte(fmt.Sprintf("value_%s_%03d", name, i)))
+			}
+			require.Greater(t, uint64(len(keys)), config.GetGlobalConfig().TiKVClient.ResolveLockLiteThreshold)
+
+			// prewrite
+			txn, err := store.Begin()
+			require.NoError(t, err)
+			for i, key := range keys {
+				require.NoError(t, txn.Set(key, values[i]))
+			}
+			committer, err := txn.NewCommitter(1)
+			require.NoError(t, err)
+			committer.SetPrimaryKey(keys[0])
+			committer.SetTxnSize(len(keys))
+			committer.SetLockTTL(lockTTL)
+			require.NoError(t, committer.PrewriteAllMutations(ctx))
+
+			// commit or rollback the primary
+			if commitPrimary {
+				committer.SetCommitTS(fetchTSO(store))
+				require.NoError(t, committer.CommitMutations(ctx))
+			} else {
+				var lastErr error
+				require.Eventually(t, func() bool {
+					pollCtx, cancel := context.WithTimeout(ctx, time.Second)
+					defer cancel()
+
+					readTS := fetchTSO(store)
+					status, err := store.NewLockResolver().GetTxnStatus(
+						retry.NewBackofferWithVars(pollCtx, 1000, nil),
+						txn.StartTS(),
+						keys[0],
+						readTS,
+						readTS,
+						true,
+						false,
+						nil,
+					)
+					if err != nil {
+						lastErr = err
+						return false
+					}
+					lastErr = nil
+					return status.IsRolledBack()
+				}, 10*time.Second, 100*time.Millisecond)
+				require.NoError(t, lastErr)
+			}
+
+			// check all the locks except the primary lock are kept.
+			keysEnd := []byte(fmt.Sprintf("resolve_lock_%s_\xff", name))
+			locks, err := store.ScanLocks(ctx, keys[0], keysEnd, fetchTSO(store))
+			require.NoError(t, err)
+			require.Len(t, locks, len(keys)-1, "only the primary lock should be resolved")
+
+			// trigger resolve lock for read
+			resolveLocksBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLocks)
+			resolveLockLiteBefore := testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite)
+			resolveLockReqs := make([]*kvrpcpb.ResolveLockRequest, 0)
+			require.NoError(t, failpoint.Enable("tikvclient/beforeSendReqToRegion", "return"))
+			defer func() {
+				require.NoError(t, failpoint.Disable("tikvclient/beforeSendReqToRegion"))
+			}()
+			ctx = context.WithValue(ctx, "sendReqToRegionHook", func(req *tikvrpc.Request) {
+				if req.Type == tikvrpc.CmdResolveLock {
+					resolveLockReqs = append(resolveLockReqs, req.ResolveLock())
+				}
+			})
+			store.GetLockResolver().Close()
+
+			snapshot := store.GetSnapshot(fetchTSO(store))
+			value, err := snapshot.BatchGet(ctx, keys)
+			require.NoError(t, err)
+			if commitPrimary {
+				require.Len(t, value, len(keys))
+			} else {
+				require.Empty(t, value)
+			}
+
+			// wait all locks are resolved
+			require.Eventually(t, func() bool {
+				locks, err := store.ScanLocks(ctx, keys[0], keysEnd, fetchTSO(store))
+				require.NoError(t, err)
+				return len(locks) == 0
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// check resolve lock requests
+			require.NotEmpty(t, resolveLockReqs, "ResolveLock request should be sent")
+			for _, req := range resolveLockReqs {
+				require.Empty(t, req.Keys)
+				if commitPrimary {
+					require.Equal(t, committer.GetCommitTS(), req.CommitVersion)
+				} else {
+					require.Zero(t, req.CommitVersion)
+				}
+				// check in next-gen the IsAsync should be true in ResolveLockRequest
+				require.Equal(t, config.NextGen, req.GetIsAsync(), "ResolveLock should use TiKV-side async resolve")
+			}
+
+			// check resolve lock metrics, no resolve lock lite should be used
+			require.Greater(t,
+				testutil.ToFloat64(metrics.LockResolverCountWithResolveLocks),
+				resolveLocksBefore,
+				"ResolveLocks should be called",
+			)
+			require.Equal(
+				t,
+				resolveLockLiteBefore,
+				testutil.ToFloat64(metrics.LockResolverCountWithResolveLockLite),
+				"ResolveLock should be non-lite",
+			)
+
+			// check the keys are committed or rolled back correctly
+			snapshot = store.GetSnapshot(fetchTSO(store))
+			for i, key := range keys {
+				value, err := snapshot.Get(ctx, key)
+				if commitPrimary {
+					require.NoError(t, err)
+					require.Equal(t, values[i], value.Value)
+				} else {
+					require.True(t, tikverr.IsErrNotFound(err), "unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }

--- a/integration_tests/lock_test.go
+++ b/integration_tests/lock_test.go
@@ -1062,10 +1062,10 @@ func (s *testLockSuite) TestBatchLiteResolveLocksByRegion() {
 	runCase := func(name string, forRead bool) {
 		s.Run(name, func() {
 			key := func(suffix string) []byte {
-				return []byte(fmt.Sprintf("batch_lite_%s_%s", name, suffix))
+				return s.key(fmt.Sprintf("batch_lite_%s_%s", name, suffix))
 			}
 			scanStartKey := key("")
-			scanEndKey := []byte(fmt.Sprintf("batch_lite_%s_\xff", name))
+			scanEndKey := key("\xff")
 
 			// Split the keyspace so the multi-key lite transaction is resolved
 			// by one ResolveLock request per region.
@@ -1302,8 +1302,8 @@ func (s *testLockSuite) TestBatchLiteResolveLocksForReadIgnoresInlineCleanupErro
 	// confirmed the transaction status, the read can already proceed, so a later
 	// physical cleanup error should be swallowed instead of being returned to
 	// ResolveLocksForRead.
-	key := []byte("batch_lite_for_read_fallback_key")
-	primaryKey := []byte("batch_lite_for_read_fallback_primary")
+	key := s.key("batch_lite_for_read_fallback_key")
+	primaryKey := s.key("batch_lite_for_read_fallback_primary")
 	startTS, _ := s.lockKey(key, []byte("value"), primaryKey, []byte("primary_value"), 3000, true, false)
 	lock := s.mustGetLock(key)
 	lock.TxnSize = 1
@@ -2182,7 +2182,7 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 
 			keys, values := make([][]byte, 0, 20), make([][]byte, 0, 20)
 			for i := 0; i < cap(keys); i++ {
-				keys = append(keys, []byte(fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
+				keys = append(keys, encodeKey("~lock_tikv", fmt.Sprintf("resolve_lock_%s_%03d", name, i)))
 				values = append(values, []byte(fmt.Sprintf("value_%s_%03d", name, i)))
 			}
 			require.Greater(t, uint64(len(keys)), resolveLiteThreshold)
@@ -2232,7 +2232,7 @@ func TestResolveLockWithTiKVSideAsync(t *testing.T) {
 			}
 
 			// check all the locks except the primary lock are kept.
-			keysEnd := []byte(fmt.Sprintf("resolve_lock_%s_\xff", name))
+			keysEnd := encodeKey("~lock_tikv", fmt.Sprintf("resolve_lock_%s_\xff", name))
 			locks, err := store.ScanLocks(ctx, keys[0], keysEnd, fetchTSO(store))
 			require.NoError(t, err)
 			require.Len(t, locks, len(keys)-1, "only the primary lock should be resolved")

--- a/internal/client/client_collapse.go
+++ b/internal/client/client_collapse.go
@@ -82,7 +82,7 @@ func (r reqCollapse) SendRequestAsync(ctx context.Context, addr string, req *tik
 	}
 	if req.Type == tikvrpc.CmdResolveLock && len(req.ResolveLock().Keys) == 0 && len(req.ResolveLock().TxnInfos) == 0 {
 		// try collapse resolve lock request.
-		key := strconv.FormatUint(req.RegionId, 10) + "-" + strconv.FormatUint(req.ResolveLock().StartVersion, 10)
+		key := resolveLockCollapseKey(req)
 		copyReq := *req
 		rsC := resolveRegionSf.DoChan(key, func() (interface{}, error) {
 			// resolveRegionSf will call this function in a goroutine, thus use SendRequest directly.
@@ -119,13 +119,20 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 			return
 		}
 		canCollapse = true
-		key := strconv.FormatUint(req.RegionId, 10) + "-" + strconv.FormatUint(resolveLock.StartVersion, 10)
+		key := resolveLockCollapseKey(req)
 		resp, err = r.collapse(ctx, key, &resolveRegionSf, addr, req, timeout)
 		return
 	default:
 		// now we only support collapse resolve lock.
 		return
 	}
+}
+
+func resolveLockCollapseKey(req *tikvrpc.Request) string {
+	resolveLock := req.ResolveLock()
+	return strconv.FormatUint(req.RegionId, 10) + "-" +
+		strconv.FormatUint(resolveLock.StartVersion, 10) + "-" +
+		strconv.FormatBool(resolveLock.GetIsAsync())
 }
 
 func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -227,12 +227,13 @@ func (c *chanClient) SendRequestAsync(ctx context.Context, addr string, req *tik
 }
 
 func TestCollapseResolveLock(t *testing.T) {
-	buildResolveLockReq := func(regionID uint64, startTS uint64, commitTS uint64, keys [][]byte) *tikvrpc.Request {
+	buildResolveLockReq := func(regionID uint64, startTS uint64, commitTS uint64, keys [][]byte, isAsync bool) *tikvrpc.Request {
 		region := &metapb.Region{Id: regionID}
 		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, &kvrpcpb.ResolveLockRequest{
 			StartVersion:  startTS,
 			CommitVersion: commitTS,
 			Keys:          keys,
+			IsAsync:       isAsync,
 		})
 		tikvrpc.SetContextNoAttach(req, region, nil)
 		return req
@@ -252,7 +253,7 @@ func TestCollapseResolveLock(t *testing.T) {
 	ctx := context.Background()
 
 	// Collapse ResolveLock.
-	resolveLockReq := buildResolveLockReq(1, 10, 20, nil)
+	resolveLockReq := buildResolveLockReq(1, 10, 20, nil, false)
 	wg.Add(1)
 	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
 	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
@@ -266,8 +267,33 @@ func TestCollapseResolveLock(t *testing.T) {
 	default:
 	}
 
+	// Collapse async ResolveLock separately.
+	asyncResolveLockReq := buildResolveLockReq(1, 10, 20, nil, true)
+	wg.Add(1)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	time.Sleep(300 * time.Millisecond)
+	wg.Done()
+	req = <-reqCh
+	assert.Equal(t, *req, *asyncResolveLockReq)
+	select {
+	case <-reqCh:
+		assert.Fail(t, "fail to collapse async ResolveLock")
+	default:
+	}
+
+	// Don't collapse sync ResolveLock with async ResolveLock signal.
+	wg.Add(1)
+	go client.SendRequest(ctx, "", resolveLockReq, time.Second)
+	go client.SendRequest(ctx, "", asyncResolveLockReq, time.Second)
+	time.Sleep(300 * time.Millisecond)
+	wg.Done()
+	for i := 0; i < 2; i++ {
+		<-reqCh
+	}
+
 	// Don't collapse ResolveLockLite.
-	resolveLockLiteReq := buildResolveLockReq(1, 10, 20, [][]byte{[]byte("foo")})
+	resolveLockLiteReq := buildResolveLockReq(1, 10, 20, [][]byte{[]byte("foo")}, false)
 	wg.Add(1)
 	go client.SendRequest(ctx, "", resolveLockLiteReq, time.Second)
 	go client.SendRequest(ctx, "", resolveLockLiteReq, time.Second)

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -563,24 +563,24 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 	// TODO: Maybe put it in LockResolver and share by all txns.
 	cleanTxns := make(map[uint64]map[locate.RegionVerID]struct{})
 	pessimisticCleanTxns := make(map[uint64]map[locate.RegionVerID]struct{})
-	var resolve func(*Lock, bool) (TxnStatus, error)
-	resolve = func(l *Lock, forceSyncCommit bool) (TxnStatus, error) {
+	var resolve func(*Lock, bool) (TxnStatus, bool, error)
+	resolve = func(l *Lock, forceSyncCommit bool) (_ TxnStatus, needBatchLiteResolve bool, _ error) {
 		status, err := lr.getTxnStatusFromLock(bo, l, callerStartTS, forceSyncCommit, detail)
 
 		if _, ok := errors.Cause(err).(primaryMismatch); ok {
 			if !l.IsPessimistic() {
 				logutil.BgLogger().Info("unexpected primaryMismatch error occurred on a non-pessimistic lock", zap.Stringer("lock", l), zap.Error(err))
-				return TxnStatus{}, err
+				return TxnStatus{}, false, err
 			}
 			// Pessimistic rollback the pessimistic lock as it points to an invalid primary.
 			status, err = TxnStatus{}, nil
 		} else if err != nil {
-			return TxnStatus{}, err
+			return TxnStatus{}, false, err
 		}
 		ttlExpired := (lr.store == nil) || (lr.store.GetOracle().IsExpired(l.TxnID, status.ttl, &oracle.Option{TxnScope: oracle.GlobalTxnScope}))
 		expiredAsyncCommitLocks := status.primaryLock != nil && status.primaryLock.UseAsyncCommit && !forceSyncCommit && ttlExpired
 		if status.ttl != 0 && !expiredAsyncCommitLocks {
-			return status, nil
+			return status, false, nil
 		}
 
 		// If the lock is non-async-commit type:
@@ -602,14 +602,14 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			// resolveAsyncCommitLock will resolve all locks of the transaction, so we needn't resolve
 			// it again if it has been resolved once.
 			if exists {
-				return status, nil
+				return status, false, nil
 			}
 			// status of async-commit transaction is determined by resolveAsyncCommitLock.
 			status, err = lr.resolveAsyncCommitLock(bo, l, status, forRead)
 			if _, ok := errors.Cause(err).(*nonAsyncCommitLock); ok {
-				status, err = resolve(l, true)
+				status, needBatchLiteResolve, err = resolve(l, true)
 			}
-			return status, err
+			return status, needBatchLiteResolve, err
 		}
 		if l.IsPessimistic() {
 			// pessimistic locks don't block read so it needn't be async.
@@ -624,12 +624,16 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				err = lr.resolvePessimisticLock(bo, l, false, nil)
 			}
 		} else {
+			if lite || l.TxnSize < lr.resolveLockLiteThreshold {
+				// Avoid sending one lite ResolveLock request per lock.
+				// Defer it so locks from the same transaction can be batched later.
+				return status, true, err
+			}
 			asyncResolve := false
 			resultRequired := true
 			if forRead {
 				resultRequired = false
-				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
-				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
+				asyncBo := lr.newAsyncResolveBackoffer(bo)
 				asyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
@@ -647,21 +651,45 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				err = lr.resolveLock(bo, l, status, lite, resultRequired, cleanRegions)
 			}
 		}
-		return status, err
+		return status, false, err
 	}
 
 	var canIgnore, canAccess []uint64
+	type batchLiteResolveTxn struct {
+		txnStatus TxnStatus
+		firstLock *Lock
+		keys      [][]byte
+	}
+	// TxnID -> locks that should use the lite ResolveLock path. They are
+	// collected first so a transaction with multiple encountered locks sends at
+	// most one ResolveLock request per region instead of one request per key.
+	var batchLiteResolveTxnList map[uint64]*batchLiteResolveTxn
 	for _, l := range locks {
 		if l.IsShared() {
 			logutil.Logger(bo.GetCtx()).Warn("cannot resolve a shared lock directly, should extract the inner locks and resolve them one by one", zap.Stack("stack"))
 			return ResolveLockResult{}, errors.New("misuse of resolveLocks: trying to resolve a shared lock directly")
 		}
-		status, err := resolve(l, false)
+		status, batchLiteResolve, err := resolve(l, false)
 		if err != nil {
 			msBeforeTxnExpired.update(0)
 			return ResolveLockResult{
 				TTL: msBeforeTxnExpired.value(),
 			}, err
+		}
+		if batchLiteResolve {
+			if batchLiteResolveTxnList == nil {
+				batchLiteResolveTxnList = make(map[uint64]*batchLiteResolveTxn)
+			}
+			txn, ok := batchLiteResolveTxnList[l.TxnID]
+			if ok {
+				txn.keys = append(txn.keys, l.Key)
+			} else {
+				batchLiteResolveTxnList[l.TxnID] = &batchLiteResolveTxn{
+					txnStatus: status,
+					firstLock: l,
+					keys:      [][]byte{l.Key},
+				}
+			}
 		}
 		if !forRead {
 			if status.ttl != 0 {
@@ -688,6 +716,19 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			msBeforeTxnExpired.update(msBeforeLockExpired)
 		}
 	}
+
+	// Resolve all collected lite locks after the status pass. For read requests,
+	// this cleanup may be scheduled in the async resolve pool; for write or
+	// result-required requests it is resolved synchronously.
+	for _, txn := range batchLiteResolveTxnList {
+		if err = lr.batchLiteResolveLocks(bo, txn.firstLock, txn.keys, txn.txnStatus, forRead); err != nil {
+			msBeforeTxnExpired.update(0)
+			return ResolveLockResult{
+				TTL: msBeforeTxnExpired.value(),
+			}, err
+		}
+	}
+
 	if msBeforeTxnExpired.value() > 0 {
 		metrics.LockResolverCountWithWaitExpired.Inc()
 	}
@@ -1314,6 +1355,107 @@ func (lr *LockResolver) checkAllSecondaries(bo *retry.Backoffer, l *Lock, status
 	return &shared, nil
 }
 
+func (lr *LockResolver) newAsyncResolveBackoffer(originalBo *retry.Backoffer) *retry.Backoffer {
+	// Async cleanup must not inherit the caller's cancellation, but it should
+	// keep RequestSource for observability.
+	// This intentionally preserves the existing for-read async resolve behavior:
+	// resource group attribution is not copied to the detached cleanup context here.
+	// Whether background lock cleanup should be charged to the triggering request's resource group is a separate
+	// policy decision.
+	asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, originalBo.GetCtx().Value(util.RequestSourceKey))
+	return retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
+}
+
+// batchLiteResolveLocks resolves small-transaction locks that have already had
+// their primary status checked. keys must all belong to l.TxnID.
+func (lr *LockResolver) batchLiteResolveLocks(bo *retry.Backoffer, l *Lock, keys [][]byte, status TxnStatus, forRead bool) error {
+	logErr := func(err error, failedKeys [][]byte) {
+		if err == nil {
+			return
+		}
+		failedKeysForLog := make([]string, len(failedKeys))
+		for i, key := range failedKeys {
+			failedKeysForLog[i] = redact.Key(key)
+		}
+		logutil.BgLogger().Info("failed to batch resolve lock lite",
+			zap.String("lock", l.String()),
+			zap.Strings("keys", failedKeysForLog),
+			zap.Uint64("commitTS", status.CommitTS()),
+			zap.Bool("forRead", forRead),
+			zap.Error(err),
+		)
+	}
+
+	inplaceOrScheduleAsync := func(bo *retry.Backoffer, f func(*retry.Backoffer) error) (err error) {
+		isAsync := false
+		if forRead {
+			asyncBo := lr.newAsyncResolveBackoffer(bo)
+			isAsync = lr.asyncResolvePool.tryAsyncResolve(func() {
+				// do not return error when forRead
+				_ = f(asyncBo)
+			}, metrics.LockResolverAsyncRunningTasksForReadResolve)
+
+			if !isAsync {
+				metrics.LockResolverCountWithReadAsyncResolveFallback.Inc()
+			}
+		}
+
+		// isAsync is false means either it is not for read or the async resolve
+		// task is rejected.
+		if !isAsync {
+			if err = f(bo); err != nil && forRead {
+				// Do not return error for read to make a some behavior with the async cleanup,
+				// so that the only difference between async and async-fallback path is whether the cleanup is
+				// performed in-place or not.
+				err = nil
+			}
+		}
+
+		return
+	}
+
+	if len(keys) == 1 {
+		if intest.InTest {
+			if !bytes.Equal(l.Key, keys[0]) {
+				panic(fmt.Sprintf("the only key in keys should be the same as l.Key, but got %v and %v", l.Key, keys[0]))
+			}
+		}
+		return inplaceOrScheduleAsync(bo, func(asyncBo *retry.Backoffer) error {
+			if err := lr.resolveLock(asyncBo, l, status, true, true, nil); err != nil {
+				logErr(err, keys)
+				return err
+			}
+			return nil
+		})
+	}
+
+	return inplaceOrScheduleAsync(bo, func(asyncBo *retry.Backoffer) error {
+		regions, _, err := lr.store.GetRegionCache().GroupKeysByRegion(asyncBo, keys, nil)
+		if err != nil {
+			logErr(err, keys)
+			return err
+		}
+
+		// Multiple lite keys are resolved with exact key lists per region. This
+		// avoids one RPC per key while still avoiding a whole-region resolve scan.
+		for region, regionKeys := range regions {
+			err = inplaceOrScheduleAsync(asyncBo, func(asyncBo *retry.Backoffer) error {
+				metrics.LockResolverCountWithResolveLockLite.Inc()
+				if err := lr.resolveRegionLocks(asyncBo, l, region, regionKeys, status); err != nil {
+					logErr(err, regionKeys)
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
 // resolveRegionLocks is essentially the same as resolveLock, but we resolve all keys in the same region at the same time.
 func (lr *LockResolver) resolveRegionLocks(bo *retry.Backoffer, l *Lock, region locate.RegionVerID, keys [][]byte, status TxnStatus) error {
 	lreq := &kvrpcpb.ResolveLockRequest{
@@ -1324,6 +1466,7 @@ func (lr *LockResolver) resolveRegionLocks(bo *retry.Backoffer, l *Lock, region 
 	}
 	lreq.Keys = keys
 	req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, lreq, kvrpcpb.Context{
+		RequestSource: util.RequestSourceFromCtx(bo.GetCtx()),
 		ResourceControlContext: &kvrpcpb.ResourceControlContext{
 			ResourceGroupName: util.ResourceGroupNameFromCtx(bo.GetCtx()),
 		},

--- a/txnkv/txnlock/lock_resolver.go
+++ b/txnkv/txnlock/lock_resolver.go
@@ -87,6 +87,9 @@ type LockResolver struct {
 	// The Cancel function is to cancel these goroutines for passing goleak test.
 	asyncResolveCtx    context.Context
 	asyncResolveCancel func()
+
+	// enableTiKVSideAsyncResolve indicates whether to enable TiKV side async resolve.
+	enableTiKVSideAsyncResolve atomic.Bool
 }
 
 // ResolvingLock stands for current resolving locks' information
@@ -109,6 +112,8 @@ func NewLockResolver(store storage) *LockResolver {
 	r.mu.resolvingConcurrency = make(map[uint64]int)
 	r.mu.recentResolved = list.New()
 	r.asyncResolveCtx, r.asyncResolveCancel = context.WithCancel(context.Background())
+	// only next-gen supports TiKV side async resolve currently.
+	r.enableTiKVSideAsyncResolve.Store(config.NextGen)
 	return r
 }
 
@@ -620,13 +625,15 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 			}
 		} else {
 			asyncResolve := false
+			resultRequired := true
 			if forRead {
+				resultRequired = false
 				asyncCtx := context.WithValue(lr.asyncResolveCtx, util.RequestSourceKey, bo.GetCtx().Value(util.RequestSourceKey))
 				asyncBo := retry.NewBackoffer(asyncCtx, asyncResolveLockMaxBackoff)
 				asyncResolve = lr.asyncResolvePool.tryAsyncResolve(func() {
 					// Pass an empty cleanRegions here to avoid data race and
 					// let `reqCollapse` deduplicate identical resolve requests.
-					err := lr.resolveLock(asyncBo, l, status, lite, map[locate.RegionVerID]struct{}{})
+					err := lr.resolveLock(asyncBo, l, status, lite, resultRequired, map[locate.RegionVerID]struct{}{})
 					if err != nil {
 						logutil.BgLogger().Info("failed to resolve lock asynchronously",
 							zap.String("lock", l.String()), zap.Uint64("commitTS", status.CommitTS()), zap.Error(err))
@@ -637,7 +644,7 @@ func (lr *LockResolver) resolveLocks(bo *retry.Backoffer, opts ResolveLocksOptio
 				}
 			}
 			if !asyncResolve {
-				err = lr.resolveLock(bo, l, status, lite, cleanRegions)
+				err = lr.resolveLock(bo, l, status, lite, resultRequired, cleanRegions)
 			}
 		}
 		return status, err
@@ -1383,7 +1390,7 @@ func resolveActionLabel(status TxnStatus) string {
 	return "rollback"
 }
 
-func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStatus, lite bool, cleanRegions map[locate.RegionVerID]struct{}) error {
+func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStatus, lite bool, resultRequired bool, cleanRegions map[locate.RegionVerID]struct{}) error {
 	util.EvalFailpoint("resolveLock")
 
 	metrics.LockResolverCountWithResolveLocks.Inc()
@@ -1420,6 +1427,11 @@ func (lr *LockResolver) resolveLock(bo *retry.Backoffer, l *Lock, status TxnStat
 			// prevent from scanning the whole region in this case.
 			metrics.LockResolverCountWithResolveLockLite.Inc()
 			lreq.Keys = [][]byte{l.Key}
+		} else if !resultRequired && lr.enableTiKVSideAsyncResolve.Load() {
+			if intest.InTest && !config.NextGen {
+				panic("TiKV side async resolve should only be enabled in next-gen cluster")
+			}
+			lreq.IsAsync = true
 		}
 		req := tikvrpc.NewRequest(tikvrpc.CmdResolveLock, lreq, kvrpcpb.Context{
 			ResourceControlContext: &kvrpcpb.ResourceControlContext{

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -15,6 +15,8 @@
 package txnlock
 
 import (
+	"context"
+
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pkg/errors"
 	"github.com/tikv/client-go/v2/config/retry"
@@ -81,6 +83,23 @@ func (l LockResolverProbe) GetSecondariesFromTxnStatus(status TxnStatus) [][]byt
 // SetMeetLockCallback is called whenever it meets locks.
 func (l LockResolverProbe) SetMeetLockCallback(f func([]*Lock)) {
 	l.testingKnobs.meetLock = f
+}
+
+// SetAsyncResolveContext replaces the context used by async resolve tasks.
+func (l LockResolverProbe) SetAsyncResolveContext(ctx context.Context) {
+	l.asyncResolveCancel()
+	l.asyncResolveCtx, l.asyncResolveCancel = context.WithCancel(ctx)
+}
+
+// SetAsyncResolvePoolSize replaces the async resolve pool with a bounded one.
+func (l LockResolverProbe) SetAsyncResolvePoolSize(size int) {
+	l.asyncResolvePool.Close()
+	l.asyncResolvePool = newAsyncResolveTaskPool(make(chan struct{}, size))
+}
+
+// AsyncResolveTaskCount returns the number of running or queued async resolve tasks.
+func (l LockResolverProbe) AsyncResolveTaskCount() int {
+	return len(l.asyncResolvePool.semaphore)
 }
 
 // CheckAllSecondaries checks the secondary locks of an async commit transaction to find out the final

--- a/txnkv/txnlock/test_probe.go
+++ b/txnkv/txnlock/test_probe.go
@@ -54,7 +54,7 @@ func (l LockResolverProbe) ResolveAsyncCommitLock(bo *retry.Backoffer, lock *Loc
 
 // ResolveLock resolves single lock.
 func (l LockResolverProbe) ResolveLock(bo *retry.Backoffer, lock *Lock) error {
-	return l.resolveLock(bo, lock, TxnStatus{}, false, make(map[locate.RegionVerID]struct{}))
+	return l.resolveLock(bo, lock, TxnStatus{}, false, true, make(map[locate.RegionVerID]struct{}))
 }
 
 // ResolvePessimisticLock resolves single pessimistic lock.


### PR DESCRIPTION
## What changed

close #1963

This PR backports #1973 and #1981 to `release-nextgen-202603`:

- enable TiKV-side asynchronous region lock resolution for the read path in NextGen;
- keep synchronous and asynchronous `ResolveLock` requests in separate collapse groups;
- batch lite lock resolution by transaction and region instead of sending one request per key;
- raise the default lite-resolve threshold from 16 to 512 and preserve request-source attribution;
- use TiDB-like mem-comparable keys in the added integration tests, matching the target branch's NextGen/CSE test requirements.

## Why

Read-path lock cleanup can otherwise block on client-side region resolution, while small transactions may issue one lite `ResolveLock` RPC for every encountered key. The backport lets NextGen offload eligible non-lite cleanup to TiKV and reduces lite-resolve RPC fan-out by grouping keys per region.

## Impact

The TiKV-side asynchronous flag is enabled only for NextGen read-path cleanup. Lite resolve batching keeps exact key lists and splits them by region, so it avoids whole-region scans while reducing request count. Read cleanup retains the existing detached/fallback behavior, and synchronous callers still wait for cleanup results.

## Tests

- `go test ./config ./internal/client ./txnkv/txnlock`
- `cd integration_tests && go test . -run '^(TestLock/(TestBatchLiteResolveLocksByRegion|TestBatchLiteResolveLocksForReadIgnoresInlineCleanupError)|TestResolveLockWithTiKVSideAsync)$' -count=1`
- `git diff --check release-nextgen-202603...HEAD`

The TiKV-only async-resolve case compiled but was skipped locally because the test was not run with `--with-tikv`; the two mock-backed lock suite cases passed.
