### PR TITLE
txnkv: expose point response runtime stats

### DIFF
--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -327,6 +327,50 @@ func (s *testPipelinedMemDBSuite) TestPipelinedRollback() {
 	s.Len(storageValues, 0)
 }
 
+func (s *testPipelinedMemDBSuite) TestBufferBatchGetPointResponseStats() {
+	ctx := context.Background()
+	key := s.key("point_response_stats_buffer")
+	txn, err := s.store.Begin(tikv.WithDefaultPipelinedTxn())
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(txn.Rollback()) }()
+	s.Require().NoError(txn.Set(key, []byte("value")))
+	flushed, err := txn.GetMemBuffer().Flush(true)
+	s.Require().NoError(err)
+	s.Require().True(flushed)
+	s.Require().NoError(txn.GetMemBuffer().FlushWait())
+
+	originalClient := s.store.GetTiKVClient()
+	statsClient := &pointResponseBatchGetClient{Client: originalClient}
+	s.store.SetTiKVClient(statsClient)
+	defer s.store.SetTiKVClient(originalClient)
+
+	runtimeStats := &txnkv.SnapshotRuntimeStats{}
+	snapshot := txn.GetSnapshot()
+	snapshot.SetRuntimeStats(runtimeStats)
+	entries, err := snapshot.BatchGetWithTier(
+		ctx,
+		[][]byte{key},
+		txnsnapshot.BatchGetBufferTier,
+		kv.BatchGetOptions{},
+	)
+	s.Require().NoError(err)
+	s.Require().Equal([]byte("value"), entries[string(key)].Value)
+
+	responses := statsClient.getCompletedResponses()
+	s.Require().Positive(responses)
+	pointStats := runtimeStats.GetPointResponseStats()
+	s.True(pointStats.IsValid())
+	s.True(pointStats.ScanDetailComplete())
+	s.True(pointStats.PayloadComplete())
+	s.Equal(int64(responses*5), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(responses*3), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(responses*30), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(uint64(len(key)+len("value")), pointStats.PayloadBytes)
+	s.Equal(responses, pointStats.ScanDetailRecords)
+	s.Equal(responses, pointStats.PayloadRecords)
+	s.Equal(responses, pointStats.CompletedResponses)
+}
+
 func (s *testPipelinedMemDBSuite) TestPipelinedPrefetch() {
 	failpoint.Enable("tikvclient/beforeSendReqToRegion", "return")
 	defer failpoint.Disable("tikvclient/beforeSendReqToRegion")

--- a/integration_tests/pipelined_memdb_test.go
+++ b/integration_tests/pipelined_memdb_test.go
@@ -366,9 +366,6 @@ func (s *testPipelinedMemDBSuite) TestBufferBatchGetPointResponseStats() {
 	s.Equal(int64(responses*3), pointStats.ScanDetail.ProcessedKeys)
 	s.Equal(int64(responses*30), pointStats.ScanDetail.ProcessedKeysSize)
 	s.Equal(uint64(len(key)+len("value")), pointStats.PayloadBytes)
-	s.Equal(responses, pointStats.ScanDetailRecords)
-	s.Equal(responses, pointStats.PayloadRecords)
-	s.Equal(responses, pointStats.CompletedResponses)
 }
 
 func (s *testPipelinedMemDBSuite) TestPipelinedPrefetch() {

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pkg/errors"
@@ -59,6 +60,7 @@ import (
 	"github.com/tikv/client-go/v2/txnkv"
 	"github.com/tikv/client-go/v2/txnkv/transaction"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
+	"github.com/tikv/client-go/v2/util/async"
 )
 
 func TestSnapshot(t *testing.T) {
@@ -70,6 +72,78 @@ type testSnapshotSuite struct {
 	store   tikv.StoreProbe
 	prefix  string
 	rowNums []int
+}
+
+type pointResponseBatchGetClient struct {
+	tikv.Client
+	mu                 sync.Mutex
+	completedResponses uint64
+	asyncRequests      uint64
+}
+
+func (c *pointResponseBatchGetClient) decorateResponse(
+	resp *tikvrpc.Response,
+	err error,
+) (*tikvrpc.Response, error) {
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	regionErr, regionErrErr := resp.GetRegionError()
+	if regionErrErr != nil || regionErr != nil {
+		return resp, err
+	}
+
+	details := &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions:         5,
+		ProcessedVersions:     3,
+		ProcessedVersionsSize: 30,
+	}}
+	switch body := resp.Resp.(type) {
+	case *kvrpcpb.BatchGetResponse:
+		body.ExecDetailsV2 = details
+	case *kvrpcpb.BufferBatchGetResponse:
+		body.ExecDetailsV2 = details
+	default:
+		return resp, err
+	}
+	c.mu.Lock()
+	c.completedResponses++
+	c.mu.Unlock()
+	return resp, err
+}
+
+func (c *pointResponseBatchGetClient) SendRequest(
+	ctx context.Context,
+	addr string,
+	req *tikvrpc.Request,
+	timeout time.Duration,
+) (*tikvrpc.Response, error) {
+	return c.decorateResponse(c.Client.SendRequest(ctx, addr, req, timeout))
+}
+
+func (c *pointResponseBatchGetClient) SendRequestAsync(
+	ctx context.Context,
+	addr string,
+	req *tikvrpc.Request,
+	cb async.Callback[*tikvrpc.Response],
+) {
+	cb.Inject(c.decorateResponse)
+	c.mu.Lock()
+	c.asyncRequests++
+	c.mu.Unlock()
+	c.Client.SendRequestAsync(ctx, addr, req, cb)
+}
+
+func (c *pointResponseBatchGetClient) getCompletedResponses() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.completedResponses
+}
+
+func (c *pointResponseBatchGetClient) getAsyncRequests() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.asyncRequests
 }
 
 func (s *testSnapshotSuite) SetupTest() {
@@ -439,6 +513,260 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats() {
 		"dispatch_count:{total:1, max:1, min:1}, " +
 		"fair_queue:{enabled:false, waited_task_slices:{total:0, max:0, min:0}}}"
 	s.Equal(expect, snapshot.FormatStats())
+}
+
+func (s *testSnapshotSuite) TestSnapshotRuntimeStatsGetAndBatchGetCoverage() {
+	restoreConfig := config.UpdateGlobal(func(conf *config.Config) {
+		conf.EnableAsyncBatchGet = false
+	})
+	defer restoreConfig()
+
+	missingKey := s.key("runtime_stats_missing")
+	getKey := s.key("runtime_stats_get")
+	batchGetKey := s.key("runtime_stats_batch_get")
+	txn := s.beginTxn()
+	s.Nil(txn.Set(getKey, []byte("get")))
+	s.Nil(txn.Set(batchGetKey, []byte("batch-get")))
+	s.Nil(txn.Commit(context.Background()))
+
+	snapshot := s.store.GetSnapshot(math.MaxUint64)
+	runtimeStats := &txnkv.SnapshotRuntimeStats{}
+	snapshot.SetRuntimeStats(runtimeStats)
+
+	var responseMu sync.Mutex
+	getResponses := 0
+	fn := func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
+		return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+			resp, err := next(target, req)
+			if err != nil || resp == nil {
+				return resp, err
+			}
+			regionErr, regionErrErr := resp.GetRegionError()
+			if regionErrErr != nil || regionErr != nil {
+				return resp, err
+			}
+
+			responseMu.Lock()
+			defer responseMu.Unlock()
+			switch body := resp.Resp.(type) {
+			case *kvrpcpb.GetResponse:
+				getResponses++
+				if getResponses == 1 {
+					body.ExecDetailsV2 = nil
+				} else {
+					body.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+						TotalVersions:         5,
+						ProcessedVersions:     3,
+						ProcessedVersionsSize: 30,
+					}}
+				}
+			case *kvrpcpb.BatchGetResponse:
+				body.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+					TotalVersions:         7,
+					ProcessedVersions:     4,
+					ProcessedVersionsSize: 40,
+				}}
+			}
+			return resp, err
+		}
+	}
+	snapshot.SetRPCInterceptor(interceptor.NewRPCInterceptor("scan-detail-coverage", fn))
+
+	_, err := snapshot.Get(context.Background(), missingKey)
+	s.True(tikverr.IsErrNotFound(err))
+	entry, err := snapshot.Get(context.Background(), getKey)
+	s.Nil(err)
+	s.Equal([]byte("get"), entry.Value)
+	entries, err := snapshot.BatchGet(context.Background(), [][]byte{batchGetKey})
+	s.Nil(err)
+	s.Equal([]byte("batch-get"), entries[string(batchGetKey)].Value)
+
+	pointStats := runtimeStats.GetPointResponseStats()
+	s.True(pointStats.IsValid())
+	s.False(pointStats.ScanDetailComplete())
+	s.True(pointStats.PayloadComplete())
+	s.Equal(int64(12), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(7), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(70), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(uint64(len("get")+len(batchGetKey)+len("batch-get")), pointStats.PayloadBytes)
+	s.Equal(uint64(2), pointStats.ScanDetailRecords)
+	s.Equal(uint64(3), pointStats.PayloadRecords)
+	s.Equal(uint64(3), pointStats.CompletedResponses)
+}
+
+func (s *testSnapshotSuite) TestSnapshotRuntimeStatsExcludesEpochNotMatch() {
+	ctx := context.Background()
+	key := encodeKey(s.prefix, "runtime_stats_epoch_not_match")
+	txn := s.beginTxn()
+	s.Nil(txn.Set(key, []byte("value")))
+	s.Nil(txn.Commit(ctx))
+
+	snapshot := s.store.GetSnapshot(math.MaxUint64)
+	runtimeStats := &txnkv.SnapshotRuntimeStats{}
+	snapshot.SetRuntimeStats(runtimeStats)
+
+	getAttempts := 0
+	fn := func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
+		return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+			if req.Type == tikvrpc.CmdGet {
+				getAttempts++
+				if getAttempts == 1 {
+					return &tikvrpc.Response{Resp: &kvrpcpb.GetResponse{RegionError: &errorpb.Error{
+						EpochNotMatch: &errorpb.EpochNotMatch{},
+					}}}, nil
+				}
+			}
+			resp, err := next(target, req)
+			if err == nil && resp != nil && req.Type == tikvrpc.CmdGet {
+				body := resp.Resp.(*kvrpcpb.GetResponse)
+				body.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+					TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 10,
+				}}
+			}
+			return resp, err
+		}
+	}
+	snapshot.SetRPCInterceptor(interceptor.NewRPCInterceptor("scan-detail-epoch-not-match", fn))
+
+	entry, err := snapshot.Get(ctx, key)
+	s.Nil(err)
+	s.Equal([]byte("value"), entry.Value)
+	s.Equal(2, getAttempts)
+	pointStats := runtimeStats.GetPointResponseStats()
+	s.True(pointStats.IsValid())
+	s.True(pointStats.ScanDetailComplete())
+	s.True(pointStats.PayloadComplete())
+	s.Equal(int64(1), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(1), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(10), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(uint64(len("value")), pointStats.PayloadBytes)
+	s.Equal(uint64(1), pointStats.ScanDetailRecords)
+	s.Equal(uint64(1), pointStats.PayloadRecords)
+	s.Equal(uint64(1), pointStats.CompletedResponses)
+}
+
+func (s *testSnapshotSuite) TestSnapshotRuntimeStatsPointGetLockRetryCoverage() {
+	ctx := context.Background()
+	key := encodeKey(s.prefix, "runtime_stats_point_lock_retry")
+	txn := s.beginTxn()
+	s.Nil(txn.Set(key, []byte("old-value")))
+	s.Nil(txn.Commit(ctx))
+
+	lockingTxn := s.beginTxn()
+	s.Nil(lockingTxn.Set(key, []byte("locked-value")))
+	committer, err := lockingTxn.NewCommitter(1)
+	s.Nil(err)
+	s.Nil(committer.PrewriteAllMutations(ctx))
+	defer committer.Cleanup(ctx)
+
+	readTxn := s.beginTxn()
+	snapshot := readTxn.GetSnapshot()
+	runtimeStats := &txnkv.SnapshotRuntimeStats{}
+	snapshot.SetRuntimeStats(runtimeStats)
+	lockedResponseSeen := make(chan struct{})
+	cleanupDone := make(chan struct{})
+	go func() {
+		<-lockedResponseSeen
+		committer.Cleanup(ctx)
+		close(cleanupDone)
+	}()
+
+	getResponses := 0
+	var signalLockResponse sync.Once
+	fn := func(next interceptor.RPCInterceptorFunc) interceptor.RPCInterceptorFunc {
+		return func(target string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
+			resp, err := next(target, req)
+			if err != nil || resp == nil || req.Type != tikvrpc.CmdGet {
+				return resp, err
+			}
+			body := resp.Resp.(*kvrpcpb.GetResponse)
+			getResponses++
+			body.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+				TotalVersions: 2, ProcessedVersions: 1, ProcessedVersionsSize: 10,
+			}}
+			if body.GetError() != nil && body.GetError().GetLocked() != nil {
+				signalLockResponse.Do(func() { close(lockedResponseSeen) })
+				<-cleanupDone
+			}
+			return resp, err
+		}
+	}
+	snapshot.SetRPCInterceptor(interceptor.NewRPCInterceptor("scan-detail-point-lock-retry", fn))
+
+	entry, err := snapshot.Get(ctx, key)
+	s.Nil(err)
+	s.Equal([]byte("old-value"), entry.Value)
+	s.Equal(2, getResponses)
+	pointStats := runtimeStats.GetPointResponseStats()
+	s.True(pointStats.IsValid())
+	s.True(pointStats.ScanDetailComplete())
+	s.True(pointStats.PayloadComplete())
+	s.Equal(int64(4), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(2), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(20), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(uint64(len("old-value")), pointStats.PayloadBytes)
+	s.Equal(uint64(2), pointStats.ScanDetailRecords)
+	s.Equal(uint64(2), pointStats.PayloadRecords)
+	s.Equal(uint64(2), pointStats.CompletedResponses)
+}
+
+func (s *testSnapshotSuite) TestSnapshotRuntimeStatsAsyncBatchGetMultipleRegionsCoverage() {
+	restoreConfig := config.UpdateGlobal(func(conf *config.Config) {
+		conf.EnableAsyncBatchGet = true
+	})
+	defer restoreConfig()
+
+	ctx := context.Background()
+	leftKey := s.key("runtime_stats_async_a")
+	splitKey := s.key("runtime_stats_async_m")
+	rightKey := s.key("runtime_stats_async_z")
+	txn := s.beginTxn()
+	s.Nil(txn.Set(leftKey, []byte("left")))
+	s.Nil(txn.Set(rightKey, []byte("right")))
+	s.Nil(txn.Commit(ctx))
+
+	preSplitLoc, err := s.store.GetRegionCache().LocateKey(retry.NewNoopBackoff(ctx), splitKey)
+	s.Nil(err)
+	_, err = s.store.SplitRegions(ctx, [][]byte{splitKey}, false, nil)
+	s.Nil(err)
+	s.store.GetRegionCache().InvalidateCachedRegion(preSplitLoc.Region)
+	var leftLoc, rightLoc *tikv.KeyLocation
+	s.Eventually(func() bool {
+		leftLoc, err = s.store.GetRegionCache().LocateKey(retry.NewNoopBackoff(ctx), leftKey)
+		if err != nil {
+			return false
+		}
+		rightLoc, err = s.store.GetRegionCache().LocateKey(retry.NewNoopBackoff(ctx), rightKey)
+		return err == nil && leftLoc.Region.GetID() != rightLoc.Region.GetID()
+	}, 5*time.Second, time.Millisecond)
+
+	originalClient := s.store.GetTiKVClient()
+	detailClient := &pointResponseBatchGetClient{Client: originalClient}
+	s.store.SetTiKVClient(detailClient)
+	defer s.store.SetTiKVClient(originalClient)
+
+	snapshot := s.store.GetSnapshot(math.MaxUint64)
+	runtimeStats := &txnkv.SnapshotRuntimeStats{}
+	snapshot.SetRuntimeStats(runtimeStats)
+	entries, err := snapshot.BatchGet(ctx, [][]byte{leftKey, rightKey})
+	s.Nil(err)
+	s.Equal([]byte("left"), entries[string(leftKey)].Value)
+	s.Equal([]byte("right"), entries[string(rightKey)].Value)
+
+	pointStats := runtimeStats.GetPointResponseStats()
+	injectedResponses := detailClient.getCompletedResponses()
+	s.GreaterOrEqual(detailClient.getAsyncRequests(), uint64(2))
+	s.GreaterOrEqual(injectedResponses, uint64(2))
+	s.True(pointStats.IsValid())
+	s.True(pointStats.ScanDetailComplete())
+	s.True(pointStats.PayloadComplete())
+	s.Equal(injectedResponses, pointStats.CompletedResponses)
+	s.Equal(pointStats.CompletedResponses, pointStats.ScanDetailRecords)
+	s.Equal(pointStats.CompletedResponses, pointStats.PayloadRecords)
+	s.Equal(int64(pointStats.CompletedResponses*5), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(pointStats.CompletedResponses*3), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(pointStats.CompletedResponses*30), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(uint64(len(leftKey)+len("left")+len(rightKey)+len("right")), pointStats.PayloadBytes)
 }
 
 func (s *testSnapshotSuite) TestRCRead() {

--- a/integration_tests/snapshot_test.go
+++ b/integration_tests/snapshot_test.go
@@ -589,9 +589,6 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStatsGetAndBatchGetCoverage() {
 	s.Equal(int64(7), pointStats.ScanDetail.ProcessedKeys)
 	s.Equal(int64(70), pointStats.ScanDetail.ProcessedKeysSize)
 	s.Equal(uint64(len("get")+len(batchGetKey)+len("batch-get")), pointStats.PayloadBytes)
-	s.Equal(uint64(2), pointStats.ScanDetailRecords)
-	s.Equal(uint64(3), pointStats.PayloadRecords)
-	s.Equal(uint64(3), pointStats.CompletedResponses)
 }
 
 func (s *testSnapshotSuite) TestSnapshotRuntimeStatsExcludesEpochNotMatch() {
@@ -640,9 +637,6 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStatsExcludesEpochNotMatch() {
 	s.Equal(int64(1), pointStats.ScanDetail.ProcessedKeys)
 	s.Equal(int64(10), pointStats.ScanDetail.ProcessedKeysSize)
 	s.Equal(uint64(len("value")), pointStats.PayloadBytes)
-	s.Equal(uint64(1), pointStats.ScanDetailRecords)
-	s.Equal(uint64(1), pointStats.PayloadRecords)
-	s.Equal(uint64(1), pointStats.CompletedResponses)
 }
 
 func (s *testSnapshotSuite) TestSnapshotRuntimeStatsPointGetLockRetryCoverage() {
@@ -705,9 +699,6 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStatsPointGetLockRetryCoverage() 
 	s.Equal(int64(2), pointStats.ScanDetail.ProcessedKeys)
 	s.Equal(int64(20), pointStats.ScanDetail.ProcessedKeysSize)
 	s.Equal(uint64(len("old-value")), pointStats.PayloadBytes)
-	s.Equal(uint64(2), pointStats.ScanDetailRecords)
-	s.Equal(uint64(2), pointStats.PayloadRecords)
-	s.Equal(uint64(2), pointStats.CompletedResponses)
 }
 
 func (s *testSnapshotSuite) TestSnapshotRuntimeStatsAsyncBatchGetMultipleRegionsCoverage() {
@@ -760,12 +751,9 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStatsAsyncBatchGetMultipleRegions
 	s.True(pointStats.IsValid())
 	s.True(pointStats.ScanDetailComplete())
 	s.True(pointStats.PayloadComplete())
-	s.Equal(injectedResponses, pointStats.CompletedResponses)
-	s.Equal(pointStats.CompletedResponses, pointStats.ScanDetailRecords)
-	s.Equal(pointStats.CompletedResponses, pointStats.PayloadRecords)
-	s.Equal(int64(pointStats.CompletedResponses*5), pointStats.ScanDetail.TotalKeys)
-	s.Equal(int64(pointStats.CompletedResponses*3), pointStats.ScanDetail.ProcessedKeys)
-	s.Equal(int64(pointStats.CompletedResponses*30), pointStats.ScanDetail.ProcessedKeysSize)
+	s.Equal(int64(injectedResponses*5), pointStats.ScanDetail.TotalKeys)
+	s.Equal(int64(injectedResponses*3), pointStats.ScanDetail.ProcessedKeys)
+	s.Equal(int64(injectedResponses*30), pointStats.ScanDetail.ProcessedKeysSize)
 	s.Equal(uint64(len(leftKey)+len("left")+len(rightKey)+len("right")), pointStats.PayloadBytes)
 }
 

--- a/txnkv/snapshot_export.go
+++ b/txnkv/snapshot_export.go
@@ -16,6 +16,7 @@ package txnkv
 
 import (
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
+	"github.com/tikv/client-go/v2/util"
 )
 
 // Scanner support tikv scan
@@ -28,10 +29,10 @@ type KVSnapshot = txnsnapshot.KVSnapshot
 type SnapshotRuntimeStats = txnsnapshot.SnapshotRuntimeStats
 
 // PointReadScanDetail is the storage work reported by point-read responses.
-type PointReadScanDetail = txnsnapshot.PointReadScanDetail
+type PointReadScanDetail = util.PointReadScanDetail
 
-// PointResponseStats is one atomic snapshot of point-read response statistics.
-type PointResponseStats = txnsnapshot.PointResponseStats
+// PointResponseStats is a value snapshot of point-read response statistics.
+type PointResponseStats = util.PointResponseStats
 
 // IsoLevel is the transaction's isolation level.
 type IsoLevel = txnsnapshot.IsoLevel

--- a/txnkv/snapshot_export.go
+++ b/txnkv/snapshot_export.go
@@ -27,6 +27,12 @@ type KVSnapshot = txnsnapshot.KVSnapshot
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats = txnsnapshot.SnapshotRuntimeStats
 
+// PointReadScanDetail is the storage work reported by point-read responses.
+type PointReadScanDetail = txnsnapshot.PointReadScanDetail
+
+// PointResponseStats is one atomic snapshot of point-read response statistics.
+type PointResponseStats = txnsnapshot.PointResponseStats
+
 // IsoLevel is the transaction's isolation level.
 type IsoLevel = txnsnapshot.IsoLevel
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -401,7 +401,11 @@ type batchGetLockInfo struct {
 func collectBatchGetResponseData(
 	resp *tikvrpc.Response,
 	onKvPair func([]byte, kv.ValueEntry),
-	onResponse func(*kvrpcpb.ExecDetailsV2, uint64, bool),
+	// onResponse receives the execution details and logical payload bytes.
+	onResponse func(
+		details *kvrpcpb.ExecDetailsV2,
+		payloadBytes uint64,
+	),
 ) (*batchGetLockInfo, error) {
 	if resp.Resp == nil {
 		return nil, errors.WithStack(tikverr.ErrBodyMissing)
@@ -424,10 +428,10 @@ func collectBatchGetResponseData(
 		return nil, errors.Errorf("unknown response %T", v)
 	}
 	if onResponse != nil {
-		payloadBytes, payloadValid := batchGetResponsePayloadBytes(data.keyErr, pairs)
+		payloadBytes := batchGetResponsePayloadBytes(data.keyErr, pairs)
 		// Record every recognized response, including missing ExecDetailsV2 and
 		// key errors, so missing detail remains visible across successful retries.
-		onResponse(details, payloadBytes, payloadValid)
+		onResponse(details, payloadBytes)
 	}
 	if data.keyErr != nil {
 		// If a response-level error happens, skip reading pairs.
@@ -466,25 +470,18 @@ func collectBatchGetResponseData(
 	return data, nil
 }
 
-func batchGetResponsePayloadBytes(responseError *kvrpcpb.KeyError, pairs []*kvrpcpb.KvPair) (uint64, bool) {
+func batchGetResponsePayloadBytes(responseError *kvrpcpb.KeyError, pairs []*kvrpcpb.KvPair) uint64 {
 	if responseError != nil {
-		return 0, true
+		return 0
 	}
 	var payloadBytes uint64
 	for _, pair := range pairs {
 		if pair.GetError() != nil {
 			continue
 		}
-		pairBytes, ok := checkedAddUint64(uint64(len(pair.GetKey())), uint64(len(pair.GetValue())))
-		if !ok {
-			return 0, false
-		}
-		payloadBytes, ok = checkedAddUint64(payloadBytes, pairBytes)
-		if !ok {
-			return 0, false
-		}
+		payloadBytes += uint64(len(pair.GetKey())) + uint64(len(pair.GetValue()))
 	}
-	return payloadBytes, true
+	return payloadBytes
 }
 
 //go:noinline
@@ -908,7 +905,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte, opt
 			if cmdGetResp.GetError() != nil {
 				payloadBytes = 0
 			}
-			onResponse(cmdGetResp.ExecDetailsV2, payloadBytes, true)
+			onResponse(cmdGetResp.ExecDetailsV2, payloadBytes)
 		}
 		if cmdGetResp.ExecDetailsV2 != nil {
 			readKeys := len(cmdGetResp.Value)
@@ -978,7 +975,7 @@ func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
 	if detail == nil || s.mu.stats == nil {
 		return
 	}
-	s.mu.stats.pointResponseStats.recordScanDetail(detail.ScanDetailV2)
+	s.mu.stats.scanDetail.MergeFromScanDetailV2(detail.GetScanDetailV2())
 	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
 	if details := detail.GetReadPoolTaskDetails(); details != nil {
 		if s.mu.stats.readPoolTaskDetails == nil {
@@ -988,7 +985,7 @@ func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
 	}
 }
 
-func (s *KVSnapshot) pointResponseRecorder() func(*kvrpcpb.ExecDetailsV2, uint64, bool) {
+func (s *KVSnapshot) pointResponseRecorder() func(*kvrpcpb.ExecDetailsV2, uint64) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.mu.stats == nil {
@@ -997,13 +994,18 @@ func (s *KVSnapshot) pointResponseRecorder() func(*kvrpcpb.ExecDetailsV2, uint64
 	return s.mergePointResponse
 }
 
-func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBytes uint64, payloadValid bool) {
+func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBytes uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.stats == nil {
 		return
 	}
-	s.mu.stats.pointResponseStats.recordResponse(detail.GetScanDetailV2(), payloadBytes, payloadValid)
+	scanDetail := detail.GetScanDetailV2()
+	s.mu.stats.pointResponseExtra.recordResponse(
+		scanDetail,
+		payloadBytes,
+	)
+	s.mu.stats.scanDetail.MergeFromScanDetailV2(scanDetail)
 	if detail == nil {
 		return
 	}
@@ -1347,57 +1349,62 @@ type PointReadScanDetail = util.PointReadScanDetail
 // PointResponseStats is a value snapshot of point-read response statistics.
 type PointResponseStats = util.PointResponseStats
 
-// pointResponseStats keeps the diagnostic scan detail and point-response
-// snapshot under one lock. Only the data, never the lock, is copied or merged.
-type pointResponseStats struct {
-	mu         sync.RWMutex
-	scanDetail util.ScanDetail
-	stats      util.PointResponseStats
+// pointReadResponseExtraStats stores only state that is not already present in
+// SnapshotRuntimeStats.scanDetail. Scan counters are projected when the public
+// PointResponseStats value is requested.
+type pointReadResponseExtraStats struct {
+	payloadBytes      uint64
+	seenResponse      bool
+	missingScanDetail bool
 }
 
-func (s *pointResponseStats) recordResponse(scanDetail *kvrpcpb.ScanDetailV2, payloadBytes uint64, payloadValid bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.scanDetail.MergeFromScanDetailV2(scanDetail)
-	s.stats.RecordResponse(scanDetail, payloadBytes, payloadValid)
+func (s *pointReadResponseExtraStats) recordResponse(
+	scanDetail *kvrpcpb.ScanDetailV2,
+	payloadBytes uint64,
+) {
+	s.payloadBytes += payloadBytes
+	s.seenResponse = true
+	s.missingScanDetail = s.missingScanDetail || scanDetail == nil
 }
 
-func (s *pointResponseStats) recordScanDetail(detail *kvrpcpb.ScanDetailV2) {
-	if detail == nil {
-		return
+func (s *pointReadResponseExtraStats) merge(other pointReadResponseExtraStats) {
+	s.payloadBytes += other.payloadBytes
+	s.seenResponse = s.seenResponse || other.seenResponse
+	s.missingScanDetail = s.missingScanDetail || other.missingScanDetail
+}
+
+func (s pointReadResponseExtraStats) buildPointResponseStats(scanDetail util.ScanDetail) PointResponseStats {
+	if !s.seenResponse {
+		return PointResponseStats{}
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.scanDetail.MergeFromScanDetailV2(detail)
-}
-
-func (s *pointResponseStats) snapshot() (util.ScanDetail, util.PointResponseStats) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.scanDetail, s.stats
-}
-
-func (s *pointResponseStats) clone() pointResponseStats {
-	scanDetail, stats := s.snapshot()
-	// Construct a fresh mutex instead of copying the source's mutex.
-	return pointResponseStats{scanDetail: scanDetail, stats: stats}
-}
-
-func (s *pointResponseStats) merge(other *pointResponseStats) {
-	// Release the source lock before locking the target, including for self-merge.
-	scanDetail, stats := other.snapshot()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.scanDetail.Merge(&scanDetail)
-	s.stats.Merge(stats)
+	stats := PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         scanDetail.TotalKeys,
+			ProcessedKeys:     scanDetail.ProcessedKeys,
+			ProcessedKeysSize: scanDetail.ProcessedKeysSize,
+		},
+		PayloadBytes: s.payloadBytes,
+	}
+	// PointResponseStats keeps coverage private. Record a zero-valued response
+	// here only to transfer that coverage into the returned value.
+	coverageScanDetail := &kvrpcpb.ScanDetailV2{}
+	if s.missingScanDetail {
+		coverageScanDetail = nil
+	}
+	stats.RecordResponse(coverageScanDetail, 0)
+	return stats
 }
 
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats struct {
-	rpcStats            *locate.RegionRequestRuntimeStats
-	backoffSleepMS      map[string]int
-	backoffTimes        map[string]int
-	pointResponseStats  pointResponseStats
+	rpcStats       *locate.RegionRequestRuntimeStats
+	backoffSleepMS map[string]int
+	backoffTimes   map[string]int
+	// scanDetail stores the aggregated storage scan details for this stats instance.
+	// Each instance represents either coprocessor or point-read (Get/BatchGet)
+	// responses, never a mixture of both.
+	scanDetail          util.ScanDetail
+	pointResponseExtra  pointReadResponseExtraStats
 	timeDetail          util.TimeDetail
 	resolveLockDetail   util.ResolveLockDetail
 	readPoolTaskDetails *util.PoolTaskDetails
@@ -1406,7 +1413,8 @@ type SnapshotRuntimeStats struct {
 // Clone implements the RuntimeStats interface.
 func (rs *SnapshotRuntimeStats) Clone() *SnapshotRuntimeStats {
 	newRs := SnapshotRuntimeStats{
-		pointResponseStats:  rs.pointResponseStats.clone(),
+		scanDetail:          rs.scanDetail,
+		pointResponseExtra:  rs.pointResponseExtra,
 		timeDetail:          rs.timeDetail,
 		resolveLockDetail:   rs.resolveLockDetail,
 		readPoolTaskDetails: rs.readPoolTaskDetails.Clone(),
@@ -1449,7 +1457,10 @@ func (rs *SnapshotRuntimeStats) Merge(other *SnapshotRuntimeStats) {
 			rs.backoffTimes[k] += v
 		}
 	}
-	rs.pointResponseStats.merge(&other.pointResponseStats)
+	otherScanDetail := other.scanDetail
+	otherPointResponseExtra := other.pointResponseExtra
+	rs.pointResponseExtra.merge(otherPointResponseExtra)
+	rs.scanDetail.Merge(&otherScanDetail)
 	rs.timeDetail.Merge(&other.timeDetail)
 	rs.resolveLockDetail.Merge(&other.resolveLockDetail)
 	if !other.readPoolTaskDetails.Empty() {
@@ -1490,8 +1501,7 @@ func (rs *SnapshotRuntimeStats) String() string {
 		buf.WriteString("resolve_lock_time:")
 		buf.WriteString(util.FormatDuration(time.Duration(rs.resolveLockDetail.ResolveLockTime)))
 	}
-	scanDetailSnapshot, _ := rs.pointResponseStats.snapshot()
-	scanDetail := scanDetailSnapshot.String()
+	scanDetail := rs.scanDetail.String()
 	if scanDetail != "" {
 		buf.WriteString(", ")
 		buf.WriteString(scanDetail)
@@ -1506,16 +1516,9 @@ func (rs *SnapshotRuntimeStats) String() string {
 	return buf.String()
 }
 
-func checkedAddUint64(current, delta uint64) (uint64, bool) {
-	if delta > math.MaxUint64-current {
-		return 0, false
-	}
-	return current + delta, true
-}
-
 // GetPointResponseStats returns a consistent value snapshot of point-read scan
 // detail, response payload, and their response-level coverage. The result is
-// invalid when the receiver is nil or any field overflowed during aggregation.
+// invalid when the receiver is nil.
 // ScanDetailComplete and PayloadComplete distinguish response coverage from a
 // valid zero-response snapshot.
 func (rs *SnapshotRuntimeStats) GetPointResponseStats() PointResponseStats {
@@ -1524,8 +1527,7 @@ func (rs *SnapshotRuntimeStats) GetPointResponseStats() PointResponseStats {
 		stats.Invalidate()
 		return stats
 	}
-	_, pointResponseStats := rs.pointResponseStats.snapshot()
-	return pointResponseStats
+	return rs.pointResponseExtra.buildPointResponseStats(rs.scanDetail)
 }
 
 // GetTimeDetail returns the timeDetail

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -969,9 +969,9 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte, opt
 	}
 }
 
+// mergeExecDetail merges execution details into runtime stats. The caller must
+// hold s.mu.
 func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if detail == nil || s.mu.stats == nil {
 		return
 	}
@@ -1005,17 +1005,7 @@ func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBy
 		scanDetail,
 		payloadBytes,
 	)
-	s.mu.stats.scanDetail.MergeFromScanDetailV2(scanDetail)
-	if detail == nil {
-		return
-	}
-	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
-	if details := detail.GetReadPoolTaskDetails(); details != nil {
-		if s.mu.stats.readPoolTaskDetails == nil {
-			s.mu.stats.readPoolTaskDetails = &util.PoolTaskDetails{}
-		}
-		s.mu.stats.readPoolTaskDetails.MergeFromPB(details)
-	}
+	s.mergeExecDetail(detail)
 }
 
 // Iter return a list of key-value pair after `k`.

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -969,9 +969,15 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte, opt
 	}
 }
 
-// mergeExecDetail merges execution details into runtime stats. The caller must
-// hold s.mu.
 func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mergeExecDetailLocked(detail)
+}
+
+// mergeExecDetailLocked merges execution details into runtime stats. The caller
+// must hold s.mu.
+func (s *KVSnapshot) mergeExecDetailLocked(detail *kvrpcpb.ExecDetailsV2) {
 	if detail == nil || s.mu.stats == nil {
 		return
 	}
@@ -1005,7 +1011,7 @@ func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBy
 		scanDetail,
 		payloadBytes,
 	)
-	s.mergeExecDetail(detail)
+	s.mergeExecDetailLocked(detail)
 }
 
 // Iter return a list of key-value pair after `k`.

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -425,9 +425,8 @@ func collectBatchGetResponseData(
 	}
 	if onResponse != nil {
 		payloadBytes, payloadValid := batchGetResponsePayloadBytes(data.keyErr, pairs)
-		// A response with a recognized body is complete for scan-detail and payload
-		// coverage, even when it carries no ExecDetailsV2 or contains a key error.
-		// Record both at one response boundary so retries use the same aggregation.
+		// Record every recognized response, including missing ExecDetailsV2 and
+		// key errors, so missing detail remains visible across successful retries.
 		onResponse(details, payloadBytes, payloadValid)
 	}
 	if data.keyErr != nil {
@@ -979,7 +978,7 @@ func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
 	if detail == nil || s.mu.stats == nil {
 		return
 	}
-	s.mu.stats.recordScanDetail(detail.ScanDetailV2)
+	s.mu.stats.pointResponseStats.recordScanDetail(detail.ScanDetailV2)
 	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
 	if details := detail.GetReadPoolTaskDetails(); details != nil {
 		if s.mu.stats.readPoolTaskDetails == nil {
@@ -1004,7 +1003,7 @@ func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBy
 	if s.mu.stats == nil {
 		return
 	}
-	s.mu.stats.recordPointResponse(detail, payloadBytes, payloadValid)
+	s.mu.stats.pointResponseStats.recordResponse(detail.GetScanDetailV2(), payloadBytes, payloadValid)
 	if detail == nil {
 		return
 	}
@@ -1343,66 +1342,54 @@ func (s *KVSnapshot) SetPipelined(ts uint64) {
 }
 
 // PointReadScanDetail is the storage work reported by point-read responses.
-type PointReadScanDetail struct {
-	// TotalKeys is the total number of MVCC versions encountered by storage.
-	TotalKeys int64
-	// ProcessedKeys is the number of user keys processed by storage.
-	ProcessedKeys int64
-	// ProcessedKeysSize is the total size of the processed user keys and values.
-	ProcessedKeysSize int64
+type PointReadScanDetail = util.PointReadScanDetail
+
+// PointResponseStats is a value snapshot of point-read response statistics.
+type PointResponseStats = util.PointResponseStats
+
+// pointResponseStats keeps the diagnostic scan detail and point-response
+// snapshot under one lock. Only the data, never the lock, is copied or merged.
+type pointResponseStats struct {
+	mu         sync.RWMutex
+	scanDetail util.ScanDetail
+	stats      util.PointResponseStats
 }
 
-// PointResponseStats is one atomic snapshot of Get, BatchGet, and
-// BufferBatchGet response statistics.
-//
-// CompletedResponses counts recognized response bodies after transport and
-// region errors have been handled. Empty and key-error responses count, and
-// each retry response counts separately. ScanDetailRecords counts recognized
-// responses carrying ScanDetailV2. PayloadRecords counts recognized responses
-// whose payload was accounted for, including zero-byte misses and errors.
-type PointResponseStats struct {
-	// ScanDetail is the aggregated storage work from ScanDetailV2 records.
-	ScanDetail PointReadScanDetail
-	// PayloadBytes is the logical successful-response payload, not the encoded
-	// protobuf or network response size. Get contributes value bytes.
-	// BatchGet and BufferBatchGet contribute key plus value bytes for successful
-	// pairs. Misses, response errors, and pair errors contribute zero; commit
-	// timestamps, error text, protobuf fields, and transport framing are excluded.
-	PayloadBytes uint64
-	// ScanDetailRecords counts recognized responses carrying ScanDetailV2.
-	ScanDetailRecords uint64
-	// PayloadRecords counts recognized responses whose payload was accounted for.
-	PayloadRecords uint64
-	// CompletedResponses counts all recognized response bodies.
-	CompletedResponses uint64
-	invalid            bool
+func (s *pointResponseStats) recordResponse(scanDetail *kvrpcpb.ScanDetailV2, payloadBytes uint64, payloadValid bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scanDetail.MergeFromScanDetailV2(scanDetail)
+	s.stats.RecordResponse(scanDetail, payloadBytes, payloadValid)
 }
 
-// IsValid reports whether all fields were aggregated without conversion or
-// arithmetic overflow.
-func (stats PointResponseStats) IsValid() bool {
-	return !stats.invalid
+func (s *pointResponseStats) recordScanDetail(detail *kvrpcpb.ScanDetailV2) {
+	if detail == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scanDetail.MergeFromScanDetailV2(detail)
 }
 
-// ScanDetailComplete reports whether at least one recognized response was
-// observed and every recognized response carried ScanDetailV2. A valid zero
-// response snapshot is not complete evidence that a point-read operation ran.
-// Complete message coverage does not prove that every protobuf scalar field is
-// supported by the backend because those fields do not carry presence.
-func (stats PointResponseStats) ScanDetailComplete() bool {
-	return stats.IsValid() &&
-		stats.CompletedResponses > 0 &&
-		stats.ScanDetailRecords == stats.CompletedResponses
+func (s *pointResponseStats) snapshot() (util.ScanDetail, util.PointResponseStats) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.scanDetail, s.stats
 }
 
-// PayloadComplete reports whether at least one recognized response was
-// observed and every recognized response had its payload accounted for. A
-// valid zero response snapshot is not complete evidence that a point-read
-// operation ran.
-func (stats PointResponseStats) PayloadComplete() bool {
-	return stats.IsValid() &&
-		stats.CompletedResponses > 0 &&
-		stats.PayloadRecords == stats.CompletedResponses
+func (s *pointResponseStats) clone() pointResponseStats {
+	scanDetail, stats := s.snapshot()
+	// Construct a fresh mutex instead of copying the source's mutex.
+	return pointResponseStats{scanDetail: scanDetail, stats: stats}
+}
+
+func (s *pointResponseStats) merge(other *pointResponseStats) {
+	// Release the source lock before locking the target, including for self-merge.
+	scanDetail, stats := other.snapshot()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scanDetail.Merge(&scanDetail)
+	s.stats.Merge(stats)
 }
 
 // SnapshotRuntimeStats records the runtime stats of snapshot.
@@ -1410,9 +1397,7 @@ type SnapshotRuntimeStats struct {
 	rpcStats            *locate.RegionRequestRuntimeStats
 	backoffSleepMS      map[string]int
 	backoffTimes        map[string]int
-	pointResponseMu     sync.RWMutex
-	scanDetail          util.ScanDetail
-	pointResponseStats  PointResponseStats
+	pointResponseStats  pointResponseStats
 	timeDetail          util.TimeDetail
 	resolveLockDetail   util.ResolveLockDetail
 	readPoolTaskDetails *util.PoolTaskDetails
@@ -1420,10 +1405,8 @@ type SnapshotRuntimeStats struct {
 
 // Clone implements the RuntimeStats interface.
 func (rs *SnapshotRuntimeStats) Clone() *SnapshotRuntimeStats {
-	scanDetail, pointResponseStats := rs.pointResponseSnapshot()
 	newRs := SnapshotRuntimeStats{
-		scanDetail:          scanDetail,
-		pointResponseStats:  pointResponseStats,
+		pointResponseStats:  rs.pointResponseStats.clone(),
 		timeDetail:          rs.timeDetail,
 		resolveLockDetail:   rs.resolveLockDetail,
 		readPoolTaskDetails: rs.readPoolTaskDetails.Clone(),
@@ -1466,13 +1449,7 @@ func (rs *SnapshotRuntimeStats) Merge(other *SnapshotRuntimeStats) {
 			rs.backoffTimes[k] += v
 		}
 	}
-	otherScanDetail, otherPointResponseStats := other.pointResponseSnapshot()
-	rs.pointResponseMu.Lock()
-	rs.scanDetail.Merge(&otherScanDetail)
-	if !rs.mergePointResponseStats(otherPointResponseStats) {
-		rs.pointResponseStats.invalid = true
-	}
-	rs.pointResponseMu.Unlock()
+	rs.pointResponseStats.merge(&other.pointResponseStats)
 	rs.timeDetail.Merge(&other.timeDetail)
 	rs.resolveLockDetail.Merge(&other.resolveLockDetail)
 	if !other.readPoolTaskDetails.Empty() {
@@ -1513,7 +1490,7 @@ func (rs *SnapshotRuntimeStats) String() string {
 		buf.WriteString("resolve_lock_time:")
 		buf.WriteString(util.FormatDuration(time.Duration(rs.resolveLockDetail.ResolveLockTime)))
 	}
-	scanDetailSnapshot, _ := rs.pointResponseSnapshot()
+	scanDetailSnapshot, _ := rs.pointResponseStats.snapshot()
 	scanDetail := scanDetailSnapshot.String()
 	if scanDetail != "" {
 		buf.WriteString(", ")
@@ -1529,124 +1506,11 @@ func (rs *SnapshotRuntimeStats) String() string {
 	return buf.String()
 }
 
-func (rs *SnapshotRuntimeStats) recordPointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBytes uint64, payloadValid bool) {
-	rs.pointResponseMu.Lock()
-	defer rs.pointResponseMu.Unlock()
-
-	delta := PointResponseStats{
-		PayloadBytes:       payloadBytes,
-		PayloadRecords:     1,
-		CompletedResponses: 1,
-		invalid:            !payloadValid,
-	}
-	if detail != nil && detail.ScanDetailV2 != nil {
-		delta.ScanDetailRecords = 1
-		rs.scanDetail.MergeFromScanDetailV2(detail.ScanDetailV2)
-		if detail.ScanDetailV2.TotalVersions > math.MaxInt64 ||
-			detail.ScanDetailV2.ProcessedVersions > math.MaxInt64 ||
-			detail.ScanDetailV2.ProcessedVersionsSize > math.MaxInt64 {
-			delta.invalid = true
-		} else {
-			delta.ScanDetail = PointReadScanDetail{
-				TotalKeys:         int64(detail.ScanDetailV2.TotalVersions),
-				ProcessedKeys:     int64(detail.ScanDetailV2.ProcessedVersions),
-				ProcessedKeysSize: int64(detail.ScanDetailV2.ProcessedVersionsSize),
-			}
-		}
-	}
-	if !rs.mergePointResponseStats(delta) {
-		rs.pointResponseStats.invalid = true
-	}
-}
-
-func (rs *SnapshotRuntimeStats) mergePointResponseStats(other PointResponseStats) bool {
-	if rs.pointResponseStats.invalid || other.invalid {
-		return false
-	}
-	nextTotalKeys, ok := checkedAddNonNegativeInt64(
-		rs.pointResponseStats.ScanDetail.TotalKeys,
-		other.ScanDetail.TotalKeys,
-	)
-	if !ok {
-		return false
-	}
-	nextProcessedKeys, ok := checkedAddNonNegativeInt64(
-		rs.pointResponseStats.ScanDetail.ProcessedKeys,
-		other.ScanDetail.ProcessedKeys,
-	)
-	if !ok {
-		return false
-	}
-	nextProcessedKeysSize, ok := checkedAddNonNegativeInt64(
-		rs.pointResponseStats.ScanDetail.ProcessedKeysSize,
-		other.ScanDetail.ProcessedKeysSize,
-	)
-	if !ok {
-		return false
-	}
-	nextPayloadBytes, ok := checkedAddUint64(rs.pointResponseStats.PayloadBytes, other.PayloadBytes)
-	if !ok {
-		return false
-	}
-	nextDetailRecords, ok := checkedAddUint64(
-		rs.pointResponseStats.ScanDetailRecords,
-		other.ScanDetailRecords,
-	)
-	if !ok {
-		return false
-	}
-	nextPayloadRecords, ok := checkedAddUint64(rs.pointResponseStats.PayloadRecords, other.PayloadRecords)
-	if !ok {
-		return false
-	}
-	nextCompletedResponses, ok := checkedAddUint64(
-		rs.pointResponseStats.CompletedResponses,
-		other.CompletedResponses,
-	)
-	if !ok {
-		return false
-	}
-	rs.pointResponseStats = PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys:         nextTotalKeys,
-			ProcessedKeys:     nextProcessedKeys,
-			ProcessedKeysSize: nextProcessedKeysSize,
-		},
-		PayloadBytes:       nextPayloadBytes,
-		ScanDetailRecords:  nextDetailRecords,
-		PayloadRecords:     nextPayloadRecords,
-		CompletedResponses: nextCompletedResponses,
-	}
-	return true
-}
-
-func checkedAddNonNegativeInt64(current, delta int64) (int64, bool) {
-	if current < 0 || delta < 0 || delta > math.MaxInt64-current {
-		return 0, false
-	}
-	return current + delta, true
-}
-
 func checkedAddUint64(current, delta uint64) (uint64, bool) {
 	if delta > math.MaxUint64-current {
 		return 0, false
 	}
 	return current + delta, true
-}
-
-func (rs *SnapshotRuntimeStats) recordScanDetail(detail *kvrpcpb.ScanDetailV2) {
-	if detail == nil {
-		return
-	}
-	rs.pointResponseMu.Lock()
-	defer rs.pointResponseMu.Unlock()
-	rs.scanDetail.MergeFromScanDetailV2(detail)
-}
-
-func (rs *SnapshotRuntimeStats) pointResponseSnapshot() (util.ScanDetail, PointResponseStats) {
-	rs.pointResponseMu.RLock()
-	defer rs.pointResponseMu.RUnlock()
-	return rs.scanDetail, rs.pointResponseStats
 }
 
 // GetPointResponseStats returns a consistent value snapshot of point-read scan
@@ -1656,9 +1520,11 @@ func (rs *SnapshotRuntimeStats) pointResponseSnapshot() (util.ScanDetail, PointR
 // valid zero-response snapshot.
 func (rs *SnapshotRuntimeStats) GetPointResponseStats() PointResponseStats {
 	if rs == nil {
-		return PointResponseStats{invalid: true}
+		var stats PointResponseStats
+		stats.Invalidate()
+		return stats
 	}
-	_, pointResponseStats := rs.pointResponseSnapshot()
+	_, pointResponseStats := rs.pointResponseStats.snapshot()
 	return pointResponseStats
 }
 

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -401,7 +401,7 @@ type batchGetLockInfo struct {
 func collectBatchGetResponseData(
 	resp *tikvrpc.Response,
 	onKvPair func([]byte, kv.ValueEntry),
-	onDetails func(*kvrpcpb.ExecDetailsV2),
+	onResponse func(*kvrpcpb.ExecDetailsV2, uint64, bool),
 ) (*batchGetLockInfo, error) {
 	if resp.Resp == nil {
 		return nil, errors.WithStack(tikverr.ErrBodyMissing)
@@ -422,6 +422,13 @@ func collectBatchGetResponseData(
 		details = v.GetExecDetailsV2()
 	default:
 		return nil, errors.Errorf("unknown response %T", v)
+	}
+	if onResponse != nil {
+		payloadBytes, payloadValid := batchGetResponsePayloadBytes(data.keyErr, pairs)
+		// A response with a recognized body is complete for scan-detail and payload
+		// coverage, even when it carries no ExecDetailsV2 or contains a key error.
+		// Record both at one response boundary so retries use the same aggregation.
+		onResponse(details, payloadBytes, payloadValid)
 	}
 	if data.keyErr != nil {
 		// If a response-level error happens, skip reading pairs.
@@ -456,9 +463,29 @@ func collectBatchGetResponseData(
 		}
 		readSize := float64(details.GetScanDetailV2().GetProcessedVersionsSize())
 		metrics.ObserveReadSLI(uint64(readKeys), readTime, readSize)
-		onDetails(details)
 	}
 	return data, nil
+}
+
+func batchGetResponsePayloadBytes(responseError *kvrpcpb.KeyError, pairs []*kvrpcpb.KvPair) (uint64, bool) {
+	if responseError != nil {
+		return 0, true
+	}
+	var payloadBytes uint64
+	for _, pair := range pairs {
+		if pair.GetError() != nil {
+			continue
+		}
+		pairBytes, ok := checkedAddUint64(uint64(len(pair.GetKey())), uint64(len(pair.GetValue())))
+		if !ok {
+			return 0, false
+		}
+		payloadBytes, ok = checkedAddUint64(payloadBytes, pairBytes)
+		if !ok {
+			return 0, false
+		}
+	}
+	return payloadBytes, true
 }
 
 //go:noinline
@@ -674,7 +701,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *retry.Backoffer, batch batchKeys, 
 			continue
 		}
 
-		lockInfo, err := collectBatchGetResponseData(resp, collectF, s.mergeExecDetail)
+		lockInfo, err := collectBatchGetResponseData(resp, collectF, s.pointResponseRecorder())
 		if err != nil {
 			return err
 		}
@@ -876,6 +903,14 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte, opt
 			return kv.ValueEntry{}, errors.WithStack(tikverr.ErrBodyMissing)
 		}
 		cmdGetResp := resp.Resp.(*kvrpcpb.GetResponse)
+		val := cmdGetResp.GetValue()
+		if onResponse := s.pointResponseRecorder(); onResponse != nil {
+			payloadBytes := uint64(len(val))
+			if cmdGetResp.GetError() != nil {
+				payloadBytes = 0
+			}
+			onResponse(cmdGetResp.ExecDetailsV2, payloadBytes, true)
+		}
 		if cmdGetResp.ExecDetailsV2 != nil {
 			readKeys := len(cmdGetResp.Value)
 			var readTime float64
@@ -886,9 +921,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *retry.Backoffer, k []byte, opt
 			}
 			readSize := float64(cmdGetResp.ExecDetailsV2.GetScanDetailV2().GetProcessedVersionsSize())
 			metrics.ObserveReadSLI(uint64(readKeys), readTime, readSize)
-			s.mergeExecDetail(cmdGetResp.ExecDetailsV2)
 		}
-		val := cmdGetResp.GetValue()
 		commitTS := cmdGetResp.GetCommitTs()
 		if keyErr := cmdGetResp.GetError(); keyErr != nil {
 			lock, err := txnlock.ExtractLockFromKeyErr(keyErr)
@@ -946,7 +979,35 @@ func (s *KVSnapshot) mergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
 	if detail == nil || s.mu.stats == nil {
 		return
 	}
-	s.mu.stats.scanDetail.MergeFromScanDetailV2(detail.ScanDetailV2)
+	s.mu.stats.recordScanDetail(detail.ScanDetailV2)
+	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
+	if details := detail.GetReadPoolTaskDetails(); details != nil {
+		if s.mu.stats.readPoolTaskDetails == nil {
+			s.mu.stats.readPoolTaskDetails = &util.PoolTaskDetails{}
+		}
+		s.mu.stats.readPoolTaskDetails.MergeFromPB(details)
+	}
+}
+
+func (s *KVSnapshot) pointResponseRecorder() func(*kvrpcpb.ExecDetailsV2, uint64, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.mu.stats == nil {
+		return nil
+	}
+	return s.mergePointResponse
+}
+
+func (s *KVSnapshot) mergePointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBytes uint64, payloadValid bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.stats == nil {
+		return
+	}
+	s.mu.stats.recordPointResponse(detail, payloadBytes, payloadValid)
+	if detail == nil {
+		return
+	}
 	s.mu.stats.timeDetail.MergeFromTimeDetail(detail.TimeDetailV2, detail.TimeDetail)
 	if details := detail.GetReadPoolTaskDetails(); details != nil {
 		if s.mu.stats.readPoolTaskDetails == nil {
@@ -1281,12 +1342,77 @@ func (s *KVSnapshot) SetPipelined(ts uint64) {
 	s.resolvedLocks.Put(ts)
 }
 
+// PointReadScanDetail is the storage work reported by point-read responses.
+type PointReadScanDetail struct {
+	// TotalKeys is the total number of MVCC versions encountered by storage.
+	TotalKeys int64
+	// ProcessedKeys is the number of user keys processed by storage.
+	ProcessedKeys int64
+	// ProcessedKeysSize is the total size of the processed user keys and values.
+	ProcessedKeysSize int64
+}
+
+// PointResponseStats is one atomic snapshot of Get, BatchGet, and
+// BufferBatchGet response statistics.
+//
+// CompletedResponses counts recognized response bodies after transport and
+// region errors have been handled. Empty and key-error responses count, and
+// each retry response counts separately. ScanDetailRecords counts recognized
+// responses carrying ScanDetailV2. PayloadRecords counts recognized responses
+// whose payload was accounted for, including zero-byte misses and errors.
+type PointResponseStats struct {
+	// ScanDetail is the aggregated storage work from ScanDetailV2 records.
+	ScanDetail PointReadScanDetail
+	// PayloadBytes is the logical successful-response payload, not the encoded
+	// protobuf or network response size. Get contributes value bytes.
+	// BatchGet and BufferBatchGet contribute key plus value bytes for successful
+	// pairs. Misses, response errors, and pair errors contribute zero; commit
+	// timestamps, error text, protobuf fields, and transport framing are excluded.
+	PayloadBytes uint64
+	// ScanDetailRecords counts recognized responses carrying ScanDetailV2.
+	ScanDetailRecords uint64
+	// PayloadRecords counts recognized responses whose payload was accounted for.
+	PayloadRecords uint64
+	// CompletedResponses counts all recognized response bodies.
+	CompletedResponses uint64
+	invalid            bool
+}
+
+// IsValid reports whether all fields were aggregated without conversion or
+// arithmetic overflow.
+func (stats PointResponseStats) IsValid() bool {
+	return !stats.invalid
+}
+
+// ScanDetailComplete reports whether at least one recognized response was
+// observed and every recognized response carried ScanDetailV2. A valid zero
+// response snapshot is not complete evidence that a point-read operation ran.
+// Complete message coverage does not prove that every protobuf scalar field is
+// supported by the backend because those fields do not carry presence.
+func (stats PointResponseStats) ScanDetailComplete() bool {
+	return stats.IsValid() &&
+		stats.CompletedResponses > 0 &&
+		stats.ScanDetailRecords == stats.CompletedResponses
+}
+
+// PayloadComplete reports whether at least one recognized response was
+// observed and every recognized response had its payload accounted for. A
+// valid zero response snapshot is not complete evidence that a point-read
+// operation ran.
+func (stats PointResponseStats) PayloadComplete() bool {
+	return stats.IsValid() &&
+		stats.CompletedResponses > 0 &&
+		stats.PayloadRecords == stats.CompletedResponses
+}
+
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats struct {
 	rpcStats            *locate.RegionRequestRuntimeStats
 	backoffSleepMS      map[string]int
 	backoffTimes        map[string]int
+	pointResponseMu     sync.RWMutex
 	scanDetail          util.ScanDetail
+	pointResponseStats  PointResponseStats
 	timeDetail          util.TimeDetail
 	resolveLockDetail   util.ResolveLockDetail
 	readPoolTaskDetails *util.PoolTaskDetails
@@ -1294,8 +1420,10 @@ type SnapshotRuntimeStats struct {
 
 // Clone implements the RuntimeStats interface.
 func (rs *SnapshotRuntimeStats) Clone() *SnapshotRuntimeStats {
+	scanDetail, pointResponseStats := rs.pointResponseSnapshot()
 	newRs := SnapshotRuntimeStats{
-		scanDetail:          rs.scanDetail,
+		scanDetail:          scanDetail,
+		pointResponseStats:  pointResponseStats,
 		timeDetail:          rs.timeDetail,
 		resolveLockDetail:   rs.resolveLockDetail,
 		readPoolTaskDetails: rs.readPoolTaskDetails.Clone(),
@@ -1338,7 +1466,13 @@ func (rs *SnapshotRuntimeStats) Merge(other *SnapshotRuntimeStats) {
 			rs.backoffTimes[k] += v
 		}
 	}
-	rs.scanDetail.Merge(&other.scanDetail)
+	otherScanDetail, otherPointResponseStats := other.pointResponseSnapshot()
+	rs.pointResponseMu.Lock()
+	rs.scanDetail.Merge(&otherScanDetail)
+	if !rs.mergePointResponseStats(otherPointResponseStats) {
+		rs.pointResponseStats.invalid = true
+	}
+	rs.pointResponseMu.Unlock()
 	rs.timeDetail.Merge(&other.timeDetail)
 	rs.resolveLockDetail.Merge(&other.resolveLockDetail)
 	if !other.readPoolTaskDetails.Empty() {
@@ -1379,7 +1513,8 @@ func (rs *SnapshotRuntimeStats) String() string {
 		buf.WriteString("resolve_lock_time:")
 		buf.WriteString(util.FormatDuration(time.Duration(rs.resolveLockDetail.ResolveLockTime)))
 	}
-	scanDetail := rs.scanDetail.String()
+	scanDetailSnapshot, _ := rs.pointResponseSnapshot()
+	scanDetail := scanDetailSnapshot.String()
 	if scanDetail != "" {
 		buf.WriteString(", ")
 		buf.WriteString(scanDetail)
@@ -1392,6 +1527,139 @@ func (rs *SnapshotRuntimeStats) String() string {
 		buf.WriteString(rs.readPoolTaskDetails.String())
 	}
 	return buf.String()
+}
+
+func (rs *SnapshotRuntimeStats) recordPointResponse(detail *kvrpcpb.ExecDetailsV2, payloadBytes uint64, payloadValid bool) {
+	rs.pointResponseMu.Lock()
+	defer rs.pointResponseMu.Unlock()
+
+	delta := PointResponseStats{
+		PayloadBytes:       payloadBytes,
+		PayloadRecords:     1,
+		CompletedResponses: 1,
+		invalid:            !payloadValid,
+	}
+	if detail != nil && detail.ScanDetailV2 != nil {
+		delta.ScanDetailRecords = 1
+		rs.scanDetail.MergeFromScanDetailV2(detail.ScanDetailV2)
+		if detail.ScanDetailV2.TotalVersions > math.MaxInt64 ||
+			detail.ScanDetailV2.ProcessedVersions > math.MaxInt64 ||
+			detail.ScanDetailV2.ProcessedVersionsSize > math.MaxInt64 {
+			delta.invalid = true
+		} else {
+			delta.ScanDetail = PointReadScanDetail{
+				TotalKeys:         int64(detail.ScanDetailV2.TotalVersions),
+				ProcessedKeys:     int64(detail.ScanDetailV2.ProcessedVersions),
+				ProcessedKeysSize: int64(detail.ScanDetailV2.ProcessedVersionsSize),
+			}
+		}
+	}
+	if !rs.mergePointResponseStats(delta) {
+		rs.pointResponseStats.invalid = true
+	}
+}
+
+func (rs *SnapshotRuntimeStats) mergePointResponseStats(other PointResponseStats) bool {
+	if rs.pointResponseStats.invalid || other.invalid {
+		return false
+	}
+	nextTotalKeys, ok := checkedAddNonNegativeInt64(
+		rs.pointResponseStats.ScanDetail.TotalKeys,
+		other.ScanDetail.TotalKeys,
+	)
+	if !ok {
+		return false
+	}
+	nextProcessedKeys, ok := checkedAddNonNegativeInt64(
+		rs.pointResponseStats.ScanDetail.ProcessedKeys,
+		other.ScanDetail.ProcessedKeys,
+	)
+	if !ok {
+		return false
+	}
+	nextProcessedKeysSize, ok := checkedAddNonNegativeInt64(
+		rs.pointResponseStats.ScanDetail.ProcessedKeysSize,
+		other.ScanDetail.ProcessedKeysSize,
+	)
+	if !ok {
+		return false
+	}
+	nextPayloadBytes, ok := checkedAddUint64(rs.pointResponseStats.PayloadBytes, other.PayloadBytes)
+	if !ok {
+		return false
+	}
+	nextDetailRecords, ok := checkedAddUint64(
+		rs.pointResponseStats.ScanDetailRecords,
+		other.ScanDetailRecords,
+	)
+	if !ok {
+		return false
+	}
+	nextPayloadRecords, ok := checkedAddUint64(rs.pointResponseStats.PayloadRecords, other.PayloadRecords)
+	if !ok {
+		return false
+	}
+	nextCompletedResponses, ok := checkedAddUint64(
+		rs.pointResponseStats.CompletedResponses,
+		other.CompletedResponses,
+	)
+	if !ok {
+		return false
+	}
+	rs.pointResponseStats = PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         nextTotalKeys,
+			ProcessedKeys:     nextProcessedKeys,
+			ProcessedKeysSize: nextProcessedKeysSize,
+		},
+		PayloadBytes:       nextPayloadBytes,
+		ScanDetailRecords:  nextDetailRecords,
+		PayloadRecords:     nextPayloadRecords,
+		CompletedResponses: nextCompletedResponses,
+	}
+	return true
+}
+
+func checkedAddNonNegativeInt64(current, delta int64) (int64, bool) {
+	if current < 0 || delta < 0 || delta > math.MaxInt64-current {
+		return 0, false
+	}
+	return current + delta, true
+}
+
+func checkedAddUint64(current, delta uint64) (uint64, bool) {
+	if delta > math.MaxUint64-current {
+		return 0, false
+	}
+	return current + delta, true
+}
+
+func (rs *SnapshotRuntimeStats) recordScanDetail(detail *kvrpcpb.ScanDetailV2) {
+	if detail == nil {
+		return
+	}
+	rs.pointResponseMu.Lock()
+	defer rs.pointResponseMu.Unlock()
+	rs.scanDetail.MergeFromScanDetailV2(detail)
+}
+
+func (rs *SnapshotRuntimeStats) pointResponseSnapshot() (util.ScanDetail, PointResponseStats) {
+	rs.pointResponseMu.RLock()
+	defer rs.pointResponseMu.RUnlock()
+	return rs.scanDetail, rs.pointResponseStats
+}
+
+// GetPointResponseStats returns a consistent value snapshot of point-read scan
+// detail, response payload, and their response-level coverage. The result is
+// invalid when the receiver is nil or any field overflowed during aggregation.
+// ScanDetailComplete and PayloadComplete distinguish response coverage from a
+// valid zero-response snapshot.
+func (rs *SnapshotRuntimeStats) GetPointResponseStats() PointResponseStats {
+	if rs == nil {
+		return PointResponseStats{invalid: true}
+	}
+	_, pointResponseStats := rs.pointResponseSnapshot()
+	return pointResponseStats
 }
 
 // GetTimeDetail returns the timeDetail

--- a/txnkv/txnsnapshot/snapshot_async.go
+++ b/txnkv/txnsnapshot/snapshot_async.go
@@ -168,7 +168,7 @@ func (s *KVSnapshot) tryBatchGetSingleRegionUsingAsyncAPI(
 			return
 		}
 
-		lockInfo, err := collectBatchGetResponseData(&resp.Response, collectF, s.mergeExecDetail)
+		lockInfo, err := collectBatchGetResponseData(&resp.Response, collectF, s.pointResponseRecorder())
 		if err != nil {
 			cb.Invoke(struct{}{}, err)
 			metrics.AsyncBatchGetCounterWithOtherError.Inc()
@@ -289,7 +289,7 @@ func (s *KVSnapshot) retryBatchGetSingleRegionAfterAsyncAPI(
 		if regionErr != nil {
 			continue
 		}
-		lockInfo, err = collectBatchGetResponseData(resp, collectF, s.mergeExecDetail)
+		lockInfo, err = collectBatchGetResponseData(resp, collectF, s.pointResponseRecorder())
 		if err != nil {
 			return err
 		}

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -74,7 +74,7 @@ func TestSnapshotRuntimeStatsStandaloneScanDetailDoesNotEstablishPointCoverage(t
 
 	// Standalone execution details remain visible through the legacy diagnostic
 	// scan detail, but do not establish point-response coverage.
-	SnapshotProbe{KVSnapshot: snapshot}.MergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+	snapshot.mergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
 		TotalVersions: 9,
 	}})
 	pointStats := stats.GetPointResponseStats()

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -1,0 +1,365 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnsnapshot
+
+import (
+	"math"
+	"sync"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/kv"
+	"github.com/tikv/client-go/v2/tikvrpc"
+)
+
+func newSnapshotWithRuntimeStats(stats *SnapshotRuntimeStats) *KVSnapshot {
+	snapshot := &KVSnapshot{}
+	snapshot.SetRuntimeStats(stats)
+	return snapshot
+}
+
+func TestSnapshotRuntimeStatsPointResponseStats(t *testing.T) {
+	stats := &SnapshotRuntimeStats{}
+	snapshot := newSnapshotWithRuntimeStats(stats)
+
+	pointStats := stats.GetPointResponseStats()
+	require.True(t, pointStats.IsValid())
+	require.False(t, pointStats.ScanDetailComplete())
+	require.False(t, pointStats.PayloadComplete())
+	require.Equal(t, PointResponseStats{}, pointStats)
+
+	// Merging a standalone ExecDetails value preserves its existing diagnostic
+	// purpose and does not fabricate point-response coverage.
+	snapshot.mergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions: 9,
+	}})
+	require.Equal(t, PointResponseStats{}, stats.GetPointResponseStats())
+	require.Contains(t, stats.String(), "total_keys: 9")
+
+	// Missing ExecDetailsV2 differs from a present, zero-valued ScanDetailV2.
+	snapshot.mergePointResponse(nil, 0, true)
+	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{}, 7, true)
+	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{}}, 0, true)
+	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions:            11,
+		ProcessedVersions:        7,
+		ProcessedVersionsSize:    70,
+		RocksdbBlockReadByte:     99,
+		IaRemoteReadSegmentBytes: 101,
+	}}, 13, true)
+
+	pointStats = stats.GetPointResponseStats()
+	require.True(t, pointStats.IsValid())
+	require.False(t, pointStats.ScanDetailComplete())
+	require.True(t, pointStats.PayloadComplete())
+	require.Equal(t, PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         11,
+			ProcessedKeys:     7,
+			ProcessedKeysSize: 70,
+		},
+		PayloadBytes:       20,
+		ScanDetailRecords:  2,
+		PayloadRecords:     4,
+		CompletedResponses: 4,
+	}, pointStats)
+
+	// The getter returns an independent value snapshot.
+	pointStats.ScanDetail.TotalKeys = 1000
+	require.Equal(t, int64(11), stats.GetPointResponseStats().ScanDetail.TotalKeys)
+}
+
+func TestSnapshotRuntimeStatsPointResponseCloneAndMerge(t *testing.T) {
+	source := &SnapshotRuntimeStats{}
+	sourceSnapshot := newSnapshotWithRuntimeStats(source)
+	sourceSnapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions:         5,
+		ProcessedVersions:     3,
+		ProcessedVersionsSize: 30,
+	}}, 7, true)
+	sourceSnapshot.mergePointResponse(nil, 0, true)
+
+	clone := source.Clone()
+	sourceSnapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions:         7,
+		ProcessedVersions:     4,
+		ProcessedVersionsSize: 40,
+	}}, 11, true)
+
+	require.Equal(t, PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         5,
+			ProcessedKeys:     3,
+			ProcessedKeysSize: 30,
+		},
+		PayloadBytes:       7,
+		ScanDetailRecords:  1,
+		PayloadRecords:     2,
+		CompletedResponses: 2,
+	}, clone.GetPointResponseStats())
+
+	target := &SnapshotRuntimeStats{}
+	target.Merge(clone)
+	target.Merge(source)
+	require.Equal(t, PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         17,
+			ProcessedKeys:     10,
+			ProcessedKeysSize: 100,
+		},
+		PayloadBytes:       25,
+		ScanDetailRecords:  3,
+		PayloadRecords:     5,
+		CompletedResponses: 5,
+	}, target.GetPointResponseStats())
+}
+
+func TestSnapshotRuntimeStatsPointResponseInvalid(t *testing.T) {
+	var nilStats *SnapshotRuntimeStats
+	require.False(t, nilStats.GetPointResponseStats().IsValid())
+
+	t.Run("protobuf conversion", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			detail *kvrpcpb.ScanDetailV2
+		}{
+			{name: "total versions", detail: &kvrpcpb.ScanDetailV2{TotalVersions: math.MaxUint64}},
+			{name: "processed versions", detail: &kvrpcpb.ScanDetailV2{ProcessedVersions: math.MaxUint64}},
+			{name: "processed versions size", detail: &kvrpcpb.ScanDetailV2{ProcessedVersionsSize: math.MaxUint64}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				stats := &SnapshotRuntimeStats{}
+				newSnapshotWithRuntimeStats(stats).mergePointResponse(
+					&kvrpcpb.ExecDetailsV2{ScanDetailV2: tc.detail}, 0, true,
+				)
+				require.False(t, stats.GetPointResponseStats().IsValid())
+				require.False(t, stats.Clone().GetPointResponseStats().IsValid())
+			})
+		}
+	})
+
+	t.Run("record overflow", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			stats PointResponseStats
+		}{
+			{name: "total keys", stats: PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64}}},
+			{name: "processed keys", stats: PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: math.MaxInt64}}},
+			{name: "processed size", stats: PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: math.MaxInt64}}},
+			{name: "payload bytes", stats: PointResponseStats{PayloadBytes: math.MaxUint64}},
+			{name: "detail records", stats: PointResponseStats{ScanDetailRecords: math.MaxUint64}},
+			{name: "payload records", stats: PointResponseStats{PayloadRecords: math.MaxUint64}},
+			{name: "completed responses", stats: PointResponseStats{CompletedResponses: math.MaxUint64}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				stats := &SnapshotRuntimeStats{pointResponseStats: tc.stats}
+				newSnapshotWithRuntimeStats(stats).mergePointResponse(
+					&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+						TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
+					}}, 1, true,
+				)
+				require.False(t, stats.GetPointResponseStats().IsValid())
+			})
+		}
+	})
+
+	t.Run("merge overflow and invalid propagation", func(t *testing.T) {
+		target := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{
+			ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64},
+		}}
+		source := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{
+			ScanDetail:         PointReadScanDetail{TotalKeys: 1},
+			PayloadRecords:     1,
+			CompletedResponses: 1,
+		}}
+		target.Merge(source)
+		require.False(t, target.GetPointResponseStats().IsValid())
+
+		invalidSource := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{invalid: true}}
+		cleanTarget := &SnapshotRuntimeStats{}
+		cleanTarget.Merge(invalidSource)
+		require.False(t, cleanTarget.GetPointResponseStats().IsValid())
+	})
+
+	t.Run("payload parser invalid", func(t *testing.T) {
+		stats := &SnapshotRuntimeStats{}
+		newSnapshotWithRuntimeStats(stats).mergePointResponse(nil, 0, false)
+		require.False(t, stats.GetPointResponseStats().IsValid())
+	})
+}
+
+func TestCollectBatchGetResponseDataPointResponseStats(t *testing.T) {
+	stats := &SnapshotRuntimeStats{}
+	snapshot := newSnapshotWithRuntimeStats(stats)
+	collect := func(resp any) (*batchGetLockInfo, error) {
+		return collectBatchGetResponseData(
+			&tikvrpc.Response{Resp: resp},
+			func([]byte, kv.ValueEntry) {},
+			snapshot.mergePointResponse,
+		)
+	}
+
+	// A nil recorder keeps the normal response parsing path but performs no
+	// point-response accounting.
+	_, err := collectBatchGetResponseData(
+		&tikvrpc.Response{Resp: &kvrpcpb.BatchGetResponse{}},
+		func([]byte, kv.ValueEntry) {},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, PointResponseStats{}, stats.GetPointResponseStats())
+
+	_, err = collectBatchGetResponseData(
+		&tikvrpc.Response{}, func([]byte, kv.ValueEntry) {}, snapshot.mergePointResponse,
+	)
+	require.Error(t, err)
+
+	_, err = collect(&kvrpcpb.BatchGetResponse{})
+	require.NoError(t, err)
+	_, err = collect(&kvrpcpb.BatchGetResponse{
+		ExecDetailsV2: &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{}},
+	})
+	require.NoError(t, err)
+
+	lockInfo, err := collect(&kvrpcpb.BatchGetResponse{
+		Error: &kvrpcpb.KeyError{Locked: testLockInfo("k")},
+		ExecDetailsV2: &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+			TotalVersions: 2, ProcessedVersions: 1, ProcessedVersionsSize: 10,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, lockInfo.lockedKeys, 1)
+
+	// The successful retry is a separate recognized response.
+	_, err = collect(&kvrpcpb.BatchGetResponse{
+		Pairs: []*kvrpcpb.KvPair{
+			{Key: []byte("aa"), Value: []byte("bbb")},
+			{Error: &kvrpcpb.KeyError{Locked: testLockInfo("locked")}},
+		},
+		ExecDetailsV2: &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+			TotalVersions: 3, ProcessedVersions: 2, ProcessedVersionsSize: 20,
+		}},
+	})
+	require.NoError(t, err)
+	_, err = collect(&kvrpcpb.BufferBatchGetResponse{
+		Pairs: []*kvrpcpb.KvPair{{Key: []byte("c"), Value: []byte("dd")}},
+	})
+	require.NoError(t, err)
+	_, err = collect(&kvrpcpb.GetResponse{})
+	require.Error(t, err)
+
+	pointStats := stats.GetPointResponseStats()
+	require.True(t, pointStats.IsValid())
+	require.False(t, pointStats.ScanDetailComplete())
+	require.True(t, pointStats.PayloadComplete())
+	require.Equal(t, PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys: 5, ProcessedKeys: 3, ProcessedKeysSize: 30,
+		},
+		PayloadBytes:       8,
+		ScanDetailRecords:  3,
+		PayloadRecords:     5,
+		CompletedResponses: 5,
+	}, pointStats)
+}
+
+func testLockInfo(key string) *kvrpcpb.LockInfo {
+	return &kvrpcpb.LockInfo{
+		PrimaryLock: []byte(key),
+		LockVersion: 1,
+		Key:         []byte(key),
+		LockTtl:     1,
+		TxnSize:     1,
+		LockType:    kvrpcpb.Op_Put,
+	}
+}
+
+func TestSnapshotRuntimeStatsConcurrentPointResponseAccess(t *testing.T) {
+	const (
+		writers       = 8
+		responsesEach = 100
+		readers       = 4
+		readsEach     = 200
+	)
+	stats := &SnapshotRuntimeStats{}
+	snapshot := newSnapshotWithRuntimeStats(stats)
+	start := make(chan struct{})
+
+	var readerWG sync.WaitGroup
+	for range readers {
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			<-start
+			for range readsEach {
+				stats.GetPointResponseStats()
+				clone := stats.Clone()
+				merged := &SnapshotRuntimeStats{}
+				merged.Merge(clone)
+				_ = merged.String()
+			}
+		}()
+	}
+
+	var writerWG sync.WaitGroup
+	errCh := make(chan error, writers)
+	for range writers {
+		writerWG.Add(1)
+		go func() {
+			defer writerWG.Done()
+			<-start
+			for i := range responsesEach {
+				response := &kvrpcpb.BatchGetResponse{
+					Pairs: []*kvrpcpb.KvPair{{Key: []byte("k"), Value: []byte("vv")}},
+				}
+				if i%2 == 0 {
+					response.ExecDetailsV2 = &kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+						TotalVersions: 1, ProcessedVersions: 2, ProcessedVersionsSize: 3,
+					}}
+				}
+				_, err := collectBatchGetResponseData(
+					&tikvrpc.Response{Resp: response},
+					func([]byte, kv.ValueEntry) {},
+					snapshot.mergePointResponse,
+				)
+				if err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	writerWG.Wait()
+	readerWG.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         writers * responsesEach / 2,
+			ProcessedKeys:     writers * responsesEach,
+			ProcessedKeysSize: writers * responsesEach * 3 / 2,
+		},
+		PayloadBytes:       writers * responsesEach * 3,
+		ScanDetailRecords:  writers * responsesEach / 2,
+		PayloadRecords:     writers * responsesEach,
+		CompletedResponses: writers * responsesEach,
+	}, stats.GetPointResponseStats())
+}

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -40,25 +40,17 @@ func TestSnapshotRuntimeStatsPointResponseStats(t *testing.T) {
 	require.False(t, pointStats.PayloadComplete())
 	require.Equal(t, PointResponseStats{}, pointStats)
 
-	// Merging a standalone ExecDetails value preserves its existing diagnostic
-	// purpose and does not fabricate point-response coverage.
-	snapshot.mergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
-		TotalVersions: 9,
-	}})
-	require.Equal(t, PointResponseStats{}, stats.GetPointResponseStats())
-	require.Contains(t, stats.String(), "total_keys: 9")
-
 	// Missing ExecDetailsV2 differs from a present, zero-valued ScanDetailV2.
-	snapshot.mergePointResponse(nil, 0, true)
-	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{}, 7, true)
-	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{}}, 0, true)
+	snapshot.mergePointResponse(nil, 0)
+	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{}, 7)
+	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{}}, 0)
 	snapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
 		TotalVersions:            11,
 		ProcessedVersions:        7,
 		ProcessedVersionsSize:    70,
 		RocksdbBlockReadByte:     99,
 		IaRemoteReadSegmentBytes: 101,
-	}}, 13, true)
+	}}, 13)
 
 	pointStats = stats.GetPointResponseStats()
 	require.True(t, pointStats.IsValid())
@@ -76,6 +68,23 @@ func TestSnapshotRuntimeStatsPointResponseStats(t *testing.T) {
 	require.Equal(t, int64(11), stats.GetPointResponseStats().ScanDetail.TotalKeys)
 }
 
+func TestSnapshotRuntimeStatsStandaloneScanDetailDoesNotEstablishPointCoverage(t *testing.T) {
+	stats := &SnapshotRuntimeStats{}
+	snapshot := newSnapshotWithRuntimeStats(stats)
+
+	// Standalone execution details remain visible through the legacy diagnostic
+	// scan detail, but do not establish point-response coverage.
+	snapshot.mergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+		TotalVersions: 9,
+	}})
+	pointStats := stats.GetPointResponseStats()
+	require.True(t, pointStats.IsValid())
+	require.False(t, pointStats.ScanDetailComplete())
+	require.False(t, pointStats.PayloadComplete())
+	require.Equal(t, PointResponseStats{}, pointStats)
+	require.Contains(t, stats.String(), "total_keys: 9")
+}
+
 func TestSnapshotRuntimeStatsPointResponseCloneAndMerge(t *testing.T) {
 	source := &SnapshotRuntimeStats{}
 	sourceSnapshot := newSnapshotWithRuntimeStats(source)
@@ -83,15 +92,15 @@ func TestSnapshotRuntimeStatsPointResponseCloneAndMerge(t *testing.T) {
 		TotalVersions:         5,
 		ProcessedVersions:     3,
 		ProcessedVersionsSize: 30,
-	}}, 7, true)
-	sourceSnapshot.mergePointResponse(nil, 0, true)
+	}}, 7)
+	sourceSnapshot.mergePointResponse(nil, 0)
 
 	clone := source.Clone()
 	sourceSnapshot.mergePointResponse(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
 		TotalVersions:         7,
 		ProcessedVersions:     4,
 		ProcessedVersionsSize: 40,
-	}}, 11, true)
+	}}, 11)
 
 	cloneStats := clone.GetPointResponseStats()
 	require.Equal(t, PointReadScanDetail{
@@ -118,9 +127,11 @@ func TestSnapshotRuntimeStatsPointResponseCloneAndMerge(t *testing.T) {
 	require.False(t, targetStats.ScanDetailComplete())
 	require.True(t, targetStats.PayloadComplete())
 
-	// Merging with itself snapshots the source before acquiring the target lock.
+	// Self-merge doubles the accumulated values without changing the source clone.
 	target.Merge(target)
-	require.Equal(t, uint64(50), target.GetPointResponseStats().PayloadBytes)
+	targetStats = target.GetPointResponseStats()
+	require.Equal(t, int64(34), targetStats.ScanDetail.TotalKeys)
+	require.Equal(t, uint64(50), targetStats.PayloadBytes)
 	require.Equal(t, cloneStats, clone.GetPointResponseStats())
 }
 
@@ -129,14 +140,6 @@ func TestSnapshotRuntimeStatsPointResponseInvalid(t *testing.T) {
 	require.False(t, nilStats.GetPointResponseStats().IsValid())
 	require.False(t, nilStats.GetPointResponseStats().ScanDetailComplete())
 	require.False(t, nilStats.GetPointResponseStats().PayloadComplete())
-
-	stats := &SnapshotRuntimeStats{}
-	newSnapshotWithRuntimeStats(stats).mergePointResponse(nil, 0, false)
-	require.False(t, stats.GetPointResponseStats().IsValid())
-	require.False(t, stats.Clone().GetPointResponseStats().IsValid())
-	merged := &SnapshotRuntimeStats{}
-	merged.Merge(stats)
-	require.False(t, merged.GetPointResponseStats().IsValid())
 }
 
 func TestCollectBatchGetResponseDataPointResponseStats(t *testing.T) {
@@ -220,32 +223,14 @@ func testLockInfo(key string) *kvrpcpb.LockInfo {
 	}
 }
 
-func TestSnapshotRuntimeStatsConcurrentPointResponseAccess(t *testing.T) {
+func TestSnapshotRuntimeStatsConcurrentPointResponseWrites(t *testing.T) {
 	const (
 		writers       = 8
 		responsesEach = 100
-		readers       = 4
-		readsEach     = 200
 	)
 	stats := &SnapshotRuntimeStats{}
 	snapshot := newSnapshotWithRuntimeStats(stats)
 	start := make(chan struct{})
-
-	var readerWG sync.WaitGroup
-	for range readers {
-		readerWG.Add(1)
-		go func() {
-			defer readerWG.Done()
-			<-start
-			for range readsEach {
-				stats.GetPointResponseStats()
-				clone := stats.Clone()
-				merged := &SnapshotRuntimeStats{}
-				merged.Merge(clone)
-				_ = merged.String()
-			}
-		}()
-	}
 
 	var writerWG sync.WaitGroup
 	errCh := make(chan error, writers)
@@ -278,7 +263,6 @@ func TestSnapshotRuntimeStatsConcurrentPointResponseAccess(t *testing.T) {
 
 	close(start)
 	writerWG.Wait()
-	readerWG.Wait()
 	close(errCh)
 	for err := range errCh {
 		require.NoError(t, err)

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -15,7 +15,6 @@
 package txnsnapshot
 
 import (
-	"math"
 	"sync"
 	"testing"
 
@@ -65,17 +64,12 @@ func TestSnapshotRuntimeStatsPointResponseStats(t *testing.T) {
 	require.True(t, pointStats.IsValid())
 	require.False(t, pointStats.ScanDetailComplete())
 	require.True(t, pointStats.PayloadComplete())
-	require.Equal(t, PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys:         11,
-			ProcessedKeys:     7,
-			ProcessedKeysSize: 70,
-		},
-		PayloadBytes:       20,
-		ScanDetailRecords:  2,
-		PayloadRecords:     4,
-		CompletedResponses: 4,
-	}, pointStats)
+	require.Equal(t, PointReadScanDetail{
+		TotalKeys:         11,
+		ProcessedKeys:     7,
+		ProcessedKeysSize: 70,
+	}, pointStats.ScanDetail)
+	require.Equal(t, uint64(20), pointStats.PayloadBytes)
 
 	// The getter returns an independent value snapshot.
 	pointStats.ScanDetail.TotalKeys = 1000
@@ -99,106 +93,50 @@ func TestSnapshotRuntimeStatsPointResponseCloneAndMerge(t *testing.T) {
 		ProcessedVersionsSize: 40,
 	}}, 11, true)
 
-	require.Equal(t, PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys:         5,
-			ProcessedKeys:     3,
-			ProcessedKeysSize: 30,
-		},
-		PayloadBytes:       7,
-		ScanDetailRecords:  1,
-		PayloadRecords:     2,
-		CompletedResponses: 2,
-	}, clone.GetPointResponseStats())
+	cloneStats := clone.GetPointResponseStats()
+	require.Equal(t, PointReadScanDetail{
+		TotalKeys:         5,
+		ProcessedKeys:     3,
+		ProcessedKeysSize: 30,
+	}, cloneStats.ScanDetail)
+	require.Equal(t, uint64(7), cloneStats.PayloadBytes)
+	require.True(t, cloneStats.IsValid())
+	require.False(t, cloneStats.ScanDetailComplete())
+	require.True(t, cloneStats.PayloadComplete())
 
 	target := &SnapshotRuntimeStats{}
 	target.Merge(clone)
 	target.Merge(source)
-	require.Equal(t, PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys:         17,
-			ProcessedKeys:     10,
-			ProcessedKeysSize: 100,
-		},
-		PayloadBytes:       25,
-		ScanDetailRecords:  3,
-		PayloadRecords:     5,
-		CompletedResponses: 5,
-	}, target.GetPointResponseStats())
+	targetStats := target.GetPointResponseStats()
+	require.Equal(t, PointReadScanDetail{
+		TotalKeys:         17,
+		ProcessedKeys:     10,
+		ProcessedKeysSize: 100,
+	}, targetStats.ScanDetail)
+	require.Equal(t, uint64(25), targetStats.PayloadBytes)
+	require.True(t, targetStats.IsValid())
+	require.False(t, targetStats.ScanDetailComplete())
+	require.True(t, targetStats.PayloadComplete())
+
+	// Merging with itself snapshots the source before acquiring the target lock.
+	target.Merge(target)
+	require.Equal(t, uint64(50), target.GetPointResponseStats().PayloadBytes)
+	require.Equal(t, cloneStats, clone.GetPointResponseStats())
 }
 
 func TestSnapshotRuntimeStatsPointResponseInvalid(t *testing.T) {
 	var nilStats *SnapshotRuntimeStats
 	require.False(t, nilStats.GetPointResponseStats().IsValid())
+	require.False(t, nilStats.GetPointResponseStats().ScanDetailComplete())
+	require.False(t, nilStats.GetPointResponseStats().PayloadComplete())
 
-	t.Run("protobuf conversion", func(t *testing.T) {
-		for _, tc := range []struct {
-			name   string
-			detail *kvrpcpb.ScanDetailV2
-		}{
-			{name: "total versions", detail: &kvrpcpb.ScanDetailV2{TotalVersions: math.MaxUint64}},
-			{name: "processed versions", detail: &kvrpcpb.ScanDetailV2{ProcessedVersions: math.MaxUint64}},
-			{name: "processed versions size", detail: &kvrpcpb.ScanDetailV2{ProcessedVersionsSize: math.MaxUint64}},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				stats := &SnapshotRuntimeStats{}
-				newSnapshotWithRuntimeStats(stats).mergePointResponse(
-					&kvrpcpb.ExecDetailsV2{ScanDetailV2: tc.detail}, 0, true,
-				)
-				require.False(t, stats.GetPointResponseStats().IsValid())
-				require.False(t, stats.Clone().GetPointResponseStats().IsValid())
-			})
-		}
-	})
-
-	t.Run("record overflow", func(t *testing.T) {
-		for _, tc := range []struct {
-			name  string
-			stats PointResponseStats
-		}{
-			{name: "total keys", stats: PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64}}},
-			{name: "processed keys", stats: PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: math.MaxInt64}}},
-			{name: "processed size", stats: PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: math.MaxInt64}}},
-			{name: "payload bytes", stats: PointResponseStats{PayloadBytes: math.MaxUint64}},
-			{name: "detail records", stats: PointResponseStats{ScanDetailRecords: math.MaxUint64}},
-			{name: "payload records", stats: PointResponseStats{PayloadRecords: math.MaxUint64}},
-			{name: "completed responses", stats: PointResponseStats{CompletedResponses: math.MaxUint64}},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				stats := &SnapshotRuntimeStats{pointResponseStats: tc.stats}
-				newSnapshotWithRuntimeStats(stats).mergePointResponse(
-					&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
-						TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
-					}}, 1, true,
-				)
-				require.False(t, stats.GetPointResponseStats().IsValid())
-			})
-		}
-	})
-
-	t.Run("merge overflow and invalid propagation", func(t *testing.T) {
-		target := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{
-			ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64},
-		}}
-		source := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{
-			ScanDetail:         PointReadScanDetail{TotalKeys: 1},
-			PayloadRecords:     1,
-			CompletedResponses: 1,
-		}}
-		target.Merge(source)
-		require.False(t, target.GetPointResponseStats().IsValid())
-
-		invalidSource := &SnapshotRuntimeStats{pointResponseStats: PointResponseStats{invalid: true}}
-		cleanTarget := &SnapshotRuntimeStats{}
-		cleanTarget.Merge(invalidSource)
-		require.False(t, cleanTarget.GetPointResponseStats().IsValid())
-	})
-
-	t.Run("payload parser invalid", func(t *testing.T) {
-		stats := &SnapshotRuntimeStats{}
-		newSnapshotWithRuntimeStats(stats).mergePointResponse(nil, 0, false)
-		require.False(t, stats.GetPointResponseStats().IsValid())
-	})
+	stats := &SnapshotRuntimeStats{}
+	newSnapshotWithRuntimeStats(stats).mergePointResponse(nil, 0, false)
+	require.False(t, stats.GetPointResponseStats().IsValid())
+	require.False(t, stats.Clone().GetPointResponseStats().IsValid())
+	merged := &SnapshotRuntimeStats{}
+	merged.Merge(stats)
+	require.False(t, merged.GetPointResponseStats().IsValid())
 }
 
 func TestCollectBatchGetResponseDataPointResponseStats(t *testing.T) {
@@ -265,15 +203,10 @@ func TestCollectBatchGetResponseDataPointResponseStats(t *testing.T) {
 	require.True(t, pointStats.IsValid())
 	require.False(t, pointStats.ScanDetailComplete())
 	require.True(t, pointStats.PayloadComplete())
-	require.Equal(t, PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys: 5, ProcessedKeys: 3, ProcessedKeysSize: 30,
-		},
-		PayloadBytes:       8,
-		ScanDetailRecords:  3,
-		PayloadRecords:     5,
-		CompletedResponses: 5,
-	}, pointStats)
+	require.Equal(t, PointReadScanDetail{
+		TotalKeys: 5, ProcessedKeys: 3, ProcessedKeysSize: 30,
+	}, pointStats.ScanDetail)
+	require.Equal(t, uint64(8), pointStats.PayloadBytes)
 }
 
 func testLockInfo(key string) *kvrpcpb.LockInfo {
@@ -351,15 +284,14 @@ func TestSnapshotRuntimeStatsConcurrentPointResponseAccess(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, PointResponseStats{
-		ScanDetail: PointReadScanDetail{
-			TotalKeys:         writers * responsesEach / 2,
-			ProcessedKeys:     writers * responsesEach,
-			ProcessedKeysSize: writers * responsesEach * 3 / 2,
-		},
-		PayloadBytes:       writers * responsesEach * 3,
-		ScanDetailRecords:  writers * responsesEach / 2,
-		PayloadRecords:     writers * responsesEach,
-		CompletedResponses: writers * responsesEach,
-	}, stats.GetPointResponseStats())
+	pointStats := stats.GetPointResponseStats()
+	require.Equal(t, PointReadScanDetail{
+		TotalKeys:         writers * responsesEach / 2,
+		ProcessedKeys:     writers * responsesEach,
+		ProcessedKeysSize: writers * responsesEach * 3 / 2,
+	}, pointStats.ScanDetail)
+	require.Equal(t, uint64(writers*responsesEach*3), pointStats.PayloadBytes)
+	require.True(t, pointStats.IsValid())
+	require.False(t, pointStats.ScanDetailComplete())
+	require.True(t, pointStats.PayloadComplete())
 }

--- a/txnkv/txnsnapshot/snapshot_test.go
+++ b/txnkv/txnsnapshot/snapshot_test.go
@@ -74,7 +74,7 @@ func TestSnapshotRuntimeStatsStandaloneScanDetailDoesNotEstablishPointCoverage(t
 
 	// Standalone execution details remain visible through the legacy diagnostic
 	// scan detail, but do not establish point-response coverage.
-	snapshot.mergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
+	SnapshotProbe{KVSnapshot: snapshot}.MergeExecDetail(&kvrpcpb.ExecDetailsV2{ScanDetailV2: &kvrpcpb.ScanDetailV2{
 		TotalVersions: 9,
 	}})
 	pointStats := stats.GetPointResponseStats()

--- a/txnkv/txnsnapshot/test_probe.go
+++ b/txnkv/txnsnapshot/test_probe.go
@@ -38,8 +38,6 @@ func (s SnapshotProbe) RecordBackoffInfo(bo *retry.Backoffer) {
 
 // MergeExecDetail merges exec stats into snapshot's stats.
 func (s SnapshotProbe) MergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.mergeExecDetail(detail)
 }
 

--- a/txnkv/txnsnapshot/test_probe.go
+++ b/txnkv/txnsnapshot/test_probe.go
@@ -38,6 +38,8 @@ func (s SnapshotProbe) RecordBackoffInfo(bo *retry.Backoffer) {
 
 // MergeExecDetail merges exec stats into snapshot's stats.
 func (s SnapshotProbe) MergeExecDetail(detail *kvrpcpb.ExecDetailsV2) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.mergeExecDetail(detail)
 }
 

--- a/util/execdetails_test.go
+++ b/util/execdetails_test.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func TestPointResponseStatsRecordResponse(t *testing.T) {
 	require.False(t, stats.PayloadComplete())
 
 	// A real all-zero response establishes coverage without contributing values.
-	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0)
 	require.True(t, stats.ScanDetailComplete())
 	require.True(t, stats.PayloadComplete())
 	require.Zero(t, stats.ScanDetail)
@@ -40,24 +39,24 @@ func TestPointResponseStatsRecordResponse(t *testing.T) {
 
 	stats.RecordResponse(&kvrpcpb.ScanDetailV2{
 		TotalVersions: 5, ProcessedVersions: 3, ProcessedVersionsSize: 30,
-	}, 7, true)
+	}, 7)
 	require.Equal(t, PointReadScanDetail{TotalKeys: 5, ProcessedKeys: 3, ProcessedKeysSize: 30}, stats.ScanDetail)
 	require.Equal(t, uint64(7), stats.PayloadBytes)
 
 	// Missing scan detail does not invalidate an otherwise accounted-for payload.
-	stats.RecordResponse(nil, 2, true)
+	stats.RecordResponse(nil, 2)
 	require.True(t, stats.IsValid())
 	require.False(t, stats.ScanDetailComplete())
 	require.True(t, stats.PayloadComplete())
 	require.Equal(t, uint64(9), stats.PayloadBytes)
-	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0)
 	require.False(t, stats.ScanDetailComplete(), "later responses must not hide missing detail")
 }
 
 func TestPointResponseStatsMerge(t *testing.T) {
 	var complete, missing, invalid PointResponseStats
-	complete.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 2}, 3, true)
-	missing.RecordResponse(nil, 5, true)
+	complete.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 2}, 3)
+	missing.RecordResponse(nil, 5)
 	invalid.Invalidate()
 	states := []struct {
 		name              string
@@ -111,74 +110,17 @@ func TestPointResponseStatsInvalid(t *testing.T) {
 		require.False(t, stats.ScanDetailComplete())
 		require.False(t, stats.PayloadComplete())
 		before := stats
-		stats.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 1}, 1, true)
+		stats.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 1}, 1)
 		require.Equal(t, before, stats, "invalid state and accumulated values must be preserved")
 	}
 
-	t.Run("protobuf conversion", func(t *testing.T) {
-		for _, tc := range []struct {
-			name   string
-			detail *kvrpcpb.ScanDetailV2
-		}{
-			{"total versions", &kvrpcpb.ScanDetailV2{TotalVersions: math.MaxUint64}},
-			{"processed versions", &kvrpcpb.ScanDetailV2{ProcessedVersions: math.MaxUint64}},
-			{"processed versions size", &kvrpcpb.ScanDetailV2{ProcessedVersionsSize: math.MaxUint64}},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				var stats PointResponseStats
-				stats.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 1}, 2, true)
-				before := stats
-				stats.RecordResponse(tc.detail, 3, true)
-				assertInvalid(t, stats)
-				require.Equal(t, before.ScanDetail, stats.ScanDetail)
-				require.Equal(t, before.PayloadBytes, stats.PayloadBytes)
-			})
-		}
-	})
-
-	t.Run("numeric aggregation", func(t *testing.T) {
-		for _, tc := range []struct {
-			name  string
-			stats PointResponseStats
-		}{
-			{"total keys", PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64}}},
-			{"processed keys", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: math.MaxInt64}}},
-			{"processed size", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: math.MaxInt64}}},
-			{"payload bytes", PointResponseStats{PayloadBytes: math.MaxUint64}},
-			{"negative total keys", PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: -1}}},
-			{"negative processed keys", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: -1}}},
-			{"negative processed size", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: -1}}},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				stats := tc.stats
-				stats.RecordResponse(&kvrpcpb.ScanDetailV2{
-					TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
-				}, 1, true)
-				assertInvalid(t, stats)
-				require.Equal(t, tc.stats.ScanDetail, stats.ScanDetail)
-				require.Equal(t, tc.stats.PayloadBytes, stats.PayloadBytes)
-
-				// Merge also rejects overflow and negative fields in its source.
-				var merged PointResponseStats
-				merged.RecordResponse(&kvrpcpb.ScanDetailV2{
-					TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
-				}, 1, true)
-				before := merged
-				merged.Merge(tc.stats)
-				assertInvalid(t, merged)
-				require.Equal(t, before.ScanDetail, merged.ScanDetail)
-				require.Equal(t, before.PayloadBytes, merged.PayloadBytes)
-			})
-		}
-	})
-
-	t.Run("payload accounting and explicit invalidation", func(t *testing.T) {
+	t.Run("explicit invalidation", func(t *testing.T) {
 		var stats PointResponseStats
-		stats.RecordResponse(nil, 0, false)
+		stats.Invalidate()
 		assertInvalid(t, stats)
 
 		var complete PointResponseStats
-		complete.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+		complete.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0)
 		complete.Invalidate()
 		assertInvalid(t, complete)
 	})

--- a/util/execdetails_test.go
+++ b/util/execdetails_test.go
@@ -15,13 +15,174 @@
 package util
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	rmpb "github.com/pingcap/kvproto/pkg/resource_manager"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestPointResponseStatsRecordResponse(t *testing.T) {
+	var stats PointResponseStats
+	require.True(t, stats.IsValid())
+	require.False(t, stats.ScanDetailComplete())
+	require.False(t, stats.PayloadComplete())
+
+	// A real all-zero response establishes coverage without contributing values.
+	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+	require.True(t, stats.ScanDetailComplete())
+	require.True(t, stats.PayloadComplete())
+	require.Zero(t, stats.ScanDetail)
+	require.Zero(t, stats.PayloadBytes)
+
+	stats.RecordResponse(&kvrpcpb.ScanDetailV2{
+		TotalVersions: 5, ProcessedVersions: 3, ProcessedVersionsSize: 30,
+	}, 7, true)
+	require.Equal(t, PointReadScanDetail{TotalKeys: 5, ProcessedKeys: 3, ProcessedKeysSize: 30}, stats.ScanDetail)
+	require.Equal(t, uint64(7), stats.PayloadBytes)
+
+	// Missing scan detail does not invalidate an otherwise accounted-for payload.
+	stats.RecordResponse(nil, 2, true)
+	require.True(t, stats.IsValid())
+	require.False(t, stats.ScanDetailComplete())
+	require.True(t, stats.PayloadComplete())
+	require.Equal(t, uint64(9), stats.PayloadBytes)
+	stats.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+	require.False(t, stats.ScanDetailComplete(), "later responses must not hide missing detail")
+}
+
+func TestPointResponseStatsMerge(t *testing.T) {
+	var complete, missing, invalid PointResponseStats
+	complete.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 2}, 3, true)
+	missing.RecordResponse(nil, 5, true)
+	invalid.Invalidate()
+	states := []struct {
+		name              string
+		stats             PointResponseStats
+		valid             bool
+		seenResponse      bool
+		missingScanDetail bool
+	}{
+		{name: "empty", valid: true},
+		{name: "complete", stats: complete, valid: true, seenResponse: true},
+		{name: "missing", stats: missing, valid: true, seenResponse: true, missingScanDetail: true},
+		{name: "invalid", stats: invalid},
+	}
+	for _, left := range states {
+		for _, right := range states {
+			t.Run(left.name+"/"+right.name, func(t *testing.T) {
+				stats := left.stats
+				stats.Merge(right.stats)
+				valid := left.valid && right.valid
+				seen := left.seenResponse || right.seenResponse
+				missingDetail := left.missingScanDetail || right.missingScanDetail
+				require.Equal(t, valid, stats.IsValid())
+				require.Equal(t, valid && seen, stats.PayloadComplete())
+				require.Equal(t, valid && seen && !missingDetail, stats.ScanDetailComplete())
+				if valid {
+					require.Equal(t, left.stats.ScanDetail.TotalKeys+right.stats.ScanDetail.TotalKeys, stats.ScanDetail.TotalKeys)
+					require.Equal(t, left.stats.PayloadBytes+right.stats.PayloadBytes, stats.PayloadBytes)
+				} else {
+					require.Equal(t, left.stats.ScanDetail, stats.ScanDetail)
+					require.Equal(t, left.stats.PayloadBytes, stats.PayloadBytes)
+				}
+			})
+		}
+	}
+
+	// Copies are independent and merging an empty snapshot preserves all state.
+	copy := complete
+	copy.Merge(PointResponseStats{})
+	require.Equal(t, complete, copy)
+	copy.Merge(copy)
+	require.Equal(t, int64(4), copy.ScanDetail.TotalKeys)
+	require.Equal(t, uint64(6), copy.PayloadBytes)
+	require.Equal(t, int64(2), complete.ScanDetail.TotalKeys)
+	require.Equal(t, uint64(3), complete.PayloadBytes)
+}
+
+func TestPointResponseStatsInvalid(t *testing.T) {
+	assertInvalid := func(t *testing.T, stats PointResponseStats) {
+		t.Helper()
+		require.False(t, stats.IsValid())
+		require.False(t, stats.ScanDetailComplete())
+		require.False(t, stats.PayloadComplete())
+		before := stats
+		stats.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 1}, 1, true)
+		require.Equal(t, before, stats, "invalid state and accumulated values must be preserved")
+	}
+
+	t.Run("protobuf conversion", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			detail *kvrpcpb.ScanDetailV2
+		}{
+			{"total versions", &kvrpcpb.ScanDetailV2{TotalVersions: math.MaxUint64}},
+			{"processed versions", &kvrpcpb.ScanDetailV2{ProcessedVersions: math.MaxUint64}},
+			{"processed versions size", &kvrpcpb.ScanDetailV2{ProcessedVersionsSize: math.MaxUint64}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				var stats PointResponseStats
+				stats.RecordResponse(&kvrpcpb.ScanDetailV2{TotalVersions: 1}, 2, true)
+				before := stats
+				stats.RecordResponse(tc.detail, 3, true)
+				assertInvalid(t, stats)
+				require.Equal(t, before.ScanDetail, stats.ScanDetail)
+				require.Equal(t, before.PayloadBytes, stats.PayloadBytes)
+			})
+		}
+	})
+
+	t.Run("numeric aggregation", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			stats PointResponseStats
+		}{
+			{"total keys", PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: math.MaxInt64}}},
+			{"processed keys", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: math.MaxInt64}}},
+			{"processed size", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: math.MaxInt64}}},
+			{"payload bytes", PointResponseStats{PayloadBytes: math.MaxUint64}},
+			{"negative total keys", PointResponseStats{ScanDetail: PointReadScanDetail{TotalKeys: -1}}},
+			{"negative processed keys", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeys: -1}}},
+			{"negative processed size", PointResponseStats{ScanDetail: PointReadScanDetail{ProcessedKeysSize: -1}}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				stats := tc.stats
+				stats.RecordResponse(&kvrpcpb.ScanDetailV2{
+					TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
+				}, 1, true)
+				assertInvalid(t, stats)
+				require.Equal(t, tc.stats.ScanDetail, stats.ScanDetail)
+				require.Equal(t, tc.stats.PayloadBytes, stats.PayloadBytes)
+
+				// Merge also rejects overflow and negative fields in its source.
+				var merged PointResponseStats
+				merged.RecordResponse(&kvrpcpb.ScanDetailV2{
+					TotalVersions: 1, ProcessedVersions: 1, ProcessedVersionsSize: 1,
+				}, 1, true)
+				before := merged
+				merged.Merge(tc.stats)
+				assertInvalid(t, merged)
+				require.Equal(t, before.ScanDetail, merged.ScanDetail)
+				require.Equal(t, before.PayloadBytes, merged.PayloadBytes)
+			})
+		}
+	})
+
+	t.Run("payload accounting and explicit invalidation", func(t *testing.T) {
+		var stats PointResponseStats
+		stats.RecordResponse(nil, 0, false)
+		assertInvalid(t, stats)
+
+		var complete PointResponseStats
+		complete.RecordResponse(&kvrpcpb.ScanDetailV2{}, 0, true)
+		complete.Invalidate()
+		assertInvalid(t, complete)
+	})
+}
 
 func TestRUDetailsDrainRUV2(t *testing.T) {
 	ruDetails := NewRUDetails()

--- a/util/point_response_stats.go
+++ b/util/point_response_stats.go
@@ -1,0 +1,144 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"math"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+)
+
+// PointReadScanDetail is the storage work reported by point-read responses.
+type PointReadScanDetail struct {
+	// TotalKeys is the total number of MVCC versions encountered by storage.
+	TotalKeys int64
+	// ProcessedKeys is the number of user keys processed by storage.
+	ProcessedKeys int64
+	// ProcessedKeysSize is the total size of the processed user keys and values.
+	ProcessedKeysSize int64
+}
+
+// PointResponseStats is a value snapshot of Get, BatchGet, and BufferBatchGet
+// response statistics. Its zero value is valid but has no response coverage.
+// Use RecordResponse and Merge to populate both the values and coverage state.
+// The value may be copied; callers must synchronize concurrent reads and writes.
+type PointResponseStats struct {
+	// ScanDetail is the aggregated storage work from ScanDetailV2 records.
+	ScanDetail PointReadScanDetail
+	// PayloadBytes is the logical successful-response payload, not the encoded
+	// protobuf or network response size. Get contributes value bytes.
+	// BatchGet and BufferBatchGet contribute key plus value bytes for successful
+	// pairs. Misses, response errors, and pair errors contribute zero; commit
+	// timestamps, error text, protobuf fields, and transport framing are excluded.
+	PayloadBytes uint64
+
+	seenResponse      bool
+	missingScanDetail bool
+	invalid           bool
+}
+
+// IsValid reports whether the snapshot has not been invalidated. Missing scan
+// detail alone does not invalidate it; use ScanDetailComplete to check coverage.
+func (stats PointResponseStats) IsValid() bool {
+	return !stats.invalid
+}
+
+// ScanDetailComplete reports whether at least one recognized response was
+// observed and every recognized response carried ScanDetailV2. A valid zero
+// response snapshot is not complete evidence that a point-read operation ran.
+// Complete message coverage does not prove that every protobuf scalar field is
+// supported by the backend because those fields do not carry presence.
+func (stats PointResponseStats) ScanDetailComplete() bool {
+	return stats.IsValid() && stats.seenResponse && !stats.missingScanDetail
+}
+
+// PayloadComplete reports whether at least one recognized response was observed
+// and every recognized response had its payload accounted for. This includes
+// zero-byte misses and errors, but does not cover transport failures or
+// unrecognized responses.
+func (stats PointResponseStats) PayloadComplete() bool {
+	return stats.IsValid() && stats.seenResponse
+}
+
+// Invalidate marks the snapshot invalid. Recording or merging further responses
+// cannot make it valid again.
+func (stats *PointResponseStats) Invalidate() {
+	stats.invalid = true
+}
+
+// RecordResponse records one recognized response after transport and region
+// errors have been handled. Empty and key-error responses must also be recorded,
+// and each retry response is recorded separately. A nil scanDetail records
+// missing scan detail. A false payloadValid or any numeric overflow invalidates
+// the snapshot without adding the response's values.
+func (stats *PointResponseStats) RecordResponse(scanDetail *kvrpcpb.ScanDetailV2, payloadBytes uint64, payloadValid bool) {
+	if !payloadValid {
+		stats.Invalidate()
+		return
+	}
+	delta := PointResponseStats{
+		PayloadBytes:      payloadBytes,
+		seenResponse:      true,
+		missingScanDetail: scanDetail == nil,
+	}
+	if scanDetail != nil {
+		if scanDetail.TotalVersions > math.MaxInt64 ||
+			scanDetail.ProcessedVersions > math.MaxInt64 ||
+			scanDetail.ProcessedVersionsSize > math.MaxInt64 {
+			stats.Invalidate()
+			return
+		}
+		delta.ScanDetail = PointReadScanDetail{
+			TotalKeys:         int64(scanDetail.TotalVersions),
+			ProcessedKeys:     int64(scanDetail.ProcessedVersions),
+			ProcessedKeysSize: int64(scanDetail.ProcessedVersionsSize),
+		}
+	}
+	stats.Merge(delta)
+}
+
+// Merge adds another snapshot's values and preserves missing-detail and invalid
+// states. Invalid input or arithmetic overflow invalidates the receiver without
+// changing its accumulated values. Merging a zero-value snapshot is a no-op.
+func (stats *PointResponseStats) Merge(other PointResponseStats) {
+	if !stats.IsValid() || !other.IsValid() {
+		stats.Invalidate()
+		return
+	}
+	totalKeys, totalOK := checkedAddNonNegativeInt64(stats.ScanDetail.TotalKeys, other.ScanDetail.TotalKeys)
+	processedKeys, processedOK := checkedAddNonNegativeInt64(stats.ScanDetail.ProcessedKeys, other.ScanDetail.ProcessedKeys)
+	processedSize, sizeOK := checkedAddNonNegativeInt64(stats.ScanDetail.ProcessedKeysSize, other.ScanDetail.ProcessedKeysSize)
+	if !totalOK || !processedOK || !sizeOK || other.PayloadBytes > math.MaxUint64-stats.PayloadBytes {
+		stats.Invalidate()
+		return
+	}
+	*stats = PointResponseStats{
+		ScanDetail: PointReadScanDetail{
+			TotalKeys:         totalKeys,
+			ProcessedKeys:     processedKeys,
+			ProcessedKeysSize: processedSize,
+		},
+		PayloadBytes:      stats.PayloadBytes + other.PayloadBytes,
+		seenResponse:      stats.seenResponse || other.seenResponse,
+		missingScanDetail: stats.missingScanDetail || other.missingScanDetail,
+	}
+}
+
+func checkedAddNonNegativeInt64(current, delta int64) (int64, bool) {
+	if current < 0 || delta < 0 || delta > math.MaxInt64-current {
+		return 0, false
+	}
+	return current + delta, true
+}

--- a/util/point_response_stats.go
+++ b/util/point_response_stats.go
@@ -14,11 +14,7 @@
 
 package util
 
-import (
-	"math"
-
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-)
+import "github.com/pingcap/kvproto/pkg/kvrpcpb"
 
 // PointReadScanDetail is the storage work reported by point-read responses.
 type PointReadScanDetail struct {
@@ -81,25 +77,14 @@ func (stats *PointResponseStats) Invalidate() {
 // RecordResponse records one recognized response after transport and region
 // errors have been handled. Empty and key-error responses must also be recorded,
 // and each retry response is recorded separately. A nil scanDetail records
-// missing scan detail. A false payloadValid or any numeric overflow invalidates
-// the snapshot without adding the response's values.
-func (stats *PointResponseStats) RecordResponse(scanDetail *kvrpcpb.ScanDetailV2, payloadBytes uint64, payloadValid bool) {
-	if !payloadValid {
-		stats.Invalidate()
-		return
-	}
+// missing scan detail.
+func (stats *PointResponseStats) RecordResponse(scanDetail *kvrpcpb.ScanDetailV2, payloadBytes uint64) {
 	delta := PointResponseStats{
 		PayloadBytes:      payloadBytes,
 		seenResponse:      true,
 		missingScanDetail: scanDetail == nil,
 	}
 	if scanDetail != nil {
-		if scanDetail.TotalVersions > math.MaxInt64 ||
-			scanDetail.ProcessedVersions > math.MaxInt64 ||
-			scanDetail.ProcessedVersionsSize > math.MaxInt64 {
-			stats.Invalidate()
-			return
-		}
 		delta.ScanDetail = PointReadScanDetail{
 			TotalKeys:         int64(scanDetail.TotalVersions),
 			ProcessedKeys:     int64(scanDetail.ProcessedVersions),
@@ -109,36 +94,22 @@ func (stats *PointResponseStats) RecordResponse(scanDetail *kvrpcpb.ScanDetailV2
 	stats.Merge(delta)
 }
 
-// Merge adds another snapshot's values and preserves missing-detail and invalid
-// states. Invalid input or arithmetic overflow invalidates the receiver without
-// changing its accumulated values. Merging a zero-value snapshot is a no-op.
+// Merge adds another snapshot's values and preserves missing-detail state. If
+// either snapshot is invalid, the receiver becomes invalid without changing its
+// accumulated values. Merging a zero-value snapshot is a no-op.
 func (stats *PointResponseStats) Merge(other PointResponseStats) {
 	if !stats.IsValid() || !other.IsValid() {
 		stats.Invalidate()
 		return
 	}
-	totalKeys, totalOK := checkedAddNonNegativeInt64(stats.ScanDetail.TotalKeys, other.ScanDetail.TotalKeys)
-	processedKeys, processedOK := checkedAddNonNegativeInt64(stats.ScanDetail.ProcessedKeys, other.ScanDetail.ProcessedKeys)
-	processedSize, sizeOK := checkedAddNonNegativeInt64(stats.ScanDetail.ProcessedKeysSize, other.ScanDetail.ProcessedKeysSize)
-	if !totalOK || !processedOK || !sizeOK || other.PayloadBytes > math.MaxUint64-stats.PayloadBytes {
-		stats.Invalidate()
-		return
-	}
 	*stats = PointResponseStats{
 		ScanDetail: PointReadScanDetail{
-			TotalKeys:         totalKeys,
-			ProcessedKeys:     processedKeys,
-			ProcessedKeysSize: processedSize,
+			TotalKeys:         stats.ScanDetail.TotalKeys + other.ScanDetail.TotalKeys,
+			ProcessedKeys:     stats.ScanDetail.ProcessedKeys + other.ScanDetail.ProcessedKeys,
+			ProcessedKeysSize: stats.ScanDetail.ProcessedKeysSize + other.ScanDetail.ProcessedKeysSize,
 		},
 		PayloadBytes:      stats.PayloadBytes + other.PayloadBytes,
 		seenResponse:      stats.seenResponse || other.seenResponse,
 		missingScanDetail: stats.missingScanDetail || other.missingScanDetail,
 	}
-}
-
-func checkedAddNonNegativeInt64(current, delta int64) (int64, bool) {
-	if current < 0 || delta < 0 || delta > math.MaxInt64-current {
-		return 0, false
-	}
-	return current + delta, true
 }


### PR DESCRIPTION
Close https://github.com/tikv/client-go/issues/2057
## Problem

`SnapshotRuntimeStats` aggregates point-read scan detail, but callers cannot tell whether every recognized response contributed scan detail, nor inspect the logical payload returned by Get, BatchGet, and BufferBatchGet. In particular, aggregate zero values alone cannot distinguish a real zero from missing response data.

## What changed

- Add `PointReadScanDetail` and `PointResponseStats`, exposed through `txnkv`, and add `SnapshotRuntimeStats.GetPointResponseStats()`.
- Track recognized response bodies, scan-detail records, payload records, and logical successful-response payload bytes independently so callers can check response-level completeness.
- Account for Get, BatchGet, and BufferBatchGet responses after transport and region handling, including retry, empty-response, and key-error semantics; fail closed on conversion or arithmetic overflow.
- Keep clone, merge, and accessor paths concurrency-safe, with unit and integration coverage for retry/error paths, async multi-region BatchGet, and pipelined BufferBatchGet.

## Compatibility

This is an additive public API change. It does not change existing exported signatures, wire protocols, or module dependencies.

## Tests

```text
go test -count=1 -race --tags=intest ./...
go test -count=1 --tags=intest ./txnkv/...
go vet ./txnkv/...
go generate ./...

cd integration_tests
go test -count=1 -race -run 'TestSnapshot/TestSnapshotRuntimeStats(GetAndBatchGetCoverage|ExcludesEpochNotMatch|PointGetLockRetryCoverage|AsyncBatchGetMultipleRegionsCoverage)$|TestPipelinedMemDB/TestBufferBatchGetPointResponseStats$' .

env GOLANGCI_LINT_CACHE=/tmp/client-go-golangci-cache \
  go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 \
  run --new-from-rev=origin/master ./txnkv/...

git diff --check origin/master
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added point-read response statistics for Get, BatchGet, and buffered batch-get operations.
  * Added tracking for scan details, payload sizes, response coverage, and completeness.
  * Extended statistics collection across asynchronous requests, retries, lock handling, and multi-region operations.

* **Bug Fixes**
  * Improved runtime-statistics accuracy when response details are missing or requests are retried.

* **Tests**
  * Added comprehensive coverage for recording, merging, invalidation, payload metrics, and response-statistics reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->