### PR TITLE
apicodec: decode StoreBatchCop response keys

### DIFF
--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -665,6 +665,16 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		if err != nil {
 			return nil, err
 		}
+		for _, batchResp := range r.BatchResponses {
+			batchResp.RegionError, err = c.decodeRegionError(batchResp.RegionError)
+			if err != nil {
+				return nil, err
+			}
+			batchResp.Locked, err = c.decodeLockInfo(batchResp.Locked)
+			if err != nil {
+				return nil, err
+			}
+		}
 		r.Range, err = c.decodeCopRange(r.Range)
 		if err != nil {
 			return nil, err

--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -1014,6 +1014,18 @@ func (c *codecV2) decodeRegionError(regionError *errorpb.Error) (*errorpb.Error,
 		errInfo.CurrentRegions = decodedRegions
 	}
 
+	if errInfo := regionError.BucketVersionNotMatch; errInfo != nil {
+		// The region cache compares bucket boundaries with decoded user keys.
+		// BucketVersionNotMatch.Keys still uses API v2's mem-comparable,
+		// keyspace-prefixed region-key format, so caching it as-is would mix key
+		// representations and produce incorrect cop task boundaries. Decoding also
+		// keeps malformed boundaries out of the cache.
+		errInfo.Keys, err = c.DecodeBucketKeys(errInfo.Keys)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return regionError, nil
 }
 

--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -731,6 +731,10 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		if err != nil {
 			return nil, err
 		}
+		r.Errors, err = c.decodeKeyErrors(r.Errors)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return resp, nil

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -752,10 +752,20 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 				resp := decoded.Resp.(*coprocessor.Response)
 				re.Len(resp.BatchResponses, 1)
 				lock := resp.BatchResponses[0].Locked
-				// StoreBatch child responses are not decoded: their keys stay keyspace-encoded.
-				re.Equal(append(keyspacePrefix, []byte("batch-lock-key")...), lock.Key)
-				re.Equal(append(keyspacePrefix, []byte("batch-primary")...), lock.PrimaryLock)
-				re.Equal([][]byte{append(keyspacePrefix, []byte("batch-secondary")...)}, lock.Secondaries)
+				re.Equal([]byte("batch-lock-key"), lock.Key)
+				re.Equal([]byte("batch-primary"), lock.PrimaryLock)
+				re.Equal([][]byte{[]byte("batch-secondary")}, lock.Secondaries)
+
+				// A decoded lock must round-trip through request encoding, e.g. when
+				// the lock's primary is fed back into a CheckTxnStatus request.
+				checkTxnStatusReq, err := suite.codec.EncodeRequest(&tikvrpc.Request{
+					Type: tikvrpc.CmdCheckTxnStatus,
+					Req: &kvrpcpb.CheckTxnStatusRequest{
+						PrimaryKey: lock.PrimaryLock,
+					},
+				})
+				re.NoError(err)
+				re.Equal(append(keyspacePrefix, []byte("batch-primary")...), checkTxnStatusReq.CheckTxnStatus().PrimaryKey)
 			},
 		},
 		{
@@ -781,11 +791,9 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 				resp := decoded.Resp.(*coprocessor.Response)
 				re.Len(resp.BatchResponses, 1)
 				regionErr := resp.BatchResponses[0].RegionError.KeyNotInRegion
-				// StoreBatch child responses are not decoded: their keys stay keyspace-encoded.
-				encodedStart, encodedEnd := suite.codec.EncodeRegionRange([]byte("batch-range-start"), []byte("batch-range-end"))
-				re.Equal(append(keyspacePrefix, []byte("batch-region-key")...), regionErr.Key)
-				re.Equal(encodedStart, regionErr.StartKey)
-				re.Equal(encodedEnd, regionErr.EndKey)
+				re.Equal([]byte("batch-region-key"), regionErr.Key)
+				re.Equal([]byte("batch-range-start"), regionErr.StartKey)
+				re.Equal([]byte("batch-range-end"), regionErr.EndKey)
 			},
 		},
 		{

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -1008,11 +1008,9 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 				re.Equal([]byte("split-end"), resp.Regions[0].EndKey)
 				re.Len(resp.Errors, 1)
 				lock := resp.Errors[0].Locked
-				// SplitRegion key errors are not decoded: their lock keys stay
-				// keyspace-encoded.
-				re.Equal(append(keyspacePrefix, []byte("split-lock-key")...), lock.Key)
-				re.Equal(append(keyspacePrefix, []byte("split-primary")...), lock.PrimaryLock)
-				re.Equal([][]byte{append(keyspacePrefix, []byte("split-secondary")...)}, lock.Secondaries)
+				re.Equal([]byte("split-lock-key"), lock.Key)
+				re.Equal([]byte("split-primary"), lock.PrimaryLock)
+				re.Equal([][]byte{[]byte("split-secondary")}, lock.Secondaries)
 			},
 		},
 	}

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -730,6 +730,65 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 			},
 		},
 		{
+			name: "CmdCopStoreBatchLock",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCop,
+				Req:  &coprocessor.Request{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &coprocessor.Response{
+					BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+						{
+							Locked: &kvrpcpb.LockInfo{
+								Key:         suite.codec.EncodeKey([]byte("batch-lock-key")),
+								PrimaryLock: suite.codec.EncodeKey([]byte("batch-primary")),
+								Secondaries: [][]byte{suite.codec.EncodeKey([]byte("batch-secondary"))},
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*coprocessor.Response)
+				re.Len(resp.BatchResponses, 1)
+				lock := resp.BatchResponses[0].Locked
+				// StoreBatch child responses are not decoded: their keys stay keyspace-encoded.
+				re.Equal(append(keyspacePrefix, []byte("batch-lock-key")...), lock.Key)
+				re.Equal(append(keyspacePrefix, []byte("batch-primary")...), lock.PrimaryLock)
+				re.Equal([][]byte{append(keyspacePrefix, []byte("batch-secondary")...)}, lock.Secondaries)
+			},
+		},
+		{
+			name: "CmdCopStoreBatchRegionError",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCop,
+				Req:  &coprocessor.Request{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &coprocessor.Response{
+					BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+						{
+							RegionError: makeRegionError(
+								[]byte("batch-region-key"),
+								[]byte("batch-range-start"),
+								[]byte("batch-range-end"),
+							),
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*coprocessor.Response)
+				re.Len(resp.BatchResponses, 1)
+				regionErr := resp.BatchResponses[0].RegionError.KeyNotInRegion
+				// StoreBatch child responses are not decoded: their keys stay keyspace-encoded.
+				encodedStart, encodedEnd := suite.codec.EncodeRegionRange([]byte("batch-range-start"), []byte("batch-range-end"))
+				re.Equal(append(keyspacePrefix, []byte("batch-region-key")...), regionErr.Key)
+				re.Equal(encodedStart, regionErr.StartKey)
+				re.Equal(encodedEnd, regionErr.EndKey)
+			},
+		},
+		{
 			name: "CmdLockWaitInfo",
 			req: &tikvrpc.Request{
 				Type: tikvrpc.CmdLockWaitInfo,

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -974,6 +974,47 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 				re.Equal([]byte("compacted-end"), resp.CompactedEndKey)
 			},
 		},
+		{
+			name: "CmdSplitRegionKeyError",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdSplitRegion,
+				Req:  &kvrpcpb.SplitRegionRequest{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &kvrpcpb.SplitRegionResponse{
+					RegionError: makeRegionError([]byte("region-key"), []byte("range-start"), []byte("range-end")),
+					Regions: []*metapb.Region{
+						{
+							StartKey: suite.codec.EncodeRegionKey([]byte("split-start")),
+							EndKey:   suite.codec.EncodeRegionKey([]byte("split-end")),
+						},
+					},
+					Errors: []*kvrpcpb.KeyError{
+						{
+							Locked: &kvrpcpb.LockInfo{
+								Key:         suite.codec.EncodeKey([]byte("split-lock-key")),
+								PrimaryLock: suite.codec.EncodeKey([]byte("split-primary")),
+								Secondaries: [][]byte{suite.codec.EncodeKey([]byte("split-secondary"))},
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*kvrpcpb.SplitRegionResponse)
+				re.Equal([]byte("region-key"), resp.RegionError.KeyNotInRegion.Key)
+				re.Len(resp.Regions, 1)
+				re.Equal([]byte("split-start"), resp.Regions[0].StartKey)
+				re.Equal([]byte("split-end"), resp.Regions[0].EndKey)
+				re.Len(resp.Errors, 1)
+				lock := resp.Errors[0].Locked
+				// SplitRegion key errors are not decoded: their lock keys stay
+				// keyspace-encoded.
+				re.Equal(append(keyspacePrefix, []byte("split-lock-key")...), lock.Key)
+				re.Equal(append(keyspacePrefix, []byte("split-primary")...), lock.PrimaryLock)
+				re.Equal([][]byte{append(keyspacePrefix, []byte("split-secondary")...)}, lock.Secondaries)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -824,12 +824,7 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 				re.Len(resp.BatchResponses, 1)
 				bucketErr := resp.BatchResponses[0].RegionError.BucketVersionNotMatch
 				re.Equal(uint64(2), bucketErr.Version)
-				// decodeRegionError does not handle BucketVersionNotMatch: its bucket
-				// keys stay keyspace-encoded.
-				re.Equal([][]byte{
-					suite.codec.EncodeRegionKey([]byte("bucket-a")),
-					suite.codec.EncodeRegionKey([]byte("bucket-b")),
-				}, bucketErr.Keys)
+				re.Equal([][]byte{[]byte("bucket-a"), []byte("bucket-b")}, bucketErr.Keys)
 			},
 		},
 		{
@@ -1016,14 +1011,9 @@ func (suite *testCodecV2Suite) TestDecodeResponseMalformedBucketKeys() {
 	}
 
 	decoded, err := suite.codec.DecodeResponse(req, resp)
-	re.NoError(err)
-	bucketErr := decoded.Resp.(*coprocessor.Response).BatchResponses[0].RegionError.BucketVersionNotMatch
-	// decodeRegionError does not handle BucketVersionNotMatch, so malformed
-	// bucket keys pass through without validation.
-	re.Equal([][]byte{
-		suite.codec.EncodeRegionKey([]byte("bucket-a")),
-		{0x01},
-	}, bucketErr.Keys)
+	re.Error(err)
+	re.True(IsDecodeError(err))
+	re.Nil(decoded)
 }
 
 func (suite *testCodecV2Suite) TestDecodeMvccInfoPreservesEmptyLockKeys() {

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -797,6 +797,42 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 			},
 		},
 		{
+			name: "CmdCopStoreBatchBucketVersionNotMatch",
+			req: &tikvrpc.Request{
+				Type: tikvrpc.CmdCop,
+				Req:  &coprocessor.Request{},
+			},
+			resp: &tikvrpc.Response{
+				Resp: &coprocessor.Response{
+					BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+						{
+							RegionError: &errorpb.Error{
+								BucketVersionNotMatch: &errorpb.BucketVersionNotMatch{
+									Version: 2,
+									Keys: [][]byte{
+										suite.codec.EncodeRegionKey([]byte("bucket-a")),
+										suite.codec.EncodeRegionKey([]byte("bucket-b")),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(re *require.Assertions, decoded *tikvrpc.Response) {
+				resp := decoded.Resp.(*coprocessor.Response)
+				re.Len(resp.BatchResponses, 1)
+				bucketErr := resp.BatchResponses[0].RegionError.BucketVersionNotMatch
+				re.Equal(uint64(2), bucketErr.Version)
+				// decodeRegionError does not handle BucketVersionNotMatch: its bucket
+				// keys stay keyspace-encoded.
+				re.Equal([][]byte{
+					suite.codec.EncodeRegionKey([]byte("bucket-a")),
+					suite.codec.EncodeRegionKey([]byte("bucket-b")),
+				}, bucketErr.Keys)
+			},
+		},
+		{
 			name: "CmdLockWaitInfo",
 			req: &tikvrpc.Request{
 				Type: tikvrpc.CmdLockWaitInfo,
@@ -954,6 +990,40 @@ func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {
 			test.validate(re, decoded)
 		})
 	}
+}
+
+func (suite *testCodecV2Suite) TestDecodeResponseMalformedBucketKeys() {
+	re := suite.Require()
+	req := &tikvrpc.Request{
+		Type: tikvrpc.CmdCop,
+		Req:  &coprocessor.Request{},
+	}
+	resp := &tikvrpc.Response{
+		Resp: &coprocessor.Response{
+			BatchResponses: []*coprocessor.StoreBatchTaskResponse{
+				{
+					RegionError: &errorpb.Error{
+						BucketVersionNotMatch: &errorpb.BucketVersionNotMatch{
+							Keys: [][]byte{
+								suite.codec.EncodeRegionKey([]byte("bucket-a")),
+								{0x01}, // Invalid mem-comparable encoding.
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	decoded, err := suite.codec.DecodeResponse(req, resp)
+	re.NoError(err)
+	bucketErr := decoded.Resp.(*coprocessor.Response).BatchResponses[0].RegionError.BucketVersionNotMatch
+	// decodeRegionError does not handle BucketVersionNotMatch, so malformed
+	// bucket keys pass through without validation.
+	re.Equal([][]byte{
+		suite.codec.EncodeRegionKey([]byte("bucket-a")),
+		{0x01},
+	}, bucketErr.Keys)
 }
 
 func (suite *testCodecV2Suite) TestDecodeMvccInfoPreservesEmptyLockKeys() {

--- a/internal/apicodec/mem_codec.go
+++ b/internal/apicodec/mem_codec.go
@@ -12,9 +12,9 @@ type memCodec interface {
 	decodeKey(encodedKey []byte) ([]byte, error)
 }
 
-// decodeError happens if the region range key is not well-formed.
-// It indicates TiKV has bugs and the client can't handle such a case,
-// so it should report the error to users soon.
+// decodeError marks malformed mem-comparable region metadata returned by TiKV
+// or PD. Such metadata cannot be safely compared with decoded user keys or
+// installed in the region cache.
 type decodeError struct {
 	error
 }

--- a/internal/locate/region_request.go
+++ b/internal/locate/region_request.go
@@ -2147,7 +2147,9 @@ func (s *RegionRequestSender) onRegionError(
 			zap.Uint64("request bucket version", ctx.BucketVersion),
 			zap.Stringer("ctx", ctx),
 		)
-		// bucket version is not match, we should split this cop request again.
+		// OnBucketVersionNotMatch stores boundaries that are later compared with
+		// decoded request keys. The API v2 response codec therefore strips their
+		// wire encoding and rejects malformed boundaries before this handler.
 		s.regionCache.OnBucketVersionNotMatch(ctx, bucketVersionNotMatch.Version, bucketVersionNotMatch.Keys)
 		return false, nil
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/70665

Some API v2 response fields remained encoded after `DecodeResponse`. Reusing those keys can add the keyspace prefix twice during lock resolution, while caching them can mix encoded bucket boundaries with decoded user keys.

### What is changed and how does it work?

Decode API v2 keys in:

- `StoreBatchCop` child region errors and lock information
- `BucketVersionNotMatch.Keys`
- `SplitRegionResponse.Errors`

`BucketVersionNotMatch.Keys` is decoded before bucket metadata reaches the region cache. If a key has malformed mem-comparable encoding, `DecodeResponse` returns a decode error instead of exposing it to normal `BucketVersionNotMatch` handling.

API v1 is unchanged.

### Tests

- `go test ./internal/apicodec -count=1`
- `go test ./internal/locate -count=1`
