### PR TITLE
internal/client, tikvrpc: reuse buffers for metadata scans

### DIFF
--- a/internal/apicodec/codec_v2.go
+++ b/internal/apicodec/codec_v2.go
@@ -360,7 +360,11 @@ func (c *codecV2) DecodeResponse(req *tikvrpc.Request, resp *tikvrpc.Response) (
 		if err != nil {
 			return nil, err
 		}
-		r.Pairs, err = c.decodePairs(r.Pairs)
+		if req.ReusableScanResponse != nil && r == req.ReusableScanResponse.Response() {
+			err = c.decodeReusableScanPairs(r.Pairs)
+		} else {
+			r.Pairs, err = c.decodePairs(r.Pairs)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -926,6 +930,28 @@ func (c *codecV2) decodePairs(encodedPairs []*kvrpcpb.KvPair) ([]*kvrpcpb.KvPair
 		pairs = append(pairs, &p)
 	}
 	return pairs, nil
+}
+
+func (c *codecV2) decodeReusableScanPairs(pairs []*kvrpcpb.KvPair) error {
+	for _, pair := range pairs {
+		var err error
+		if pair.Error != nil {
+			pair.Error, err = c.decodeKeyError(pair.Error)
+			if err != nil {
+				return err
+			}
+		}
+		if len(pair.Key) == 0 {
+			continue
+		}
+		decodedKey, err := c.DecodeKey(pair.Key)
+		if err != nil {
+			return err
+		}
+		decodedLength := copy(pair.Key, decodedKey)
+		pair.Key = pair.Key[:decodedLength]
+	}
+	return nil
 }
 
 func (c *codecV2) encodeMutations(mutations []*kvrpcpb.Mutation) []*kvrpcpb.Mutation {

--- a/internal/apicodec/codec_v2_test.go
+++ b/internal/apicodec/codec_v2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"github.com/tikv/client-go/v2/util/codec"
+	"google.golang.org/grpc/mem"
 )
 
 var (
@@ -654,6 +655,60 @@ func (suite *testCodecV2Suite) TestDecodeResponseHotPathCommands() {
 			test.validate(re, decoded)
 		})
 	}
+}
+
+func (suite *testCodecV2Suite) TestDecodeReusableScanResponseInPlace() {
+	re := suite.Require()
+	pairs := make([]*kvrpcpb.KvPair, 64)
+	for i := range pairs {
+		pairs[i] = &kvrpcpb.KvPair{
+			Key:   suite.codec.EncodeKey([]byte{byte(i), byte(i >> 8)}),
+			Value: []byte("value"),
+		}
+	}
+	encoded, err := (&kvrpcpb.ScanResponse{Pairs: pairs}).Marshal()
+	re.NoError(err)
+	input := mem.BufferSlice{mem.SliceBuffer(encoded)}
+	reusable := tikvrpc.NewReusableScanResponse(16 << 20)
+
+	re.NoError(reusable.UnmarshalBufferSlice(input))
+	rawPair := reusable.Response().Pairs[0]
+	rawKeyData := &rawPair.Key[0]
+	req := &tikvrpc.Request{Type: tikvrpc.CmdScan, ReusableScanResponse: reusable}
+	decoded, err := suite.codec.DecodeResponse(req, &tikvrpc.Response{Resp: reusable.Response()})
+	re.NoError(err)
+	decodedPair := decoded.Resp.(*kvrpcpb.ScanResponse).Pairs[0]
+	re.Same(rawPair, decodedPair)
+	re.Same(rawKeyData, &decodedPair.Key[0])
+	re.Equal([]byte{0, 0}, decodedPair.Key)
+
+	foreignEncodedKey := suite.codec.EncodeKey([]byte("foreign"))
+	foreignPair := &kvrpcpb.KvPair{Key: foreignEncodedKey}
+	foreignResponse := &kvrpcpb.ScanResponse{Pairs: []*kvrpcpb.KvPair{foreignPair}}
+	fallbackReq := &tikvrpc.Request{Type: tikvrpc.CmdScan, ReusableScanResponse: reusable}
+	decoded, err = suite.codec.DecodeResponse(fallbackReq, &tikvrpc.Response{Resp: foreignResponse})
+	re.NoError(err)
+	fallbackPair := decoded.Resp.(*kvrpcpb.ScanResponse).Pairs[0]
+	re.NotSame(foreignPair, fallbackPair)
+	re.Equal(foreignEncodedKey, foreignPair.Key)
+	re.Equal([]byte("foreign"), fallbackPair.Key)
+
+	decode := func() {
+		if err := reusable.UnmarshalBufferSlice(input); err != nil {
+			panic(err)
+		}
+		pooledReq := suite.codec.reqPool.Get().(*tikvrpc.Request)
+		*pooledReq = tikvrpc.Request{Type: tikvrpc.CmdScan, ReusableScanResponse: reusable}
+		response, err := suite.codec.DecodeResponse(pooledReq, &tikvrpc.Response{Resp: reusable.Response()})
+		if err != nil {
+			panic(err)
+		}
+		if response.Resp.(*kvrpcpb.ScanResponse).Pairs[0] != reusable.Response().Pairs[0] {
+			panic("API v2 cloned a reusable scan pair")
+		}
+	}
+	decode()
+	re.Zero(testing.AllocsPerRun(20, decode))
 }
 
 func (suite *testCodecV2Suite) TestDecodeResponseSecondWaveCommands() {

--- a/internal/client/bounded_buffer_pool.go
+++ b/internal/client/bounded_buffer_pool.go
@@ -82,9 +82,7 @@ func (p *boundedBufferPool) Get(length int) *[]byte {
 	p.retainedBytes -= bucket.capacity
 	p.mu.Unlock()
 
-	backing := (*buffer)[:cap(*buffer)]
-	clear(backing)
-	*buffer = backing[:length]
+	*buffer = (*buffer)[:length]
 	return buffer
 }
 

--- a/internal/client/bounded_buffer_pool.go
+++ b/internal/client/bounded_buffer_pool.go
@@ -1,0 +1,137 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "sync"
+
+const reusableScanBufferPoolMaxRetainedBytes = 16 << 20
+
+var reusableScanBufferPoolCapacities = [...]int{
+	256,
+	4 << 10,
+	16 << 10,
+	32 << 10,
+	1 << 20,
+}
+
+type boundedBufferBucket struct {
+	capacity int
+	buffers  []*[]byte
+}
+
+// boundedBufferPool implements gRPC's buffer pool contract while keeping an
+// explicit upper bound on retained backing arrays. It is shared by the
+// reusable-scan connections owned by one RPCClient.
+type boundedBufferPool struct {
+	mu               sync.Mutex
+	maxRetainedBytes int
+	retainedBytes    int
+	buckets          []boundedBufferBucket
+}
+
+func newBoundedBufferPool(maxRetainedBytes int, capacities ...int) *boundedBufferPool {
+	if maxRetainedBytes < 0 {
+		maxRetainedBytes = 0
+	}
+	pool := &boundedBufferPool{
+		maxRetainedBytes: maxRetainedBytes,
+		buckets:          make([]boundedBufferBucket, 0, len(capacities)),
+	}
+	previous := 0
+	for _, capacity := range capacities {
+		if capacity <= previous {
+			panic("bounded buffer pool capacities must be positive and strictly increasing")
+		}
+		pool.buckets = append(pool.buckets, boundedBufferBucket{capacity: capacity})
+		previous = capacity
+	}
+	return pool
+}
+
+func (p *boundedBufferPool) Get(length int) *[]byte {
+	bucketIndex := p.bucketIndexForLength(length)
+	if bucketIndex < 0 {
+		buffer := make([]byte, length)
+		return &buffer
+	}
+
+	p.mu.Lock()
+	bucket := &p.buckets[bucketIndex]
+	bufferCount := len(bucket.buffers)
+	if bufferCount == 0 {
+		capacity := bucket.capacity
+		p.mu.Unlock()
+		buffer := make([]byte, length, capacity)
+		return &buffer
+	}
+	buffer := bucket.buffers[bufferCount-1]
+	bucket.buffers[bufferCount-1] = nil
+	bucket.buffers = bucket.buffers[:bufferCount-1]
+	p.retainedBytes -= bucket.capacity
+	p.mu.Unlock()
+
+	backing := (*buffer)[:cap(*buffer)]
+	clear(backing)
+	*buffer = backing[:length]
+	return buffer
+}
+
+func (p *boundedBufferPool) Put(buffer *[]byte) {
+	if buffer == nil {
+		return
+	}
+	bucketIndex := p.bucketIndexForCapacity(cap(*buffer))
+	if bucketIndex < 0 {
+		return
+	}
+
+	p.mu.Lock()
+	bucket := &p.buckets[bucketIndex]
+	if p.retainedBytes+bucket.capacity > p.maxRetainedBytes {
+		p.mu.Unlock()
+		return
+	}
+	*buffer = (*buffer)[:bucket.capacity]
+	bucket.buffers = append(bucket.buffers, buffer)
+	p.retainedBytes += bucket.capacity
+	p.mu.Unlock()
+}
+
+func (p *boundedBufferPool) bucketIndexForLength(length int) int {
+	if length <= 0 {
+		return -1
+	}
+	for i := range p.buckets {
+		if length <= p.buckets[i].capacity {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *boundedBufferPool) bucketIndexForCapacity(capacity int) int {
+	for i := range p.buckets {
+		if capacity == p.buckets[i].capacity {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *boundedBufferPool) retainedMemory() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.retainedBytes
+}

--- a/internal/client/bounded_buffer_pool_test.go
+++ b/internal/client/bounded_buffer_pool_test.go
@@ -21,25 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBoundedBufferPoolReusesAndClears(t *testing.T) {
+func TestBoundedBufferPoolReusesCapacity(t *testing.T) {
 	pool := newBoundedBufferPool(1<<20, 256, 4<<10, 16<<10)
 	first := pool.Get(8 << 10)
 	require.Len(t, *first, 8<<10)
 	require.Equal(t, 16<<10, cap(*first))
-	backing := (*first)[:cap(*first)]
-	for i := range backing {
-		backing[i] = 0xff
-	}
-	firstByte := &backing[0]
+	firstByte := &(*first)[0]
 
 	pool.Put(first)
 	require.Equal(t, 16<<10, pool.retainedMemory())
 	second := pool.Get(12 << 10)
 	require.Same(t, firstByte, &(*second)[0])
 	require.Equal(t, 16<<10, cap(*second))
-	for _, value := range (*second)[:cap(*second)] {
-		require.Zero(t, value)
-	}
 	require.Zero(t, pool.retainedMemory())
 }
 

--- a/internal/client/bounded_buffer_pool_test.go
+++ b/internal/client/bounded_buffer_pool_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedBufferPoolReusesAndClears(t *testing.T) {
+	pool := newBoundedBufferPool(1<<20, 256, 4<<10, 16<<10)
+	first := pool.Get(8 << 10)
+	require.Len(t, *first, 8<<10)
+	require.Equal(t, 16<<10, cap(*first))
+	backing := (*first)[:cap(*first)]
+	for i := range backing {
+		backing[i] = 0xff
+	}
+	firstByte := &backing[0]
+
+	pool.Put(first)
+	require.Equal(t, 16<<10, pool.retainedMemory())
+	second := pool.Get(12 << 10)
+	require.Same(t, firstByte, &(*second)[0])
+	require.Equal(t, 16<<10, cap(*second))
+	for _, value := range (*second)[:cap(*second)] {
+		require.Zero(t, value)
+	}
+	require.Zero(t, pool.retainedMemory())
+}
+
+func TestBoundedBufferPoolCapsRetentionAndDropsOversizedBuffers(t *testing.T) {
+	pool := newBoundedBufferPool(16<<10, 4<<10, 16<<10)
+	first := pool.Get(16 << 10)
+	second := pool.Get(16 << 10)
+	pool.Put(first)
+	pool.Put(second)
+	require.Equal(t, 16<<10, pool.retainedMemory())
+
+	oversized := pool.Get(32 << 10)
+	require.Equal(t, 32<<10, cap(*oversized))
+	pool.Put(oversized)
+	require.Equal(t, 16<<10, pool.retainedMemory())
+}
+
+func TestBoundedBufferPoolUsesSmallestFittingClass(t *testing.T) {
+	pool := newBoundedBufferPool(1<<20, 256, 4<<10, 16<<10)
+	for _, testCase := range []struct {
+		length       int
+		wantCapacity int
+	}{
+		{length: 1, wantCapacity: 256},
+		{length: 256, wantCapacity: 256},
+		{length: 257, wantCapacity: 4 << 10},
+		{length: 4 << 10, wantCapacity: 4 << 10},
+		{length: (4 << 10) + 1, wantCapacity: 16 << 10},
+		{length: (16 << 10) + 1, wantCapacity: (16 << 10) + 1},
+	} {
+		buffer := pool.Get(testCase.length)
+		require.Equal(t, testCase.wantCapacity, cap(*buffer))
+	}
+}
+
+func TestBoundedBufferPoolConcurrentRetentionIsBounded(t *testing.T) {
+	const maxRetainedBytes = 64 << 10
+	pool := newBoundedBufferPool(maxRetainedBytes, 4<<10, 16<<10)
+	var waitGroup sync.WaitGroup
+	for range 32 {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			for range 100 {
+				buffer := pool.Get(8 << 10)
+				(*buffer)[0] = 1
+				pool.Put(buffer)
+			}
+		}()
+	}
+	waitGroup.Wait()
+	require.LessOrEqual(t, pool.retainedMemory(), maxRetainedBytes)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -189,9 +189,11 @@ func WithCodec(codec apicodec.Codec) Opt {
 type RPCClient struct {
 	sync.RWMutex
 
-	connPools map[string]*connPool
-	vers      map[string]uint64
-	option    *option
+	connPools              map[string]*connPool
+	reusableScanConnPools  map[string]*connPool
+	reusableScanBufferPool *boundedBufferPool
+	vers                   map[string]uint64
+	option                 *option
 
 	idleNotify uint32
 
@@ -209,8 +211,13 @@ var _ Client = &RPCClient{}
 // NewRPCClient creates a client that manages connections and rpc calls with tikv-servers.
 func NewRPCClient(opts ...Opt) *RPCClient {
 	cli := &RPCClient{
-		connPools: make(map[string]*connPool),
-		vers:      make(map[string]uint64),
+		connPools:             make(map[string]*connPool),
+		reusableScanConnPools: make(map[string]*connPool),
+		reusableScanBufferPool: newBoundedBufferPool(
+			reusableScanBufferPoolMaxRetainedBytes,
+			reusableScanBufferPoolCapacities[:]...,
+		),
+		vers: make(map[string]uint64),
 		option: &option{
 			dialTimeout: dialTimeout,
 		},
@@ -270,6 +277,7 @@ func (c *RPCClient) createConnPool(addr string, enableBatch bool, opts ...func(c
 			c.option.dialTimeout,
 			c.connMonitor,
 			c.eventListener,
+			nil,
 			c.option.gRPCDialOptions)
 
 		if err != nil {
@@ -281,12 +289,72 @@ func (c *RPCClient) createConnPool(addr string, enableBatch bool, opts ...func(c
 	return pool, nil
 }
 
+func (c *RPCClient) getReusableScanConnPool(addr string) (*connPool, error) {
+	c.RLock()
+	if c.isClosed {
+		c.RUnlock()
+		return nil, errors.Errorf("rpcClient is closed")
+	}
+	pool, ok := c.reusableScanConnPools[addr]
+	c.RUnlock()
+	if ok {
+		return pool, nil
+	}
+	return c.createReusableScanConnPool(addr)
+}
+
+func (c *RPCClient) createReusableScanConnPool(addr string) (*connPool, error) {
+	c.Lock()
+	defer c.Unlock()
+	pool, ok := c.reusableScanConnPools[addr]
+	if ok {
+		return pool, nil
+	}
+	if c.isClosed {
+		return nil, errors.Errorf("rpcClient is closed")
+	}
+
+	ver := c.vers[addr] + 1
+	pool, err := newConnPool(
+		1,
+		addr,
+		ver,
+		c.option.security,
+		&c.idleNotify,
+		false,
+		c.option.dialTimeout,
+		c.connMonitor,
+		c.eventListener,
+		c.reusableScanBufferPool,
+		c.option.gRPCDialOptions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c.reusableScanConnPools[addr] = pool
+	c.vers[addr] = ver
+	return pool, nil
+}
+
+func (c *RPCClient) getConnPoolForRequest(addr string, req *tikvrpc.Request) (*connPool, bool, error) {
+	if req.ReusableScanResponse != nil {
+		pool, err := c.getReusableScanConnPool(addr)
+		return pool, false, err
+	}
+	poolSupportsBatch := req.StoreTp == tikvrpc.TiKV
+	pool, err := c.getConnPool(addr, poolSupportsBatch)
+	return pool, poolSupportsBatch, err
+}
+
 func (c *RPCClient) closeConns() {
 	c.Lock()
 	if !c.isClosed {
 		c.isClosed = true
 		// close all connections
 		for _, pool := range c.connPools {
+			pool.Close()
+		}
+		for _, pool := range c.reusableScanConnPools {
 			pool.Close()
 		}
 	}
@@ -330,8 +398,7 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	// TiDB will not send batch commands to TiFlash, to resolve the conflict with Batch Cop Request.
 	// tiflash/tiflash_mpp/tidb don't use BatchCommand.
-	enableBatch := req.StoreTp == tikvrpc.TiKV
-	connPool, err := c.getConnPool(addr, enableBatch)
+	connPool, enableBatch, err := c.getConnPoolForRequest(addr, req)
 	if err != nil {
 		return nil, err
 	}
@@ -403,6 +470,9 @@ func (c *RPCClient) sendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	// Or else it's a unary call.
 	ctx1, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
+	if req.ReusableScanResponse != nil {
+		return wrapErrConn(tikvrpc.CallReusableScanRPC(ctx1, clientConn, req))
+	}
 	return wrapErrConn(tikvrpc.CallRPC(ctx1, client, req))
 }
 
@@ -564,19 +634,28 @@ func (c *RPCClient) CloseAddrVer(addr string, ver uint64) error {
 		c.Unlock()
 		return nil
 	}
-	pool, ok := c.connPools[addr]
-	if ok {
+	var poolsToClose []*connPool
+	if pool, ok := c.connPools[addr]; ok {
 		if pool.ver <= ver {
 			delete(c.connPools, addr)
-			logutil.BgLogger().Debug("close connection", zap.String("target", addr), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
+			logutil.BgLogger().Debug("close connection", zap.String("target", addr), zap.String("connection-kind", "default"), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
+			poolsToClose = append(poolsToClose, pool)
 		} else {
-			logutil.BgLogger().Debug("ignore close connection", zap.String("target", addr), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
-			pool = nil
+			logutil.BgLogger().Debug("ignore close connection", zap.String("target", addr), zap.String("connection-kind", "default"), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
+		}
+	}
+	if pool, ok := c.reusableScanConnPools[addr]; ok {
+		if pool.ver <= ver {
+			delete(c.reusableScanConnPools, addr)
+			logutil.BgLogger().Debug("close connection", zap.String("target", addr), zap.String("connection-kind", "reusable-scan"), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
+			poolsToClose = append(poolsToClose, pool)
+		} else {
+			logutil.BgLogger().Debug("ignore close connection", zap.String("target", addr), zap.String("connection-kind", "reusable-scan"), zap.Uint64("ver", ver), zap.Uint64("pool.ver", pool.ver))
 		}
 	}
 	c.Unlock()
 
-	if pool != nil {
+	for _, pool := range poolsToClose {
 		pool.Close()
 	}
 	return nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -220,8 +220,6 @@ func TestReusableScanUsesIsolatedConnPool(t *testing.T) {
 	require.Len(t, scanPool.conns, 1)
 	require.Same(t, defaultPool, client.connPools[addr])
 	require.Same(t, scanPool, client.reusableScanConnPools[addr])
-	require.Nil(t, defaultPool.bufferPool)
-	require.Same(t, client.reusableScanBufferPool, scanPool.bufferPool)
 }
 
 func TestCloseAddrVerHandlesReusableScanConnPool(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -195,6 +195,61 @@ func TestConn(t *testing.T) {
 	assert.Nil(t, conn4)
 }
 
+func TestReusableScanUsesIsolatedConnPool(t *testing.T) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.MaxBatchSize = 0
+		conf.TiKVClient.GrpcConnectionCount = 2
+	})()
+
+	client := NewRPCClient()
+	defer client.Close()
+	addr := "127.0.0.1:6379"
+
+	defaultReq := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{})
+	defaultPool, enableBatch, err := client.getConnPoolForRequest(addr, defaultReq)
+	require.NoError(t, err)
+	require.True(t, enableBatch)
+	require.Len(t, defaultPool.conns, 2)
+
+	scanReq := tikvrpc.NewRequest(tikvrpc.CmdScan, &kvrpcpb.ScanRequest{})
+	scanReq.ReusableScanResponse = tikvrpc.NewReusableScanResponse(16 << 20)
+	scanPool, enableBatch, err := client.getConnPoolForRequest(addr, scanReq)
+	require.NoError(t, err)
+	require.False(t, enableBatch)
+	require.NotSame(t, defaultPool, scanPool)
+	require.Len(t, scanPool.conns, 1)
+	require.Same(t, defaultPool, client.connPools[addr])
+	require.Same(t, scanPool, client.reusableScanConnPools[addr])
+	require.Nil(t, defaultPool.bufferPool)
+	require.Same(t, client.reusableScanBufferPool, scanPool.bufferPool)
+}
+
+func TestCloseAddrVerHandlesReusableScanConnPool(t *testing.T) {
+	defer config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.MaxBatchSize = 0
+		conf.TiKVClient.GrpcConnectionCount = 2
+	})()
+
+	client := NewRPCClient()
+	defer client.Close()
+	addr := "127.0.0.1:6379"
+
+	defaultReq := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{})
+	defaultPool, _, err := client.getConnPoolForRequest(addr, defaultReq)
+	require.NoError(t, err)
+	scanReq := tikvrpc.NewRequest(tikvrpc.CmdScan, &kvrpcpb.ScanRequest{})
+	scanReq.ReusableScanResponse = tikvrpc.NewReusableScanResponse(16 << 20)
+	scanPool, _, err := client.getConnPoolForRequest(addr, scanReq)
+	require.NoError(t, err)
+	require.Less(t, defaultPool.ver, scanPool.ver)
+
+	require.NoError(t, client.CloseAddrVer(addr, defaultPool.ver))
+	require.NotContains(t, client.connPools, addr)
+	require.Same(t, scanPool, client.reusableScanConnPools[addr])
+	require.NoError(t, client.CloseAddrVer(addr, scanPool.ver))
+	require.NotContains(t, client.reusableScanConnPools, addr)
+}
+
 func TestGetConnAfterClose(t *testing.T) {
 	client := NewRPCClient()
 	defer client.Close()
@@ -202,10 +257,14 @@ func TestGetConnAfterClose(t *testing.T) {
 	addr := "127.0.0.1:6379"
 	connPool, err := client.getConnPool(addr, true)
 	assert.Nil(t, err)
+	scanReq := tikvrpc.NewRequest(tikvrpc.CmdScan, &kvrpcpb.ScanRequest{})
+	scanReq.ReusableScanResponse = tikvrpc.NewReusableScanResponse(16 << 20)
+	scanPool, _, err := client.getConnPoolForRequest(addr, scanReq)
+	assert.Nil(t, err)
 	assert.Nil(t, client.CloseAddr(addr))
 	conn := connPool.Get()
-	state := conn.GetState()
-	assert.True(t, state == connectivity.Shutdown)
+	assert.Equal(t, connectivity.Shutdown, conn.GetState())
+	assert.Equal(t, connectivity.Shutdown, scanPool.Get().GetState())
 }
 
 func TestCancelTimeoutRetErr(t *testing.T) {

--- a/internal/client/conn_pool.go
+++ b/internal/client/conn_pool.go
@@ -53,12 +53,15 @@ type connPool struct {
 	done chan struct{}
 
 	monitor *connMonitor
+	// bufferPool is non-nil only for connection pools with an explicitly
+	// isolated gRPC transport buffer pool.
+	bufferPool mem.BufferPool
 
 	metrics atomic.Pointer[storeMetrics]
 }
 
 func newConnPool(maxSize uint, addr string, ver uint64, security config.Security,
-	idleNotify *uint32, enableBatch bool, dialTimeout time.Duration, m *connMonitor, eventListener *atomic.Pointer[ClientEventListener], opts []grpc.DialOption) (*connPool, error) {
+	idleNotify *uint32, enableBatch bool, dialTimeout time.Duration, m *connMonitor, eventListener *atomic.Pointer[ClientEventListener], bufferPool mem.BufferPool, opts []grpc.DialOption) (*connPool, error) {
 	a := &connPool{
 		ver:           ver,
 		index:         0,
@@ -67,8 +70,9 @@ func newConnPool(maxSize uint, addr string, ver uint64, security config.Security
 		done:          make(chan struct{}),
 		dialTimeout:   dialTimeout,
 		monitor:       m,
+		bufferPool:    bufferPool,
 	}
-	if err := a.Init(addr, security, idleNotify, enableBatch, eventListener, opts...); err != nil {
+	if err := a.Init(addr, security, idleNotify, enableBatch, eventListener, bufferPool, opts...); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -87,7 +91,7 @@ func (a *connPool) monitoredDial(ctx context.Context, connName, target string, o
 	return conn, nil
 }
 
-func (a *connPool) Init(addr string, security config.Security, idleNotify *uint32, enableBatch bool, eventListener *atomic.Pointer[ClientEventListener], opts ...grpc.DialOption) error {
+func (a *connPool) Init(addr string, security config.Security, idleNotify *uint32, enableBatch bool, eventListener *atomic.Pointer[ClientEventListener], bufferPool mem.BufferPool, opts ...grpc.DialOption) error {
 	a.target = addr
 
 	opt := grpc.WithTransportCredentials(insecure.NewCredentials())
@@ -147,7 +151,9 @@ func (a *connPool) Init(addr string, security config.Security, idleNotify *uint3
 				Timeout: cfg.TiKVClient.GetGrpcKeepAliveTimeout(),
 			}),
 		}, opts...)
-		if !cfg.TiKVClient.GrpcSharedBufferPool {
+		if bufferPool != nil {
+			opts = append(opts, experimental.WithBufferPool(bufferPool))
+		} else if !cfg.TiKVClient.GrpcSharedBufferPool {
 			opts = append(opts, experimental.WithBufferPool(mem.NopBufferPool{}))
 		}
 		conn, err := a.monitoredDial(

--- a/internal/client/conn_pool.go
+++ b/internal/client/conn_pool.go
@@ -53,9 +53,6 @@ type connPool struct {
 	done chan struct{}
 
 	monitor *connMonitor
-	// bufferPool is non-nil only for connection pools with an explicitly
-	// isolated gRPC transport buffer pool.
-	bufferPool mem.BufferPool
 
 	metrics atomic.Pointer[storeMetrics]
 }
@@ -70,7 +67,6 @@ func newConnPool(maxSize uint, addr string, ver uint64, security config.Security
 		done:          make(chan struct{}),
 		dialTimeout:   dialTimeout,
 		monitor:       m,
-		bufferPool:    bufferPool,
 	}
 	if err := a.Init(addr, security, idleNotify, enableBatch, eventListener, bufferPool, opts...); err != nil {
 		return nil, err

--- a/tikvrpc/reusable_scan_response.go
+++ b/tikvrpc/reusable_scan_response.go
@@ -31,27 +31,6 @@ import (
 
 const scanResponsePairSize = int64(unsafe.Sizeof(kvrpcpb.KvPair{}))
 
-// ReusableScanStats contains per-scanner data-flow and allocation-request
-// counters. Allocation counters report the sizes requested by this reusable
-// decoder; they do not include Go allocator size-class rounding.
-type ReusableScanStats struct {
-	ScannerNextCalls           uint64
-	ResponseCount              uint64
-	ResponseBytes              uint64
-	DecodeBufferAllocatedBytes uint64
-	PairSliceAllocatedBytes    uint64
-	PairObjectAllocatedBytes   uint64
-	PairKeyValueAllocatedBytes uint64
-	PairCount                  uint64
-	KeyBytes                   uint64
-	ValueBytes                 uint64
-}
-
-// ReusableScanStatsObserver receives query-owned scan counter deltas.
-type ReusableScanStatsObserver interface {
-	ObserveReusableScanStats(ReusableScanStats)
-}
-
 // ReusableScanResponse owns the buffers used to decode sequential scan RPC
 // responses. The result returned by Response remains valid only until the next
 // call to UnmarshalBufferSlice.
@@ -61,29 +40,16 @@ type ReusableScanResponse struct {
 	pairs            []*kvrpcpb.KvPair
 	activePairs      int
 	maxRetainedBytes int64
-	statsObserver    ReusableScanStatsObserver
 }
 
 // NewReusableScanResponse creates a response that drops retained capacity when
 // it grows beyond maxRetainedBytes. One oversized response can transiently
 // exceed the limit, but its buffers are discarded before decoding the next one.
 func NewReusableScanResponse(maxRetainedBytes int64) *ReusableScanResponse {
-	return NewReusableScanResponseWithObserver(maxRetainedBytes, nil)
-}
-
-// NewReusableScanResponseWithObserver creates reusable response storage and
-// reports decoder counters to observer when it is non-nil.
-func NewReusableScanResponseWithObserver(
-	maxRetainedBytes int64,
-	observer ReusableScanStatsObserver,
-) *ReusableScanResponse {
 	if maxRetainedBytes < 0 {
 		maxRetainedBytes = 0
 	}
-	return &ReusableScanResponse{
-		maxRetainedBytes: maxRetainedBytes,
-		statsObserver:    observer,
-	}
+	return &ReusableScanResponse{maxRetainedBytes: maxRetainedBytes}
 }
 
 // Response returns the most recently decoded scan response.
@@ -106,22 +72,12 @@ func (r *ReusableScanResponse) RetainedMemory() int64 {
 // UnmarshalBufferSlice copies a gRPC response into reusable storage and
 // decodes its KvPair objects without allocating after capacities stabilize.
 func (r *ReusableScanResponse) UnmarshalBufferSlice(data mem.BufferSlice) error {
-	var stats *ReusableScanStats
-	if r.statsObserver != nil {
-		stats = &ReusableScanStats{
-			ResponseCount: 1,
-			ResponseBytes: uint64(data.Len()),
-		}
-		defer func() {
-			r.observeStats(*stats)
-		}()
-	}
-	r.prepareForDecode(data.Len(), stats)
+	r.prepareForDecode(data.Len())
 	data.CopyTo(r.decodeBuffer)
-	return r.unmarshal(r.decodeBuffer, stats)
+	return r.unmarshal(r.decodeBuffer)
 }
 
-func (r *ReusableScanResponse) prepareForDecode(size int, stats *ReusableScanStats) {
+func (r *ReusableScanResponse) prepareForDecode(size int) {
 	if r.RetainedMemory() > r.maxRetainedBytes {
 		clear(r.pairs)
 		r.pairs = nil
@@ -134,24 +90,14 @@ func (r *ReusableScanResponse) prepareForDecode(size int, stats *ReusableScanSta
 	r.activePairs = 0
 	if cap(r.decodeBuffer) < size {
 		r.decodeBuffer = make([]byte, size)
-		if stats != nil {
-			stats.DecodeBufferAllocatedBytes += uint64(size)
-		}
 	} else {
 		r.decodeBuffer = r.decodeBuffer[:size]
 	}
 }
 
-func (r *ReusableScanResponse) nextPair(stats *ReusableScanStats) *kvrpcpb.KvPair {
+func (r *ReusableScanResponse) nextPair() *kvrpcpb.KvPair {
 	if r.activePairs == len(r.pairs) {
-		oldCapacity := cap(r.pairs)
 		r.pairs = append(r.pairs, &kvrpcpb.KvPair{})
-		if stats != nil && cap(r.pairs) != oldCapacity {
-			stats.PairSliceAllocatedBytes += uint64(cap(r.pairs)) * uint64(unsafe.Sizeof((*kvrpcpb.KvPair)(nil)))
-		}
-		if stats != nil {
-			stats.PairObjectAllocatedBytes += uint64(scanResponsePairSize)
-		}
 	}
 	pair := r.pairs[r.activePairs]
 	r.activePairs++
@@ -162,7 +108,7 @@ func (r *ReusableScanResponse) nextPair(stats *ReusableScanStats) *kvrpcpb.KvPai
 	return pair
 }
 
-func (r *ReusableScanResponse) unmarshal(data []byte, stats *ReusableScanStats) error {
+func (r *ReusableScanResponse) unmarshal(data []byte) error {
 	for len(data) > 0 {
 		fieldNumber, wireType, tagBytes := protowire.ConsumeTag(data)
 		if tagBytes < 0 {
@@ -187,22 +133,9 @@ func (r *ReusableScanResponse) unmarshal(data []byte, stats *ReusableScanStats) 
 			if err != nil {
 				return err
 			}
-			pair := r.nextPair(stats)
-			oldKeyCapacity := cap(pair.Key)
-			oldValueCapacity := cap(pair.Value)
+			pair := r.nextPair()
 			if err := pair.Unmarshal(message); err != nil {
 				return err
-			}
-			if stats != nil {
-				if cap(pair.Key) != oldKeyCapacity {
-					stats.PairKeyValueAllocatedBytes += uint64(cap(pair.Key))
-				}
-				if cap(pair.Value) != oldValueCapacity {
-					stats.PairKeyValueAllocatedBytes += uint64(cap(pair.Value))
-				}
-				stats.PairCount++
-				stats.KeyBytes += uint64(len(pair.Key))
-				stats.ValueBytes += uint64(len(pair.Value))
 			}
 			data = data[consumed:]
 		case 3:
@@ -226,21 +159,6 @@ func (r *ReusableScanResponse) unmarshal(data []byte, stats *ReusableScanStats) 
 	}
 	r.response.Pairs = r.pairs[:r.activePairs]
 	return nil
-}
-
-// ObserveScannerNext records one Scanner.Next call. This is separate from RPC
-// count because cached scan responses serve many iterator steps.
-func (r *ReusableScanResponse) ObserveScannerNext() {
-	if r.statsObserver == nil {
-		return
-	}
-	r.observeStats(ReusableScanStats{ScannerNextCalls: 1})
-}
-
-func (r *ReusableScanResponse) observeStats(stats ReusableScanStats) {
-	if r.statsObserver != nil {
-		r.statsObserver.ObserveReusableScanStats(stats)
-	}
 }
 
 func consumeScanResponseMessage(fieldNumber protowire.Number, wireType protowire.Type, data []byte) ([]byte, int, error) {

--- a/tikvrpc/reusable_scan_response.go
+++ b/tikvrpc/reusable_scan_response.go
@@ -1,0 +1,314 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikvrpc
+
+import (
+	"context"
+	"fmt"
+	"unsafe"
+
+	"github.com/pingcap/kvproto/pkg/errorpb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding"
+	"google.golang.org/grpc/mem"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/protoadapt"
+)
+
+const scanResponsePairSize = int64(unsafe.Sizeof(kvrpcpb.KvPair{}))
+
+// ReusableScanStats contains per-scanner data-flow and allocation-request
+// counters. Allocation counters report the sizes requested by this reusable
+// decoder; they do not include Go allocator size-class rounding.
+type ReusableScanStats struct {
+	ScannerNextCalls           uint64
+	ResponseCount              uint64
+	ResponseBytes              uint64
+	DecodeBufferAllocatedBytes uint64
+	PairSliceAllocatedBytes    uint64
+	PairObjectAllocatedBytes   uint64
+	PairKeyValueAllocatedBytes uint64
+	PairCount                  uint64
+	KeyBytes                   uint64
+	ValueBytes                 uint64
+}
+
+// ReusableScanStatsObserver receives query-owned scan counter deltas.
+type ReusableScanStatsObserver interface {
+	ObserveReusableScanStats(ReusableScanStats)
+}
+
+// ReusableScanResponse owns the buffers used to decode sequential scan RPC
+// responses. The result returned by Response remains valid only until the next
+// call to UnmarshalBufferSlice.
+type ReusableScanResponse struct {
+	response         kvrpcpb.ScanResponse
+	decodeBuffer     []byte
+	pairs            []*kvrpcpb.KvPair
+	activePairs      int
+	maxRetainedBytes int64
+	statsObserver    ReusableScanStatsObserver
+}
+
+// NewReusableScanResponse creates a response that drops retained capacity when
+// it grows beyond maxRetainedBytes. One oversized response can transiently
+// exceed the limit, but its buffers are discarded before decoding the next one.
+func NewReusableScanResponse(maxRetainedBytes int64) *ReusableScanResponse {
+	return NewReusableScanResponseWithObserver(maxRetainedBytes, nil)
+}
+
+// NewReusableScanResponseWithObserver creates reusable response storage and
+// reports decoder counters to observer when it is non-nil.
+func NewReusableScanResponseWithObserver(
+	maxRetainedBytes int64,
+	observer ReusableScanStatsObserver,
+) *ReusableScanResponse {
+	if maxRetainedBytes < 0 {
+		maxRetainedBytes = 0
+	}
+	return &ReusableScanResponse{
+		maxRetainedBytes: maxRetainedBytes,
+		statsObserver:    observer,
+	}
+}
+
+// Response returns the most recently decoded scan response.
+func (r *ReusableScanResponse) Response() *kvrpcpb.ScanResponse {
+	return &r.response
+}
+
+// RetainedMemory returns the reusable byte and object capacity owned by the
+// response. It excludes uncommon region and key error graphs.
+func (r *ReusableScanResponse) RetainedMemory() int64 {
+	usage := int64(cap(r.decodeBuffer)) + int64(cap(r.pairs))*int64(unsafe.Sizeof((*kvrpcpb.KvPair)(nil)))
+	for _, pair := range r.pairs {
+		if pair != nil {
+			usage += scanResponsePairSize + int64(cap(pair.Key)+cap(pair.Value))
+		}
+	}
+	return usage
+}
+
+// UnmarshalBufferSlice copies a gRPC response into reusable storage and
+// decodes its KvPair objects without allocating after capacities stabilize.
+func (r *ReusableScanResponse) UnmarshalBufferSlice(data mem.BufferSlice) error {
+	var stats *ReusableScanStats
+	if r.statsObserver != nil {
+		stats = &ReusableScanStats{
+			ResponseCount: 1,
+			ResponseBytes: uint64(data.Len()),
+		}
+		defer func() {
+			r.observeStats(*stats)
+		}()
+	}
+	r.prepareForDecode(data.Len(), stats)
+	data.CopyTo(r.decodeBuffer)
+	return r.unmarshal(r.decodeBuffer, stats)
+}
+
+func (r *ReusableScanResponse) prepareForDecode(size int, stats *ReusableScanStats) {
+	if r.RetainedMemory() > r.maxRetainedBytes {
+		clear(r.pairs)
+		r.pairs = nil
+		r.decodeBuffer = nil
+	}
+
+	r.response.RegionError = nil
+	r.response.Error = nil
+	r.response.Pairs = nil
+	r.activePairs = 0
+	if cap(r.decodeBuffer) < size {
+		r.decodeBuffer = make([]byte, size)
+		if stats != nil {
+			stats.DecodeBufferAllocatedBytes += uint64(size)
+		}
+	} else {
+		r.decodeBuffer = r.decodeBuffer[:size]
+	}
+}
+
+func (r *ReusableScanResponse) nextPair(stats *ReusableScanStats) *kvrpcpb.KvPair {
+	if r.activePairs == len(r.pairs) {
+		oldCapacity := cap(r.pairs)
+		r.pairs = append(r.pairs, &kvrpcpb.KvPair{})
+		if stats != nil && cap(r.pairs) != oldCapacity {
+			stats.PairSliceAllocatedBytes += uint64(cap(r.pairs)) * uint64(unsafe.Sizeof((*kvrpcpb.KvPair)(nil)))
+		}
+		if stats != nil {
+			stats.PairObjectAllocatedBytes += uint64(scanResponsePairSize)
+		}
+	}
+	pair := r.pairs[r.activePairs]
+	r.activePairs++
+	pair.Error = nil
+	pair.Key = pair.Key[:0]
+	pair.Value = pair.Value[:0]
+	pair.CommitTs = 0
+	return pair
+}
+
+func (r *ReusableScanResponse) unmarshal(data []byte, stats *ReusableScanStats) error {
+	for len(data) > 0 {
+		fieldNumber, wireType, tagBytes := protowire.ConsumeTag(data)
+		if tagBytes < 0 {
+			return protowire.ParseError(tagBytes)
+		}
+		data = data[tagBytes:]
+
+		switch fieldNumber {
+		case 1:
+			message, consumed, err := consumeScanResponseMessage(fieldNumber, wireType, data)
+			if err != nil {
+				return err
+			}
+			regionError := &errorpb.Error{}
+			if err := regionError.Unmarshal(message); err != nil {
+				return err
+			}
+			r.response.RegionError = regionError
+			data = data[consumed:]
+		case 2:
+			message, consumed, err := consumeScanResponseMessage(fieldNumber, wireType, data)
+			if err != nil {
+				return err
+			}
+			pair := r.nextPair(stats)
+			oldKeyCapacity := cap(pair.Key)
+			oldValueCapacity := cap(pair.Value)
+			if err := pair.Unmarshal(message); err != nil {
+				return err
+			}
+			if stats != nil {
+				if cap(pair.Key) != oldKeyCapacity {
+					stats.PairKeyValueAllocatedBytes += uint64(cap(pair.Key))
+				}
+				if cap(pair.Value) != oldValueCapacity {
+					stats.PairKeyValueAllocatedBytes += uint64(cap(pair.Value))
+				}
+				stats.PairCount++
+				stats.KeyBytes += uint64(len(pair.Key))
+				stats.ValueBytes += uint64(len(pair.Value))
+			}
+			data = data[consumed:]
+		case 3:
+			message, consumed, err := consumeScanResponseMessage(fieldNumber, wireType, data)
+			if err != nil {
+				return err
+			}
+			keyError := &kvrpcpb.KeyError{}
+			if err := keyError.Unmarshal(message); err != nil {
+				return err
+			}
+			r.response.Error = keyError
+			data = data[consumed:]
+		default:
+			consumed := protowire.ConsumeFieldValue(fieldNumber, wireType, data)
+			if consumed < 0 {
+				return protowire.ParseError(consumed)
+			}
+			data = data[consumed:]
+		}
+	}
+	r.response.Pairs = r.pairs[:r.activePairs]
+	return nil
+}
+
+// ObserveScannerNext records one Scanner.Next call. This is separate from RPC
+// count because cached scan responses serve many iterator steps.
+func (r *ReusableScanResponse) ObserveScannerNext() {
+	if r.statsObserver == nil {
+		return
+	}
+	r.observeStats(ReusableScanStats{ScannerNextCalls: 1})
+}
+
+func (r *ReusableScanResponse) observeStats(stats ReusableScanStats) {
+	if r.statsObserver != nil {
+		r.statsObserver.ObserveReusableScanStats(stats)
+	}
+}
+
+func consumeScanResponseMessage(fieldNumber protowire.Number, wireType protowire.Type, data []byte) ([]byte, int, error) {
+	if wireType != protowire.BytesType {
+		return nil, 0, fmt.Errorf("protobuf field %d has wire type %d, want bytes", fieldNumber, wireType)
+	}
+	message, consumed := protowire.ConsumeBytes(data)
+	if consumed < 0 {
+		return nil, 0, protowire.ParseError(consumed)
+	}
+	return message, consumed, nil
+}
+
+type reusableScanCodec struct{}
+
+func (reusableScanCodec) Marshal(value any) (mem.BufferSlice, error) {
+	message := reusableScanMessageV2Of(value)
+	if message == nil {
+		return nil, fmt.Errorf("failed to marshal %T as protobuf", value)
+	}
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	return mem.BufferSlice{mem.SliceBuffer(data)}, nil
+}
+
+func (reusableScanCodec) Unmarshal(data mem.BufferSlice, value any) error {
+	response, ok := value.(*ReusableScanResponse)
+	if !ok {
+		return fmt.Errorf("failed to unmarshal reusable scan response into %T", value)
+	}
+	return response.UnmarshalBufferSlice(data)
+}
+
+func (reusableScanCodec) Name() string {
+	return "proto"
+}
+
+func reusableScanMessageV2Of(value any) proto.Message {
+	switch message := value.(type) {
+	case protoadapt.MessageV1:
+		return protoadapt.MessageV2Of(message)
+	case protoadapt.MessageV2:
+		return message
+	default:
+		return nil
+	}
+}
+
+var _ encoding.CodecV2 = reusableScanCodec{}
+
+// CallReusableScanRPC sends one unary scan request and decodes the response
+// into the caller-owned buffers attached to req.
+func CallReusableScanRPC(ctx context.Context, conn grpc.ClientConnInterface, req *Request) (*Response, error) {
+	response := &Response{}
+	if req == nil || req.Type != CmdScan || req.ReusableScanResponse == nil {
+		return response, fmt.Errorf("reusable scan RPC requires a scan request and response storage")
+	}
+	err := conn.Invoke(
+		ctx,
+		"/tikvpb.Tikv/KvScan",
+		req.Scan(),
+		req.ReusableScanResponse,
+		grpc.ForceCodecV2(reusableScanCodec{}),
+	)
+	if err == nil {
+		response.Resp = req.ReusableScanResponse.Response()
+	}
+	return response, err
+}

--- a/tikvrpc/reusable_scan_response_test.go
+++ b/tikvrpc/reusable_scan_response_test.go
@@ -23,23 +23,6 @@ import (
 	"google.golang.org/grpc/mem"
 )
 
-type reusableScanStatsCollector struct {
-	stats ReusableScanStats
-}
-
-func (c *reusableScanStatsCollector) ObserveReusableScanStats(delta ReusableScanStats) {
-	c.stats.ScannerNextCalls += delta.ScannerNextCalls
-	c.stats.ResponseCount += delta.ResponseCount
-	c.stats.ResponseBytes += delta.ResponseBytes
-	c.stats.DecodeBufferAllocatedBytes += delta.DecodeBufferAllocatedBytes
-	c.stats.PairSliceAllocatedBytes += delta.PairSliceAllocatedBytes
-	c.stats.PairObjectAllocatedBytes += delta.PairObjectAllocatedBytes
-	c.stats.PairKeyValueAllocatedBytes += delta.PairKeyValueAllocatedBytes
-	c.stats.PairCount += delta.PairCount
-	c.stats.KeyBytes += delta.KeyBytes
-	c.stats.ValueBytes += delta.ValueBytes
-}
-
 func TestReusableScanResponseReusesDecodedBuffers(t *testing.T) {
 	encoded := marshalScanResponse(t, 256, 4<<10)
 	input := mem.BufferSlice{mem.SliceBuffer(encoded)}
@@ -106,37 +89,6 @@ func TestReusableScanResponseDropsOversizedRetention(t *testing.T) {
 	small := marshalScanResponse(t, 1, 32)
 	require.NoError(t, response.UnmarshalBufferSlice(mem.BufferSlice{mem.SliceBuffer(small)}))
 	require.LessOrEqual(t, response.RetainedMemory(), int64(retainedLimit))
-}
-
-func TestReusableScanResponseReportsStats(t *testing.T) {
-	collector := &reusableScanStatsCollector{}
-	encoded := marshalScanResponse(t, 4, 128)
-	input := mem.BufferSlice{mem.SliceBuffer(encoded)}
-	response := NewReusableScanResponseWithObserver(16<<20, collector)
-
-	response.ObserveScannerNext()
-	require.NoError(t, response.UnmarshalBufferSlice(input))
-	firstAllocationBytes := collector.stats.DecodeBufferAllocatedBytes +
-		collector.stats.PairSliceAllocatedBytes +
-		collector.stats.PairObjectAllocatedBytes +
-		collector.stats.PairKeyValueAllocatedBytes
-	require.Positive(t, firstAllocationBytes)
-	require.Equal(t, uint64(1), collector.stats.ScannerNextCalls)
-	require.Equal(t, uint64(1), collector.stats.ResponseCount)
-	require.Equal(t, uint64(len(encoded)), collector.stats.ResponseBytes)
-	require.Equal(t, uint64(4), collector.stats.PairCount)
-	require.Equal(t, uint64(8), collector.stats.KeyBytes)
-	require.Equal(t, uint64(4*128), collector.stats.ValueBytes)
-
-	require.NoError(t, response.UnmarshalBufferSlice(input))
-	require.Equal(t, uint64(2), collector.stats.ResponseCount)
-	require.Equal(t, uint64(2*len(encoded)), collector.stats.ResponseBytes)
-	require.Equal(t, uint64(8), collector.stats.PairCount)
-	require.Equal(t, firstAllocationBytes,
-		collector.stats.DecodeBufferAllocatedBytes+
-			collector.stats.PairSliceAllocatedBytes+
-			collector.stats.PairObjectAllocatedBytes+
-			collector.stats.PairKeyValueAllocatedBytes)
 }
 
 func marshalScanResponse(t *testing.T, pairCount, valueSize int) []byte {

--- a/tikvrpc/reusable_scan_response_test.go
+++ b/tikvrpc/reusable_scan_response_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikvrpc
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/mem"
+)
+
+type reusableScanStatsCollector struct {
+	stats ReusableScanStats
+}
+
+func (c *reusableScanStatsCollector) ObserveReusableScanStats(delta ReusableScanStats) {
+	c.stats.ScannerNextCalls += delta.ScannerNextCalls
+	c.stats.ResponseCount += delta.ResponseCount
+	c.stats.ResponseBytes += delta.ResponseBytes
+	c.stats.DecodeBufferAllocatedBytes += delta.DecodeBufferAllocatedBytes
+	c.stats.PairSliceAllocatedBytes += delta.PairSliceAllocatedBytes
+	c.stats.PairObjectAllocatedBytes += delta.PairObjectAllocatedBytes
+	c.stats.PairKeyValueAllocatedBytes += delta.PairKeyValueAllocatedBytes
+	c.stats.PairCount += delta.PairCount
+	c.stats.KeyBytes += delta.KeyBytes
+	c.stats.ValueBytes += delta.ValueBytes
+}
+
+func TestReusableScanResponseReusesDecodedBuffers(t *testing.T) {
+	encoded := marshalScanResponse(t, 256, 4<<10)
+	input := mem.BufferSlice{mem.SliceBuffer(encoded)}
+	response := NewReusableScanResponse(16 << 20)
+
+	require.NoError(t, response.UnmarshalBufferSlice(input))
+	require.Len(t, response.Response().GetPairs(), 256)
+	firstPair := response.Response().GetPairs()[0]
+	firstKey := unsafe.SliceData(firstPair.Key)
+	firstValue := unsafe.SliceData(firstPair.Value)
+	firstDecodeBuffer := unsafe.SliceData(response.decodeBuffer)
+
+	allocs := testing.AllocsPerRun(20, func() {
+		require.NoError(t, response.UnmarshalBufferSlice(input))
+	})
+	require.Zero(t, allocs)
+	require.Same(t, firstPair, response.Response().GetPairs()[0])
+	require.Equal(t, firstKey, unsafe.SliceData(response.Response().GetPairs()[0].Key))
+	require.Equal(t, firstValue, unsafe.SliceData(response.Response().GetPairs()[0].Value))
+	require.Equal(t, firstDecodeBuffer, unsafe.SliceData(response.decodeBuffer))
+}
+
+func TestReusableScanResponseClearsStaleData(t *testing.T) {
+	response := NewReusableScanResponse(16 << 20)
+	first := &kvrpcpb.ScanResponse{
+		Pairs: []*kvrpcpb.KvPair{{
+			Error:    &kvrpcpb.KeyError{Abort: "stale"},
+			Key:      []byte("old-key"),
+			Value:    []byte("old-value"),
+			CommitTs: 42,
+		}},
+		Error: &kvrpcpb.KeyError{Abort: "stale-response-error"},
+	}
+	firstBytes, err := first.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, response.UnmarshalBufferSlice(mem.BufferSlice{mem.SliceBuffer(firstBytes)}))
+
+	second := &kvrpcpb.ScanResponse{
+		Pairs: []*kvrpcpb.KvPair{{
+			Key:   []byte("new-key"),
+			Value: []byte("new-value"),
+		}},
+	}
+	secondBytes, err := second.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, response.UnmarshalBufferSlice(mem.BufferSlice{mem.SliceBuffer(secondBytes)}))
+
+	require.Nil(t, response.Response().GetError())
+	require.Len(t, response.Response().GetPairs(), 1)
+	pair := response.Response().GetPairs()[0]
+	require.Nil(t, pair.GetError())
+	require.Equal(t, []byte("new-key"), pair.GetKey())
+	require.Equal(t, []byte("new-value"), pair.GetValue())
+	require.Zero(t, pair.GetCommitTs())
+}
+
+func TestReusableScanResponseDropsOversizedRetention(t *testing.T) {
+	const retainedLimit = 1 << 20
+	response := NewReusableScanResponse(retainedLimit)
+	large := marshalScanResponse(t, 4, retainedLimit)
+	require.NoError(t, response.UnmarshalBufferSlice(mem.BufferSlice{mem.SliceBuffer(large)}))
+	require.Greater(t, response.RetainedMemory(), int64(retainedLimit))
+
+	small := marshalScanResponse(t, 1, 32)
+	require.NoError(t, response.UnmarshalBufferSlice(mem.BufferSlice{mem.SliceBuffer(small)}))
+	require.LessOrEqual(t, response.RetainedMemory(), int64(retainedLimit))
+}
+
+func TestReusableScanResponseReportsStats(t *testing.T) {
+	collector := &reusableScanStatsCollector{}
+	encoded := marshalScanResponse(t, 4, 128)
+	input := mem.BufferSlice{mem.SliceBuffer(encoded)}
+	response := NewReusableScanResponseWithObserver(16<<20, collector)
+
+	response.ObserveScannerNext()
+	require.NoError(t, response.UnmarshalBufferSlice(input))
+	firstAllocationBytes := collector.stats.DecodeBufferAllocatedBytes +
+		collector.stats.PairSliceAllocatedBytes +
+		collector.stats.PairObjectAllocatedBytes +
+		collector.stats.PairKeyValueAllocatedBytes
+	require.Positive(t, firstAllocationBytes)
+	require.Equal(t, uint64(1), collector.stats.ScannerNextCalls)
+	require.Equal(t, uint64(1), collector.stats.ResponseCount)
+	require.Equal(t, uint64(len(encoded)), collector.stats.ResponseBytes)
+	require.Equal(t, uint64(4), collector.stats.PairCount)
+	require.Equal(t, uint64(8), collector.stats.KeyBytes)
+	require.Equal(t, uint64(4*128), collector.stats.ValueBytes)
+
+	require.NoError(t, response.UnmarshalBufferSlice(input))
+	require.Equal(t, uint64(2), collector.stats.ResponseCount)
+	require.Equal(t, uint64(2*len(encoded)), collector.stats.ResponseBytes)
+	require.Equal(t, uint64(8), collector.stats.PairCount)
+	require.Equal(t, firstAllocationBytes,
+		collector.stats.DecodeBufferAllocatedBytes+
+			collector.stats.PairSliceAllocatedBytes+
+			collector.stats.PairObjectAllocatedBytes+
+			collector.stats.PairKeyValueAllocatedBytes)
+}
+
+func marshalScanResponse(t *testing.T, pairCount, valueSize int) []byte {
+	t.Helper()
+	response := &kvrpcpb.ScanResponse{Pairs: make([]*kvrpcpb.KvPair, pairCount)}
+	for i := range response.Pairs {
+		response.Pairs[i] = &kvrpcpb.KvPair{
+			Key:      []byte{byte(i), byte(i >> 8)},
+			Value:    make([]byte, valueSize),
+			CommitTs: uint64(i + 1),
+		}
+		response.Pairs[i].Value[0] = byte(i)
+	}
+	encoded, err := response.Marshal()
+	require.NoError(t, err)
+	return encoded
+}

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -272,6 +272,10 @@ type Request struct {
 	// controller, which decides whether the request type is eligible for
 	// paging pre-charge; non-cop hints may be ignored.
 	PredictedReadBytes uint64
+	// ReusableScanResponse enables caller-owned response buffers for a
+	// sequential scan request. Such requests must bypass batch commands because
+	// the response storage is not safe for concurrent use.
+	ReusableScanResponse *ReusableScanResponse
 	// rev represents the revision of the request, it's increased when `Req.Context` gets patched.
 	rev uint32
 }

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -58,6 +58,7 @@ type Scanner struct {
 	snapshot     *KVSnapshot
 	batchSize    int
 	cache        []*kvrpcpb.KvPair
+	reusableResp *tikvrpc.ReusableScanResponse
 	idx          int
 	nextStartKey []byte
 	endKey       []byte
@@ -83,6 +84,12 @@ func newScanner(snapshot *KVSnapshot, startKey []byte, endKey []byte, batchSize 
 		endKey:       endKey,
 		reverse:      reverse,
 		nextEndKey:   endKey,
+	}
+	if snapshot.scanResponseRetainedSize > 0 {
+		scanner.reusableResp = tikvrpc.NewReusableScanResponseWithObserver(
+			snapshot.scanResponseRetainedSize,
+			snapshot.scanResponseStatsObserver,
+		)
 	}
 	err := scanner.Next()
 	if tikverr.IsErrNotFound(err) {
@@ -116,6 +123,9 @@ const scannerNextMaxBackoff = 20000
 
 // Next return next element.
 func (s *Scanner) Next() error {
+	if s.reusableResp != nil {
+		s.reusableResp.ObserveScannerNext()
+	}
 	bo := retry.NewBackofferWithVars(context.WithValue(context.Background(), retry.TxnStartKey, s.snapshot.version), scannerNextMaxBackoff, s.snapshot.vars)
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")
@@ -175,6 +185,17 @@ func (s *Scanner) Next() error {
 // Close close iterator.
 func (s *Scanner) Close() {
 	s.valid = false
+	s.cache = nil
+	s.reusableResp = nil
+}
+
+// RetainedMemory returns the reusable scan response capacity owned by the
+// scanner.
+func (s *Scanner) RetainedMemory() int64 {
+	if s.reusableResp == nil {
+		return 0
+	}
+	return s.reusableResp.RetainedMemory()
 }
 
 func (s *Scanner) startTS() uint64 {
@@ -258,6 +279,7 @@ func (s *Scanner) getData(bo *retry.Backoffer) error {
 			req.IsRetryRequest = true
 		}
 		req.InputRequestSource = s.snapshot.GetRequestSource()
+		req.ReusableScanResponse = s.reusableResp
 		if s.snapshot.mu.resourceGroupTag == nil && s.snapshot.mu.resourceGroupTagger != nil {
 			s.snapshot.mu.resourceGroupTagger(req)
 		}

--- a/txnkv/txnsnapshot/scan.go
+++ b/txnkv/txnsnapshot/scan.go
@@ -86,10 +86,7 @@ func newScanner(snapshot *KVSnapshot, startKey []byte, endKey []byte, batchSize 
 		nextEndKey:   endKey,
 	}
 	if snapshot.scanResponseRetainedSize > 0 {
-		scanner.reusableResp = tikvrpc.NewReusableScanResponseWithObserver(
-			snapshot.scanResponseRetainedSize,
-			snapshot.scanResponseStatsObserver,
-		)
+		scanner.reusableResp = tikvrpc.NewReusableScanResponse(snapshot.scanResponseRetainedSize)
 	}
 	err := scanner.Next()
 	if tikverr.IsErrNotFound(err) {
@@ -123,9 +120,6 @@ const scannerNextMaxBackoff = 20000
 
 // Next return next element.
 func (s *Scanner) Next() error {
-	if s.reusableResp != nil {
-		s.reusableResp.ObserveScannerNext()
-	}
 	bo := retry.NewBackofferWithVars(context.WithValue(context.Background(), retry.TxnStartKey, s.snapshot.version), scannerNextMaxBackoff, s.snapshot.vars)
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -127,7 +127,12 @@ type KVSnapshot struct {
 	resolvedLocks   util.TSSet
 	committedLocks  util.TSSet
 	scanBatchSize   int
-	readTimeout     time.Duration
+	// scanResponseRetainedSize enables reusable response decoding for sequential
+	// scans and bounds the capacity retained by one scanner.
+	scanResponseRetainedSize int64
+	// scanResponseStatsObserver receives counters from reusable sequential scans.
+	scanResponseStatsObserver tikvrpc.ReusableScanStatsObserver
+	readTimeout               time.Duration
 
 	// Cache the result of Get and BatchGet.
 	// The invariance is that calling Get or BatchGet multiple times using the same start ts,
@@ -982,6 +987,19 @@ func (s *KVSnapshot) SetKeyOnly(b bool) {
 // SetScanBatchSize sets the scan batchSize used to scan data from tikv.
 func (s *KVSnapshot) SetScanBatchSize(batchSize int) {
 	s.scanBatchSize = batchSize
+}
+
+// SetScanResponseRetainedSize enables reusable scan response buffers and sets
+// the maximum capacity retained by each scanner. A non-positive value disables
+// response reuse.
+func (s *KVSnapshot) SetScanResponseRetainedSize(maxBytes int64) {
+	s.scanResponseRetainedSize = maxBytes
+}
+
+// SetScanResponseStatsObserver attaches an observer to reusable sequential
+// scans created by this snapshot.
+func (s *KVSnapshot) SetScanResponseStatsObserver(observer tikvrpc.ReusableScanStatsObserver) {
+	s.scanResponseStatsObserver = observer
 }
 
 // SetReplicaRead sets up the replica read type.

--- a/txnkv/txnsnapshot/snapshot.go
+++ b/txnkv/txnsnapshot/snapshot.go
@@ -130,9 +130,7 @@ type KVSnapshot struct {
 	// scanResponseRetainedSize enables reusable response decoding for sequential
 	// scans and bounds the capacity retained by one scanner.
 	scanResponseRetainedSize int64
-	// scanResponseStatsObserver receives counters from reusable sequential scans.
-	scanResponseStatsObserver tikvrpc.ReusableScanStatsObserver
-	readTimeout               time.Duration
+	readTimeout              time.Duration
 
 	// Cache the result of Get and BatchGet.
 	// The invariance is that calling Get or BatchGet multiple times using the same start ts,
@@ -994,12 +992,6 @@ func (s *KVSnapshot) SetScanBatchSize(batchSize int) {
 // response reuse.
 func (s *KVSnapshot) SetScanResponseRetainedSize(maxBytes int64) {
 	s.scanResponseRetainedSize = maxBytes
-}
-
-// SetScanResponseStatsObserver attaches an observer to reusable sequential
-// scans created by this snapshot.
-func (s *KVSnapshot) SetScanResponseStatsObserver(observer tikvrpc.ReusableScanStatsObserver) {
-	s.scanResponseStatsObserver = observer
 }
 
 // SetReplicaRead sets up the replica read type.


### PR DESCRIPTION
## Problem

TiDB InfoSchema V2 metadata scans issue many sequential TiKV `Scan` RPCs. The normal unary path allocates response graphs and transport receive buffers for every RPC. The API v2 response adapter also cloned every decoded `KvPair`, which defeated the caller-owned reusable response after its raw decoder had warmed up.

This is the client-go half of pingcap/tidb#70675 and remains a Draft while the end-to-end design and cluster-scale behavior are reviewed.

## What changed

- Add an opt-in `ReusableScanResponse` for sequential transactional Scan RPCs, with caller-owned pair, key, value, and decode-buffer capacity.
- Route only requests carrying that reusable response through an isolated non-batch connection per TiKV address and an `RPCClient`-scoped, size-classed transport buffer pool capped at 16 MiB.
- Drop oversized retained response or transport capacity before the next decode.
- Decode API v2 Scan pairs in place only when the response pointer is exactly the response owned by the request's `ReusableScanResponse`; ordinary and fallback responses keep the existing clone semantics.
- Keep transaction, Cop, BatchCommands, streaming, and Scan requests without this explicit opt-in on their existing connection pools and gRPC buffer policy.

## Validation

```text
GOWORK=off go test ./internal/apicodec -count=1
GOWORK=off go test ./internal/client ./tikvrpc -count=1
GOWORK=off go test -race ./internal/apicodec ./internal/client ./tikvrpc -run 'Test(CodecV2|BoundedBufferPool|ReusableScan|CloseAddrVerHandlesReusableScanConnPool|GetConnAfterClose)' -count=1
GOWORK=off go test ./txnkv/txnsnapshot -run '^$' -count=1
GOWORK=off go vet ./internal/apicodec ./internal/client ./tikvrpc ./txnkv/txnsnapshot
```

The API v2 regression covers the complete reusable raw decoder plus adapter path. After warm-up it preserves pair and key backing-storage identity with zero measured allocations in the adapter test.

## Compatibility and risk

There is no behavior change unless the caller attaches `ReusableScanResponse` to a transactional `CmdScan` request. The new path can add at most one dedicated HTTP/2 connection per contacted TiKV address and retains at most 16 MiB of transport buffers per `RPCClient`, plus the caller-configured response retention per active scanner. Multi-TiKV routing, concurrent metadata scans, reconnect behavior, and tail latency still require cluster-scale validation before this Draft is ready to merge.
