### PR TITLE
retry: delegate killed checks to signal handler (#2042)

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -383,7 +383,10 @@ func (b *Backoffer) longestSleepCfg() (*Config, int) {
 }
 
 func (b *Backoffer) CheckKilled() error {
-	if b.vars != nil && b.vars.Killed != nil {
+	if b.vars == nil {
+		return nil
+	}
+	if b.vars.Killed != nil {
 		killed := atomic.LoadUint32(b.vars.Killed)
 		if killed != 0 {
 			logutil.BgLogger().Info(
@@ -392,6 +395,9 @@ func (b *Backoffer) CheckKilled() error {
 			)
 			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: killed})
 		}
+	}
+	if b.vars.KillSignalHandler != nil {
+		return b.vars.KillSignalHandler.HandleSignal()
 	}
 	return nil
 }

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -40,7 +40,48 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/kv"
 )
+
+type killSignalHandlerFunc func() error
+
+func (f killSignalHandlerFunc) HandleSignal() error {
+	return f()
+}
+
+func TestCheckKilled(t *testing.T) {
+	handlerErr := errors.New("killed by handler")
+	called := 0
+	killed := uint32(7)
+	vars := kv.NewVariables(&killed)
+	vars.KillSignalHandler = killSignalHandlerFunc(func() error {
+		called++
+		return handlerErr
+	})
+	bo := NewBackofferWithVars(context.Background(), 1, vars)
+	err := bo.CheckKilled()
+	var interrupted tikverr.ErrQueryInterruptedWithSignal
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+	assert.Equal(t, 0, called)
+
+	killed = 0
+	assert.ErrorIs(t, bo.CheckKilled(), handlerErr)
+	assert.Equal(t, 1, called)
+	vars.KillSignalHandler = nil
+	killed = 7
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	bo = NewBackofferWithVars(context.Background(), 1, kv.NewVariables(&killed))
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	assert.NoError(t, NewBackofferWithVars(context.Background(), 1, nil).CheckKilled())
+}
 
 func TestBackoffWithMax(t *testing.T) {
 	b := NewBackofferWithVars(context.TODO(), 2000, nil)

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -34,6 +34,13 @@
 
 package kv
 
+// KillSignalHandler handles kill signals at interruptible KV request checkpoints.
+// Implementations must be safe for concurrent use.
+type KillSignalHandler interface {
+	// HandleSignal returns an error when the current operation should stop.
+	HandleSignal() error
+}
+
 // Variables defines the variables used by KV storage.
 type Variables struct {
 	// BackoffLockFast specifies the LockFast backoff base duration in milliseconds.
@@ -49,6 +56,10 @@ type Variables struct {
 	// When its value is 0, it's not killed
 	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
+
+	// KillSignalHandler takes precedence over Killed when it is set.
+	// It must be configured before Variables is used by concurrent requests.
+	KillSignalHandler KillSignalHandler
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1091,22 +1091,9 @@ func (c *twoPhaseCommitter) doActionOnBatches(
 	bo *retry.Backoffer, action twoPhaseCommitAction,
 	batches []batchMutations,
 ) error {
-	// killSignal should never be nil for TiDB
-	if c.txn != nil && c.txn.vars != nil && c.txn.vars.Killed != nil {
-		// Do not reset the killed flag here. Let the upper layer reset the flag.
-		// Before it resets, any request is considered valid to be killed if the
-		// corresponding action is interruptible.
-		status := atomic.LoadUint32(c.txn.vars.Killed)
-		if status != 0 && action.isInterruptible() {
-			logutil.BgLogger().Info(
-				"query is killed", zap.Uint32(
-					"signal",
-					status,
-				),
-			)
-			// TODO: There might be various signals besides a query interruption,
-			// but we are unable to differentiate them, because the definition is in TiDB.
-			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: status})
+	if action.isInterruptible() {
+		if err := bo.CheckKilled(); err != nil {
+			return err
 		}
 	}
 	if len(batches) == 0 {


### PR DESCRIPTION
Manual backport of #2042 to `tidb-8.5`.

The original squash commit conflicted with the release branch in `kv/variables.go` and `config/retry/backoff_test.go`. The resolution keeps the `tidb-8.5` variable layout, adds only `KillSignalHandler`, and ports the retry/2PC behavior and coverage without bringing in master-only txn-file fields.

Ref: pingcap/tidb#68682
Downstream backport: pingcap/tidb#70343

Tests:
- `go test ./config/retry ./txnkv/transaction`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interruption handling for key-value requests and transactional batch operations.
  - Kill signals are now checked consistently before processing request batches.
  - Configured signal handlers can report interruption results directly, improving error propagation.
  - Existing killed-state behavior remains supported when no signal handler is configured.
- **Tests**
  - Added coverage for killed states, signal-handler invocation, handler results, reset behavior, and missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->