### PR TITLE
retry: delegate killed checks to signal handler (#2042)

### DIFF
--- a/config/retry/backoff.go
+++ b/config/retry/backoff.go
@@ -444,7 +444,10 @@ func (b *Backoffer) longestSleepCfg() (*Config, int) {
 }
 
 func (b *Backoffer) CheckKilled() error {
-	if b.vars != nil && b.vars.Killed != nil {
+	if b.vars == nil {
+		return nil
+	}
+	if b.vars.Killed != nil {
 		killed := atomic.LoadUint32(b.vars.Killed)
 		if killed != 0 {
 			logutil.BgLogger().Info(
@@ -453,6 +456,9 @@ func (b *Backoffer) CheckKilled() error {
 			)
 			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: killed})
 		}
+	}
+	if b.vars.KillSignalHandler != nil {
+		return b.vars.KillSignalHandler.HandleSignal()
 	}
 	return nil
 }

--- a/config/retry/backoff_test.go
+++ b/config/retry/backoff_test.go
@@ -46,7 +46,47 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/stretchr/testify/assert"
 	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/kv"
 )
+
+type killSignalHandlerFunc func() error
+
+func (f killSignalHandlerFunc) HandleSignal() error {
+	return f()
+}
+
+func TestCheckKilled(t *testing.T) {
+	handlerErr := errors.New("killed by handler")
+	called := 0
+	killed := uint32(7)
+	vars := kv.NewVariables(&killed)
+	vars.KillSignalHandler = killSignalHandlerFunc(func() error {
+		called++
+		return handlerErr
+	})
+	bo := NewBackofferWithVars(context.Background(), 1, vars)
+	err := bo.CheckKilled()
+	var interrupted tikverr.ErrQueryInterruptedWithSignal
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+	assert.Equal(t, 0, called)
+
+	killed = 0
+	assert.ErrorIs(t, bo.CheckKilled(), handlerErr)
+	assert.Equal(t, 1, called)
+	vars.KillSignalHandler = nil
+	killed = 7
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	bo = NewBackofferWithVars(context.Background(), 1, kv.NewVariables(&killed))
+	err = bo.CheckKilled()
+	assert.ErrorAs(t, err, &interrupted)
+	assert.Equal(t, killed, interrupted.Signal)
+
+	assert.NoError(t, NewBackofferWithVars(context.Background(), 1, nil).CheckKilled())
+}
 
 func TestBackoffWithMax(t *testing.T) {
 	b := NewBackofferWithVars(context.TODO(), 2000, nil)

--- a/kv/variables.go
+++ b/kv/variables.go
@@ -34,6 +34,13 @@
 
 package kv
 
+// KillSignalHandler handles kill signals at interruptible KV request checkpoints.
+// Implementations must be safe for concurrent use.
+type KillSignalHandler interface {
+	// HandleSignal returns an error when the current operation should stop.
+	HandleSignal() error
+}
+
 // Variables defines the variables used by KV storage.
 type Variables struct {
 	// BackoffLockFast specifies the LockFast backoff base duration in milliseconds.
@@ -49,6 +56,10 @@ type Variables struct {
 	// When its value is 0, it's not killed
 	// When its value is not 0, it's killed, the value indicates concrete reason.
 	Killed *uint32
+
+	// KillSignalHandler takes precedence over Killed when it is set.
+	// It must be configured before Variables is used by concurrent requests.
+	KillSignalHandler KillSignalHandler
 }
 
 // NewVariables create a new Variables instance with default values.

--- a/txnkv/transaction/2pc.go
+++ b/txnkv/transaction/2pc.go
@@ -1100,22 +1100,9 @@ func (c *twoPhaseCommitter) doActionOnBatches(
 	bo *retry.Backoffer, action twoPhaseCommitAction,
 	batches []batchMutations,
 ) error {
-	// killSignal should never be nil for TiDB
-	if c.txn != nil && c.txn.vars != nil && c.txn.vars.Killed != nil {
-		// Do not reset the killed flag here. Let the upper layer reset the flag.
-		// Before it resets, any request is considered valid to be killed if the
-		// corresponding action is interruptible.
-		status := atomic.LoadUint32(c.txn.vars.Killed)
-		if status != 0 && action.isInterruptible() {
-			logutil.BgLogger().Info(
-				"query is killed", zap.Uint32(
-					"signal",
-					status,
-				),
-			)
-			// TODO: There might be various signals besides a query interruption,
-			// but we are unable to differentiate them, because the definition is in TiDB.
-			return errors.WithStack(tikverr.ErrQueryInterruptedWithSignal{Signal: status})
+	if action.isInterruptible() {
+		if err := bo.CheckKilled(); err != nil {
+			return err
 		}
 	}
 	if len(batches) == 0 {


### PR DESCRIPTION
This is a manual backport of #2042 to release-nextgen-202603.

It is required by the TiDB client-disconnect detection backport of pingcap/tidb#70343. The nextgen client-go branch diverged from master and did not contain the KillSignalHandler interface, so retaining the existing TiDB dependency would not compile the backport.

Conflict resolution:
- Preserved the nextgen Variables layout.
- Added only the KillSignalHandler interface and field from #2042; master-only transaction-file fields were not introduced.

Tests:
- go test ./config/retry ./kv ./txnkv/transaction
- git diff --check

(cherry picked from commit 52c1e76cec993571493c81de442bcbef90cdc106)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom handling of termination signals during interruptible operations.
  - Applications can now provide a signal handler that determines the resulting error when no direct termination signal is present.

- **Bug Fixes**
  - Improved cancellation handling across transactional operations.
  - Preserved direct interruption errors when an explicit termination signal is received.
  - Operations with no cancellation configuration now complete without reporting a spurious interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->