### PR TITLE
tikvrpc: add default request origin

### DIFF
--- a/examples/gcworker/go.mod
+++ b/examples/gcworker/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/rawkv/go.mod
+++ b/examples/rawkv/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/1pc_txn/go.mod
+++ b/examples/txnkv/1pc_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/async_commit/go.mod
+++ b/examples/txnkv/async_commit/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/delete_range/go.mod
+++ b/examples/txnkv/delete_range/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/go.mod
+++ b/examples/txnkv/go.mod
@@ -3,7 +3,7 @@ module txnkv
 go 1.25.8
 
 require (
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f
 	github.com/tikv/client-go/v2 v2.0.0
 )
 

--- a/examples/txnkv/pessimistic_txn/go.mod
+++ b/examples/txnkv/pessimistic_txn/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/examples/txnkv/unsafedestoryrange/go.mod
+++ b/examples/txnkv/unsafedestoryrange/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122 // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a // indirect
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f // indirect
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20241219054535-6b8c588c3122
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f
 	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXH
 github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a h1:ZfyjOcFgQQ4HPPJUcaNRTBOAvpKLvsOyDtuPagZ9JQM=
-github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f h1:REeYeyw0P9Lvl864TLeu56DU/RAabwSoeJsAPQ56Ek4=
+github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration_tests/go.mod
+++ b/integration_tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ninedraft/israce v0.0.3
 	github.com/pingcap/errors v0.11.5-0.20260310054046-9c8b3586e4b2
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86
-	github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a
+	github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f
 	github.com/pingcap/tidb v1.1.0-beta.0.20260317213042-b1525070ca3e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0

--- a/integration_tests/go.sum
+++ b/integration_tests/go.sum
@@ -1440,8 +1440,8 @@ github.com/pingcap/fn v1.0.0/go.mod h1:u9WZ1ZiOD1RpNhcI42RucFh/lBuzTu6rw88a+oF2Z
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20241113043844-e1fa7ea8c302/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
-github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a h1:ZfyjOcFgQQ4HPPJUcaNRTBOAvpKLvsOyDtuPagZ9JQM=
-github.com/pingcap/kvproto v0.0.0-20260724075646-dc53c468806a/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
+github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f h1:REeYeyw0P9Lvl864TLeu56DU/RAabwSoeJsAPQ56Ek4=
+github.com/pingcap/kvproto v0.0.0-20260902031311-e98c296c957f/go.mod h1:rXxWk2UnwfUhLXha1jxRWPADw9eMZGWEWCg92Tgmb/8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20250917021125-19901e015dc9 h1:qG9BSvlWFEE5otQGamuWedx9LRm0nrHvsQRQiW8SxEs=

--- a/tikvrpc/tikvrpc.go
+++ b/tikvrpc/tikvrpc.go
@@ -276,13 +276,34 @@ type Request struct {
 	rev uint32
 }
 
+var defaultRequestOrigin atomic.Int32
+
+// SetDefaultRequestOrigin sets the process-wide request origin used when an RPC
+// context does not carry an explicit origin.
+func SetDefaultRequestOrigin(origin kvrpcpb.RequestOrigin) {
+	defaultRequestOrigin.Store(int32(origin))
+}
+
+// GetDefaultRequestOrigin returns the process-wide default request origin.
+func GetDefaultRequestOrigin() kvrpcpb.RequestOrigin {
+	return kvrpcpb.RequestOrigin(defaultRequestOrigin.Load())
+}
+
+func fillDefaultRequestOrigin(ctx *kvrpcpb.Context) {
+	if ctx.GetRequestOrigin() == kvrpcpb.RequestOrigin_RequestOriginUnknown {
+		ctx.RequestOrigin = GetDefaultRequestOrigin()
+	}
+}
+
 // NewRequest returns new kv rpc request.
 func NewRequest(typ CmdType, pointer interface{}, ctxs ...kvrpcpb.Context) *Request {
 	if len(ctxs) > 0 {
+		ctx := ctxs[0]
+		fillDefaultRequestOrigin(&ctx)
 		return &Request{
 			Type:    typ,
 			Req:     pointer,
-			Context: ctxs[0],
+			Context: ctx,
 		}
 	}
 	return &Request{
@@ -855,6 +876,8 @@ type MPPStreamResponse struct {
 // return false if encounter unknown request type.
 // Parameter `rpcCtx` use `kvrpcpb.Context` instead of `*kvrpcpb.Context` to avoid concurrent modification by shallow copy.
 func AttachContext(req *Request, rpcCtx kvrpcpb.Context) bool {
+	fillDefaultRequestOrigin(&rpcCtx)
+	req.Context = rpcCtx
 	ctx := &rpcCtx
 	cmd := req.Type
 	// CmdCopStream and CmdCop share the same request type.

--- a/tikvrpc/tikvrpc_test.go
+++ b/tikvrpc/tikvrpc_test.go
@@ -59,6 +59,68 @@ func TestBatchResponse(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestDefaultRequestOrigin(t *testing.T) {
+	previousOrigin := GetDefaultRequestOrigin()
+	SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginTiDB)
+	t.Cleanup(func() {
+		SetDefaultRequestOrigin(previousOrigin)
+	})
+
+	req := NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{})
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
+
+	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{})
+	require.True(t, AttachContext(req, kvrpcpb.Context{}))
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.Get().GetContext().GetRequestOrigin())
+
+	for _, tc := range []struct {
+		name   string
+		req    *Request
+		origin func(*Request) kvrpcpb.RequestOrigin
+	}{
+		{
+			name: "scan_lock",
+			req:  NewRequest(CmdScanLock, &kvrpcpb.ScanLockRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.ScanLock().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "cleanup",
+			req:  NewRequest(CmdCleanup, &kvrpcpb.CleanupRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.Cleanup().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "check_txn_status",
+			req:  NewRequest(CmdCheckTxnStatus, &kvrpcpb.CheckTxnStatusRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.CheckTxnStatus().GetContext().GetRequestOrigin()
+			},
+		},
+		{
+			name: "check_secondary_locks",
+			req:  NewRequest(CmdCheckSecondaryLocks, &kvrpcpb.CheckSecondaryLocksRequest{}),
+			origin: func(req *Request) kvrpcpb.RequestOrigin {
+				return req.CheckSecondaryLocks().GetContext().GetRequestOrigin()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, AttachContext(tc.req, kvrpcpb.Context{}))
+			require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, tc.origin(tc.req))
+		})
+	}
+
+	SetDefaultRequestOrigin(kvrpcpb.RequestOrigin_RequestOriginUnknown)
+	req = NewRequest(CmdGet, &kvrpcpb.GetRequest{}, kvrpcpb.Context{
+		RequestOrigin: kvrpcpb.RequestOrigin_RequestOriginTiDB,
+	})
+	require.Equal(t, kvrpcpb.RequestOrigin_RequestOriginTiDB, req.GetRequestOrigin())
+}
+
 func TestAttachContextSetsRequestContext(t *testing.T) {
 	rpcCtx := kvrpcpb.Context{
 		RegionId:     123,


### PR DESCRIPTION
## What problem does this PR solve?

Backport https://github.com/tikv/client-go/pull/1975 to `release-nextgen-202603` so downstream TiDB can mark its KV requests with `RequestOriginTiDB`.

The client-go default remains `RequestOriginUnknown` until TiDB explicitly sets it. This PR only provides the dependency and client-side propagation support.

Depends on the merged kvproto backport: https://github.com/pingcap/kvproto/pull/1525.

## What is changed?

- update kvproto to the merged 202603 request-origin backport
- add a process-wide default request origin setter/getter
- fill the default origin in `NewRequest` and `AttachContext`
- cover direct requests and transaction-status/lock-resolution requests in tests

## Tests

- `go test -tags=nextgen ./tikvrpc`
- `go test -race -tags=nextgen ./tikvrpc -run "^TestDefaultRequestOrigin$" -count=1`
- `go test -tags=nextgen ./internal/locate`
- `go test -tags=nextgen ./...` (the existing mockstore safe-ts teardown panic in `./tikv` was reproduced on the clean target-branch base; an initial transient `internal/locate` failure passed on isolated rerun)