### PR TITLE
txnkv: close resources when client construction fails

### DIFF
--- a/txnkv/client.go
+++ b/txnkv/client.go
@@ -64,7 +64,7 @@ func WithSafePointKVPrefix(prefix string) ClientOpt {
 }
 
 // NewClient creates a txn client with pdAddrs.
-func NewClient(pdAddrs []string, opts ...ClientOpt) (*Client, error) {
+func NewClient(pdAddrs []string, opts ...ClientOpt) (_ *Client, retErr error) {
 	// Apply options.
 	opt := &option{}
 	for _, o := range opts {
@@ -75,6 +75,13 @@ func NewClient(pdAddrs []string, opts ...ClientOpt) (*Client, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
+	// The store takes ownership only when construction succeeds.
+	defer func() {
+		if retErr != nil {
+			pdClient.Close()
+		}
+	}()
 
 	pdClient = util.NewInterceptedPDClient(pdClient)
 
@@ -107,7 +114,19 @@ func NewClient(pdAddrs []string, opts ...ClientOpt) (*Client, error) {
 		return nil, err
 	}
 
+	defer func() {
+		if retErr != nil {
+			_ = spkv.Close()
+		}
+	}()
+
 	rpcClient := tikv.NewRPCClient(tikv.WithSecurity(cfg.Security), tikv.WithCodec(codecCli.GetCodec()))
+
+	defer func() {
+		if retErr != nil {
+			_ = rpcClient.Close()
+		}
+	}()
 
 	s, err := tikv.NewKVStore(uuid, pdClient, spkv, rpcClient)
 	if err != nil {

--- a/txnkv/client_cleanup_test.go
+++ b/txnkv/client_cleanup_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 TiKV Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txnkv_test
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/keyspacepb"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
+	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/txnkv"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+)
+
+type constructorConnectionStats struct {
+	active atomic.Int64
+	opened atomic.Int64
+}
+
+func (s *constructorConnectionStats) TagRPC(c context.Context, _ *stats.RPCTagInfo) context.Context {
+	return c
+}
+func (s *constructorConnectionStats) HandleRPC(context.Context, stats.RPCStats) {}
+func (s *constructorConnectionStats) TagConn(c context.Context, _ *stats.ConnTagInfo) context.Context {
+	return c
+}
+func (s *constructorConnectionStats) HandleConn(_ context.Context, event stats.ConnStats) {
+	switch event.(type) {
+	case *stats.ConnBegin:
+		s.active.Add(1)
+		s.opened.Add(1)
+	case *stats.ConnEnd:
+		s.active.Add(-1)
+	}
+}
+
+type constructorPD struct {
+	pdpb.UnimplementedPDServer
+	endpoint string
+}
+
+func (s *constructorPD) GetMembers(context.Context, *pdpb.GetMembersRequest) (*pdpb.GetMembersResponse, error) {
+	member := &pdpb.Member{Name: "fake-pd", MemberId: 1, ClientUrls: []string{s.endpoint}}
+	return &pdpb.GetMembersResponse{Header: &pdpb.ResponseHeader{ClusterId: 42}, Members: []*pdpb.Member{member}, Leader: member}, nil
+}
+func (s *constructorPD) GetClusterInfo(context.Context, *pdpb.GetClusterInfoRequest) (*pdpb.GetClusterInfoResponse, error) {
+	return &pdpb.GetClusterInfoResponse{Header: &pdpb.ResponseHeader{ClusterId: 42}, ServiceModes: []pdpb.ServiceMode{pdpb.ServiceMode_PD_SVC_MODE}}, nil
+}
+func (s *constructorPD) Tso(stream pdpb.PD_TsoServer) error {
+	for {
+		request, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		err = stream.Send(&pdpb.TsoResponse{Header: &pdpb.ResponseHeader{ClusterId: 42}, Count: request.Count, Timestamp: &pdpb.Timestamp{Physical: time.Now().UnixMilli(), Logical: 1}})
+		if err != nil {
+			return err
+		}
+	}
+}
+
+type constructorKeyspace struct {
+	keyspacepb.UnimplementedKeyspaceServer
+	calls atomic.Int64
+}
+
+func (s *constructorKeyspace) LoadKeyspace(context.Context, *keyspacepb.LoadKeyspaceRequest) (*keyspacepb.LoadKeyspaceResponse, error) {
+	s.calls.Add(1)
+	return nil, status.Error(codes.NotFound, "injected keyspace lookup failure")
+}
+
+func TestNewClientClosesConnectionsOnError(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		api        kvrpcpb.APIVersion
+		wantLookup bool
+	}{
+		{"keyspace lookup", kvrpcpb.APIVersion_V2, true},
+		{"invalid API version", kvrpcpb.APIVersion(999), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			tracker := &constructorConnectionStats{}
+			keyspace := &constructorKeyspace{}
+			server := grpc.NewServer(grpc.StatsHandler(tracker))
+			endpoint := "http://" + listener.Addr().String()
+			pdpb.RegisterPDServer(server, &constructorPD{endpoint: endpoint})
+			keyspacepb.RegisterKeyspaceServer(server, keyspace)
+			go func() { _ = server.Serve(listener) }()
+			t.Cleanup(server.Stop)
+			for i := 0; i < 3; i++ {
+				client, err := txnkv.NewClient([]string{endpoint}, txnkv.WithAPIVersion(test.api), txnkv.WithKeyspace("missing-keyspace"))
+				require.Error(t, err)
+				require.Nil(t, client)
+				if test.wantLookup {
+					require.Contains(t, err.Error(), "injected keyspace lookup failure")
+				} else {
+					require.Contains(t, err.Error(), "unknown api version")
+				}
+				require.Eventually(t, func() bool { return tracker.active.Load() == 0 }, 5*time.Second, 10*time.Millisecond, "failed constructor retained PD connections")
+			}
+			require.GreaterOrEqual(t, tracker.opened.Load(), int64(3))
+			if test.wantLookup {
+				require.Equal(t, int64(3), keyspace.calls.Load())
+			}
+		})
+	}
+}

--- a/txnkv/client_cleanup_test.go
+++ b/txnkv/client_cleanup_test.go
@@ -103,7 +103,7 @@ func TestNewClientClosesConnectionsOnError(t *testing.T) {
 		{"invalid API version", kvrpcpb.APIVersion(999), false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			tracker := &constructorConnectionStats{}
 			keyspace := &constructorKeyspace{}


### PR DESCRIPTION
When transactional client construction fails after opening the PD client (for example, an API V2 keyspace lookup error), `NewClient` returns no client to the caller but leaves the PD connections and background work alive. Later initialization failures can also leave the newly created safe-point and RPC clients open.

Close resources acquired by the constructor on error, preserving the original error. A successful KVStore retains ownership and closes those resources normally. Add a real local gRPC regression that repeatedly exercises keyspace lookup failure and an invalid API version and checks that connections return to zero.

Validation on run9 with Go 1.25.12:
- Both new regression cases fail on the unmodified implementation because PD connections remain open, and pass after the fix.
- `go test -race -tags=intest ./txnkv -count=1` passes.
- `go test -race -tags=intest ./txnkv/... ./tikv` passes.
- An isolated v2.0.7 experiment retained 1/2/3/4/5 connections after five failed constructions; applying the same cleanup returned to zero after each failure. The explicit-Close control also returned to zero.

No public API behavior changes for successful construction. This fixes the SDK resource lifecycle defect; it does not establish the cause of a particular deployment's OOM.

CI follow-up: full unit and race jobs passed on the first PR head. Fixed the new listener's `noctx` lint finding by using `net.ListenConfig.Listen` with the test context; the focused race regression passes again on run9. Full unit, full race, and golangci jobs all pass on the updated head `90d6428` in [Unit Test CI](https://github.com/tikv/client-go/actions/runs/34111197425). Updated-head integration CI has completed: local, local race, and both raw TiKV variants pass; the TiKV integration job reproduces the baseline snapshot failure described below. The separate [Prow nextgen check](https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/tikv_client-go/2060/pull-integration-test-nextgen/2096907209509179392) fails `TestResolveTxnFallbackFromAsyncCommit`: the pre-existing test passes the duration literal `5000` to `SendReq` (5 microseconds), times out at `async_commit_test.go:519`, then dereferences the absent response. This is a distinct outstanding integration failure; no base-run reproduction or rerun is claimed for it.

The TiKV integration job fails `TestSnapshotRuntimeStatsAsyncBatchGetMultipleRegionsCoverage` at `snapshot_test.go:725,749` (region split wait and async request count). The same test and assertions already fail on the exact base commit `08cbf831` in [master CI](https://github.com/tikv/client-go/actions/runs/33744350975); [first PR CI](https://github.com/tikv/client-go/actions/runs/34110231512) and [updated-head CI](https://github.com/tikv/client-go/actions/runs/34111197334) reproduce that failure. This is an outstanding baseline integration failure, not a passing check.
